### PR TITLE
Expose dynamic endpoints for Bluewater use cases

### DIFF
--- a/src/Bluewater.Web/Program.cs
+++ b/src/Bluewater.Web/Program.cs
@@ -1,21 +1,17 @@
-﻿using System.Reflection;
 using Ardalis.ListStartupServices;
 using Ardalis.SharedKernel;
 using Bluewater.Core.ContributorAggregate;
-using Bluewater.Core.DepartmentAggregate;
-using Bluewater.Core.DivisionAggregate;
 using Bluewater.Core.Interfaces;
 using Bluewater.Infrastructure;
 using Bluewater.Infrastructure.Data;
 using Bluewater.Infrastructure.Email;
 using Bluewater.UseCases.Contributors.Create;
-using Bluewater.UseCases.Departments.Create;
-using Bluewater.UseCases.Divisions.Create;
 using FastEndpoints;
 using FastEndpoints.Swagger;
 using MediatR;
 using Serilog;
 using Serilog.Extensions.Logging;
+using Bluewater.Web.UseCases;
 
 var logger = Log.Logger = new LoggerConfiguration()
   .Enrich.FromLogContext()
@@ -84,6 +80,8 @@ else
 app.UseFastEndpoints()
     .UseSwaggerGen(); // Includes AddFileServer and static files middleware
 
+app.MapUseCaseEndpoints();
+
 //app.UseHttpsRedirection();
 
 await SeedDatabase(app);
@@ -112,17 +110,11 @@ static async Task SeedDatabase(WebApplication app)
 void ConfigureMediatR()
 {
   var mediatRAssemblies = new[]
-{
-  Assembly.GetAssembly(typeof(Contributor)), // Core
-  Assembly.GetAssembly(typeof(CreateContributorCommand)), // UseCases
-
-  Assembly.GetAssembly(typeof(Division)), // Core
-  Assembly.GetAssembly(typeof(CreateDivisionCommand)), // UseCases
-
-  Assembly.GetAssembly(typeof(Department)), // Core
-  Assembly.GetAssembly(typeof(CreateDepartmentCommand)) // UseCases
-};
-  builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(mediatRAssemblies!));
+  {
+    typeof(Contributor).Assembly,
+    typeof(CreateContributorCommand).Assembly
+  };
+  builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(mediatRAssemblies));
   builder.Services.AddScoped(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>));
   builder.Services.AddScoped<IDomainEventDispatcher, MediatRDomainEventDispatcher>();
 }

