### PR TITLE
Expose division assignment in department endpoints

### DIFF
--- a/src/Bluewater.Web/Departments/Create.CreateDepartmentResponse.cs
+++ b/src/Bluewater.Web/Departments/Create.CreateDepartmentResponse.cs
@@ -1,8 +1,9 @@
-﻿namespace Bluewater.Web.Departments;
+namespace Bluewater.Web.Departments;
 
-public class CreateDepartmentResponse(Guid Id, string Name, string? Description)
+public class CreateDepartmentResponse(Guid Id, string Name, string? Description, Guid DivisionId)
 {
   public Guid Id { get; set; } = Id;
   public string Name { get; set; } = Name;
   public string? Description { get; set; } = Description;
-} 
+  public Guid DivisionId { get; set; } = DivisionId;
+}

--- a/src/Bluewater.Web/Departments/Create.cs
+++ b/src/Bluewater.Web/Departments/Create.cs
@@ -1,4 +1,5 @@
-﻿using Bluewater.UseCases.Departments.Create;
+using System;
+using Bluewater.UseCases.Departments.Create;
 using FastEndpoints;
 using MediatR;
 
@@ -13,7 +14,15 @@ public class Create(IMediator _mediator) : Endpoint<CreateDepartmentRequest, Cre
   {
     Post(CreateDepartmentRequest.Route);
     AllowAnonymous();
-    Summary(s => { s.ExampleRequest = new CreateDepartmentRequest { Name = "Department Name", Description = "Department Description" }; });
+    Summary(s =>
+    {
+      s.ExampleRequest = new CreateDepartmentRequest
+      {
+        Name = "Department Name",
+        Description = "Department Description",
+        DivisionId = Guid.NewGuid()
+      };
+    });
   }
 
   public override async Task HandleAsync(CreateDepartmentRequest request, CancellationToken cancellationToken)
@@ -21,7 +30,7 @@ public class Create(IMediator _mediator) : Endpoint<CreateDepartmentRequest, Cre
     var result = await _mediator.Send(new CreateDepartmentCommand(request.Name!, request.Description, request.DivisionId), cancellationToken);
     if (result.IsSuccess)
     {
-      Response = new CreateDepartmentResponse(result.Value, request.Name!, request.Description);
+      Response = new CreateDepartmentResponse(result.Value, request.Name!, request.Description, request.DivisionId);
       return;
     }
   }

--- a/src/Bluewater.Web/Departments/DepartmentRecord.cs
+++ b/src/Bluewater.Web/Departments/DepartmentRecord.cs
@@ -1,3 +1,3 @@
-﻿namespace Bluewater.Web.Departments;
+namespace Bluewater.Web.Departments;
 
-public record DepartmentRecord(Guid Id, string Name, string? Description);
+public record DepartmentRecord(Guid Id, string Name, string? Description, Guid DivisionId);

--- a/src/Bluewater.Web/Departments/GetById.cs
+++ b/src/Bluewater.Web/Departments/GetById.cs
@@ -30,7 +30,7 @@ public class GetById(IMediator _mediator) : Endpoint<GetDepartmentByIdRequest, D
 
     if (result.IsSuccess)
     {
-      Response = new DepartmentRecord(result.Value.Id, result.Value.Name, result.Value.Description);
+      Response = new DepartmentRecord(result.Value.Id, result.Value.Name, result.Value.Description, result.Value.DivisionId);
     }
   }
 }

--- a/src/Bluewater.Web/Departments/List.cs
+++ b/src/Bluewater.Web/Departments/List.cs
@@ -26,7 +26,9 @@ public class List(IMediator _mediator) : EndpointWithoutRequest<DepartmentListRe
     {
       Response = new DepartmentListResponse
       {
-        Departments = result.Value.Select(c => new DepartmentRecord(c.Id, c.Name, c.Description)).ToList()
+        Departments = result.Value
+          .Select(c => new DepartmentRecord(c.Id, c.Name, c.Description, c.DivisionId))
+          .ToList()
       };
     }
   }

--- a/src/Bluewater.Web/Departments/Update.cs
+++ b/src/Bluewater.Web/Departments/Update.cs
@@ -40,7 +40,7 @@ public class Update(IMediator _mediator) : Endpoint<UpdateDepartmentRequest, Upd
     if (queryResult.IsSuccess)
     {
       var dto = queryResult.Value;
-      Response = new UpdateDepartmentResponse(new DepartmentRecord(dto.Id, dto.Name, dto.Description));
+      Response = new UpdateDepartmentResponse(new DepartmentRecord(dto.Id, dto.Name, dto.Description, dto.DivisionId));
       return;
     }
   }


### PR DESCRIPTION
## Summary
- include the owning division ID in department API records and responses
- update the create endpoint example payload to show division selection
- propagate division IDs through list, get, create, and update handlers

## Testing
- dotnet build *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e87bb0688329b8c72fb563619748