--- a/src/Bluewater.Web/UseCases/UseCaseDescriptor.cs
+++ b/src/Bluewater.Web/UseCases/UseCaseDescriptor.cs
@@ -1,0 +1,200 @@
+using System.Reflection;
+using System.Text;
+using Ardalis.Result;
+using Ardalis.SharedKernel;
+
+namespace Bluewater.Web.UseCases;
+
+internal sealed class UseCaseDescriptor
+{
+  private UseCaseDescriptor(
+    string[] categorySegments,
+    string operationName,
+    string operationSlug,
+    string route,
+    Type requestType,
+    Type resultType,
+    Type? resultValueType,
+    bool isCommand)
+  {
+    CategorySegments = categorySegments;
+    OperationName = operationName;
+    OperationSlug = operationSlug;
+    Route = route;
+    RequestType = requestType;
+    ResultType = resultType;
+    ResultValueType = resultValueType;
+    IsCommand = isCommand;
+  }
+
+  public string[] CategorySegments { get; }
+
+  public string OperationName { get; }
+
+  public string OperationSlug { get; }
+
+  public string Route { get; }
+
+  public Type RequestType { get; }
+
+  public Type ResultType { get; }
+
+  public Type? ResultValueType { get; }
+
+  public bool IsCommand { get; }
+
+  public string Kind => IsCommand ? "Command" : "Query";
+
+  public string DisplayName
+  {
+    get
+    {
+      if (CategorySegments.Length == 0)
+      {
+        return OperationName;
+      }
+
+      return string.Join('.', CategorySegments) + "." + OperationName;
+    }
+  }
+
+  public static IReadOnlyList<UseCaseDescriptor> Discover(Assembly assembly)
+  {
+    var descriptors = new List<UseCaseDescriptor>();
+
+    foreach (var type in assembly.GetTypes())
+    {
+      if (TryCreate(type, out var descriptor))
+      {
+        descriptors.Add(descriptor);
+      }
+    }
+
+    return descriptors
+      .OrderBy(d => string.Join('/', d.CategorySegments))
+      .ThenBy(d => d.OperationName, StringComparer.Ordinal)
+      .ToArray();
+  }
+
+  private static bool TryCreate(Type candidate, out UseCaseDescriptor? descriptor)
+  {
+    descriptor = null;
+
+    if (!candidate.IsClass || candidate.IsAbstract || candidate.IsGenericTypeDefinition)
+    {
+      return false;
+    }
+
+    if (candidate.Namespace is null || !candidate.Namespace.StartsWith("Bluewater.UseCases", StringComparison.Ordinal))
+    {
+      return false;
+    }
+
+    var commandInterface = candidate
+      .GetInterfaces()
+      .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(ICommand<>));
+
+    var queryInterface = candidate
+      .GetInterfaces()
+      .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IQuery<>));
+
+    var selectedInterface = commandInterface ?? queryInterface;
+
+    if (selectedInterface is null)
+    {
+      return false;
+    }
+
+    var resultType = selectedInterface.GetGenericArguments()[0];
+
+    var isArdalisResult = resultType == typeof(Result) ||
+      (resultType.IsGenericType && resultType.GetGenericTypeDefinition() == typeof(Result<>));
+
+    if (!isArdalisResult)
+    {
+      return false;
+    }
+
+    var namespaceSegments = candidate.Namespace.Split('.', StringSplitOptions.RemoveEmptyEntries);
+
+    if (namespaceSegments.Length < 3)
+    {
+      return false;
+    }
+
+    var categorySegments = namespaceSegments
+      .Skip(2)
+      .Take(namespaceSegments.Length - 3)
+      .ToArray();
+
+    var operationName = TrimSuffix(candidate.Name, "Command", "Query");
+    var operationSlug = ToKebabCase(operationName);
+
+    var routeBuilder = new StringBuilder();
+
+    if (categorySegments.Length > 0)
+    {
+      routeBuilder.Append(string.Join('/', categorySegments.Select(ToKebabCase)));
+      routeBuilder.Append('/');
+    }
+
+    routeBuilder.Append(operationSlug);
+
+    var route = routeBuilder.ToString();
+
+    descriptor = new UseCaseDescriptor(
+      categorySegments,
+      operationName,
+      operationSlug,
+      route,
+      candidate,
+      resultType,
+      resultType.IsGenericType ? resultType.GetGenericArguments()[0] : null,
+      selectedInterface == commandInterface);
+
+    return true;
+  }
+
+  private static string TrimSuffix(string value, params string[] suffixes)
+  {
+    foreach (var suffix in suffixes)
+    {
+      if (value.EndsWith(suffix, StringComparison.Ordinal))
+      {
+        return value[..^suffix.Length];
+      }
+    }
+
+    return value;
+  }
+
+  private static string ToKebabCase(string value)
+  {
+    if (string.IsNullOrWhiteSpace(value))
+    {
+      return string.Empty;
+    }
+
+    var builder = new StringBuilder(value.Length * 2);
+
+    for (var i = 0; i < value.Length; i++)
+    {
+      var c = value[i];
+      if (char.IsUpper(c))
+      {
+        if (i > 0 && (char.IsLower(value[i - 1]) || (i + 1 < value.Length && char.IsLower(value[i + 1]))))
+        {
+          builder.Append('-');
+        }
+
+        builder.Append(char.ToLowerInvariant(c));
+      }
+      else
+      {
+        builder.Append(c);
+      }
+    }
+
+    return builder.ToString();
+  }
+}

--- a/src/Bluewater.Web/UseCases/UseCaseEndpointExtensions.cs
+++ b/src/Bluewater.Web/UseCases/UseCaseEndpointExtensions.cs
@@ -1,0 +1,176 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using Ardalis.Result;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.OpenApi.Models;
+
+namespace Bluewater.Web.UseCases;
+
+internal static class UseCaseEndpointExtensions
+{
+  private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web)
+  {
+    PropertyNameCaseInsensitive = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+  };
+
+  static UseCaseEndpointExtensions()
+  {
+    SerializerOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase, allowIntegerValues: true));
+  }
+
+  public static void MapUseCaseEndpoints(this WebApplication app)
+  {
+    var useCaseAssembly = typeof(Bluewater.UseCases.Contributors.Create.CreateContributorCommand).Assembly;
+    var descriptors = UseCaseDescriptor.Discover(useCaseAssembly);
+
+    if (descriptors.Count == 0)
+    {
+      return;
+    }
+
+    var group = app.MapGroup("/usecases");
+    group.WithTags("UseCases");
+    group.WithOpenApi();
+
+    group.MapGet("/", () => descriptors.Select(d => new
+    {
+      d.Kind,
+      Category = d.CategorySegments,
+      Operation = d.OperationName,
+      Route = $"/usecases/{d.Route}",
+      RequestType = d.RequestType.FullName,
+      ResultType = d.ResultType.FullName,
+      ResultValueType = d.ResultValueType?.FullName
+    }))
+    .WithName("UseCases.List")
+    .WithOpenApi(op =>
+    {
+      op.Summary = "List available Bluewater use case endpoints.";
+      return op;
+    });
+
+    foreach (var descriptor in descriptors)
+    {
+      var localDescriptor = descriptor;
+      var methods = localDescriptor.IsCommand ? new[] { "POST" } : new[] { "GET", "POST" };
+
+      var builder = group.MapMethods($"/{localDescriptor.Route}", methods, async (HttpContext context, IMediator mediator, CancellationToken ct) =>
+      {
+        var requestObject = await BindRequestAsync(context, localDescriptor.RequestType, ct);
+
+        if (requestObject is null)
+        {
+          return Results.BadRequest(new
+          {
+            error = $"A payload or query string is required to execute {localDescriptor.RequestType.Name}."
+          });
+        }
+
+        var response = await mediator.Send(requestObject, ct);
+        return ConvertResult(response, localDescriptor);
+      });
+
+      builder.WithName($"UseCases.{localDescriptor.DisplayName}");
+      builder.WithOpenApi(op =>
+      {
+        op.Summary = $"Execute {localDescriptor.DisplayName}.";
+        op.OperationId ??= $"UseCases_{localDescriptor.DisplayName.Replace('.', '_')}";
+        op.Tags ??= new List<OpenApiTag>();
+        if (localDescriptor.CategorySegments.Length > 0)
+        {
+          op.Tags.Add(new OpenApiTag { Name = string.Join(" / ", localDescriptor.CategorySegments) });
+        }
+        else
+        {
+          op.Tags.Add(new OpenApiTag { Name = "UseCases" });
+        }
+        return op;
+      });
+    }
+  }
+
+  private static async Task<object?> BindRequestAsync(HttpContext context, Type requestType, CancellationToken cancellationToken)
+  {
+    if (context.Request.ContentLength.HasValue && context.Request.ContentLength.Value > 0)
+    {
+      return await JsonSerializer.DeserializeAsync(context.Request.Body, requestType, SerializerOptions, cancellationToken);
+    }
+
+    if (context.Request.Query.Count > 0)
+    {
+      var queryDictionary = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+
+      foreach (var (key, value) in context.Request.Query)
+      {
+        if (value.Count > 1)
+        {
+          queryDictionary[key] = value.ToArray();
+        }
+        else
+        {
+          queryDictionary[key] = value.ToString();
+        }
+      }
+
+      var json = JsonSerializer.Serialize(queryDictionary, SerializerOptions);
+      return JsonSerializer.Deserialize(json, requestType, SerializerOptions);
+    }
+
+    return null;
+  }
+
+  private static IResult ConvertResult(object? response, UseCaseDescriptor descriptor)
+  {
+    if (response is null)
+    {
+      return Results.Ok();
+    }
+
+    if (response is IResult httpResult)
+    {
+      return httpResult;
+    }
+
+    if (response is Result nonGenericResult)
+    {
+      return MapStatus(nonGenericResult.Status, null, nonGenericResult.Errors, nonGenericResult.ValidationErrors, descriptor);
+    }
+
+    var responseType = response.GetType();
+
+    if (responseType.IsGenericType && responseType.GetGenericTypeDefinition() == typeof(Result<>))
+    {
+      var status = (ResultStatus)responseType.GetProperty(nameof(Result.Status))!.GetValue(response)!;
+      var errors = (IEnumerable<string>)responseType.GetProperty(nameof(Result.Errors))!.GetValue(response)!;
+      var validationErrors = responseType.GetProperty(nameof(Result.ValidationErrors))!.GetValue(response);
+      var value = responseType.GetProperty("Value")?.GetValue(response);
+
+      return MapStatus(status, value, errors, validationErrors, descriptor);
+    }
+
+    return Results.Ok(response);
+  }
+
+  private static IResult MapStatus(ResultStatus status, object? value, IEnumerable<string>? errors, object? validationErrors, UseCaseDescriptor descriptor)
+  {
+    return status switch
+    {
+      ResultStatus.Ok => value is null ? Results.Ok() : Results.Ok(value),
+      ResultStatus.Created => Results.Created($"/usecases/{descriptor.Route}", value),
+      ResultStatus.NoContent => Results.NoContent(),
+      ResultStatus.Invalid => Results.BadRequest(new { errors, validationErrors }),
+      ResultStatus.NotFound => Results.NotFound(new { errors }),
+      ResultStatus.Error => Results.Problem(string.Join(Environment.NewLine, errors ?? Array.Empty<string>())),
+      ResultStatus.CriticalError => Results.Problem(string.Join(Environment.NewLine, errors ?? Array.Empty<string>()), statusCode: StatusCodes.Status500InternalServerError),
+      ResultStatus.Unauthorized => Results.Unauthorized(),
+      ResultStatus.Forbidden => Results.StatusCode(StatusCodes.Status403Forbidden),
+      ResultStatus.Conflict => Results.Conflict(new { errors }),
+      _ => value is null ? Results.Ok() : Results.Ok(value)
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add dynamic FastEndpoints registration that maps every ICommand/IQuery in the Bluewater.UseCases assembly to an HTTP endpoint under `/usecases`
- surface a discovery endpoint that lists the generated routes and unify Ardalis.Result responses into HTTP status codes
- register the dynamic endpoints in Program.cs and simplify MediatR configuration to load the full UseCases assembly

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d3e694d65c83298ae836a9cb42dff0