### PR TITLE
Add FastEndpoints CRUD APIs for employees, employee types, and chargings

### DIFF
--- a/src/Bluewater.Web/Chargings/ChargingRecord.cs
+++ b/src/Bluewater.Web/Chargings/ChargingRecord.cs
@@ -1,0 +1,3 @@
+namespace Bluewater.Web.Chargings;
+
+public record ChargingRecord(Guid Id, string Name, string? Description, Guid? DepartmentId);

--- a/src/Bluewater.Web/Chargings/Create.CreateChargingRequest.cs
+++ b/src/Bluewater.Web/Chargings/Create.CreateChargingRequest.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.Chargings;
+
+public class CreateChargingRequest
+{
+  public const string Route = "/Chargings";
+
+  [Required]
+  public string? Name { get; set; }
+  public string? Description { get; set; }
+  public Guid? DepartmentId { get; set; }
+}

--- a/src/Bluewater.Web/Chargings/Create.CreateChargingResponse.cs
+++ b/src/Bluewater.Web/Chargings/Create.CreateChargingResponse.cs
@@ -1,0 +1,9 @@
+namespace Bluewater.Web.Chargings;
+
+public class CreateChargingResponse(Guid Id, string Name, string? Description, Guid? DepartmentId)
+{
+  public Guid Id { get; set; } = Id;
+  public string Name { get; set; } = Name;
+  public string? Description { get; set; } = Description;
+  public Guid? DepartmentId { get; set; } = DepartmentId;
+}

--- a/src/Bluewater.Web/Chargings/Create.CreateChargingValidator.cs
+++ b/src/Bluewater.Web/Chargings/Create.CreateChargingValidator.cs
@@ -1,0 +1,15 @@
+using Bluewater.Infrastructure.Data.Config;
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Chargings;
+
+public class CreateChargingValidator : Validator<CreateChargingRequest>
+{
+  public CreateChargingValidator()
+  {
+    RuleFor(x => x.Name)
+      .NotEmpty()
+      .MaximumLength(DataSchemaConstants.DEFAULT_NAME_LENGTH);
+  }
+}

--- a/src/Bluewater.Web/Chargings/Create.cs
+++ b/src/Bluewater.Web/Chargings/Create.cs
@@ -1,0 +1,28 @@
+using Bluewater.UseCases.Chargings.Create;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Chargings;
+
+/// <summary>
+/// Create a new charging definition.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Create(IMediator _mediator) : Endpoint<CreateChargingRequest, CreateChargingResponse>
+{
+  public override void Configure()
+  {
+    Post(CreateChargingRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(CreateChargingRequest req, CancellationToken ct)
+  {
+    var result = await _mediator.Send(new CreateChargingCommand(req.Name!, req.Description, req.DepartmentId), ct);
+
+    if (result.IsSuccess)
+    {
+      Response = new CreateChargingResponse(result.Value, req.Name!, req.Description, req.DepartmentId);
+    }
+  }
+}

--- a/src/Bluewater.Web/Chargings/Delete.DeleteChargingRequest.cs
+++ b/src/Bluewater.Web/Chargings/Delete.DeleteChargingRequest.cs
@@ -1,0 +1,8 @@
+namespace Bluewater.Web.Chargings;
+
+public class DeleteChargingRequest
+{
+  public const string Route = "/Chargings/{ChargingId:guid}";
+
+  public Guid ChargingId { get; set; }
+}

--- a/src/Bluewater.Web/Chargings/Delete.DeleteChargingValidator.cs
+++ b/src/Bluewater.Web/Chargings/Delete.DeleteChargingValidator.cs
@@ -1,0 +1,14 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Chargings;
+
+public class DeleteChargingValidator : Validator<DeleteChargingRequest>
+{
+  public DeleteChargingValidator()
+  {
+    RuleFor(x => x.ChargingId)
+      .NotEmpty()
+      .WithMessage("ChargingId is required.");
+  }
+}

--- a/src/Bluewater.Web/Chargings/Delete.cs
+++ b/src/Bluewater.Web/Chargings/Delete.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Chargings.Delete;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Chargings;
+
+/// <summary>
+/// Delete a charging definition.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Delete(IMediator _mediator) : Endpoint<DeleteChargingRequest>
+{
+  public override void Configure()
+  {
+    Delete(DeleteChargingRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(DeleteChargingRequest req, CancellationToken ct)
+  {
+    var result = await _mediator.Send(new DeleteChargingCommand(req.ChargingId), ct);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(ct);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      await SendNoContentAsync(ct);
+    }
+  }
+}

--- a/src/Bluewater.Web/Chargings/GetById.GetChargingByIdRequest.cs
+++ b/src/Bluewater.Web/Chargings/GetById.GetChargingByIdRequest.cs
@@ -1,0 +1,8 @@
+namespace Bluewater.Web.Chargings;
+
+public class GetChargingByIdRequest
+{
+  public const string Route = "/Chargings/{ChargingId:guid}";
+
+  public Guid ChargingId { get; set; }
+}

--- a/src/Bluewater.Web/Chargings/GetById.GetChargingValidator.cs
+++ b/src/Bluewater.Web/Chargings/GetById.GetChargingValidator.cs
@@ -1,0 +1,14 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Chargings;
+
+public class GetChargingValidator : Validator<GetChargingByIdRequest>
+{
+  public GetChargingValidator()
+  {
+    RuleFor(x => x.ChargingId)
+      .NotEmpty()
+      .WithMessage("ChargingId is required.");
+  }
+}

--- a/src/Bluewater.Web/Chargings/GetById.cs
+++ b/src/Bluewater.Web/Chargings/GetById.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Chargings.Get;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Chargings;
+
+/// <summary>
+/// Retrieve a charging definition by identifier.
+/// </summary>
+/// <param name="_mediator"></param>
+public class GetById(IMediator _mediator) : Endpoint<GetChargingByIdRequest, ChargingRecord>
+{
+  public override void Configure()
+  {
+    Get(GetChargingByIdRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(GetChargingByIdRequest req, CancellationToken ct)
+  {
+    var result = await _mediator.Send(new GetChargingQuery(req.ChargingId), ct);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(ct);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      Response = new ChargingRecord(result.Value.Id, result.Value.Name, result.Value.Description, result.Value.DepartmentId);
+    }
+  }
+}

--- a/src/Bluewater.Web/Chargings/List.ChargingListResponse.cs
+++ b/src/Bluewater.Web/Chargings/List.ChargingListResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Chargings;
+
+public class ChargingListResponse
+{
+  public List<ChargingRecord> Chargings { get; set; } = new();
+}

--- a/src/Bluewater.Web/Chargings/List.cs
+++ b/src/Bluewater.Web/Chargings/List.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Chargings;
+using Bluewater.UseCases.Chargings.List;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Chargings;
+
+/// <summary>
+/// List all charging definitions.
+/// </summary>
+/// <param name="_mediator"></param>
+public class List(IMediator _mediator) : EndpointWithoutRequest<ChargingListResponse>
+{
+  public override void Configure()
+  {
+    Get("/Chargings");
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(CancellationToken ct)
+  {
+    Result<IEnumerable<ChargingDTO>> result = await _mediator.Send(new ListChargingQuery(null, null), ct);
+
+    if (result.IsSuccess)
+    {
+      Response = new ChargingListResponse
+      {
+        Chargings = result.Value
+          .Select(c => new ChargingRecord(c.Id, c.Name, c.Description, c.DepartmentId))
+          .ToList()
+      };
+    }
+  }
+}

--- a/src/Bluewater.Web/Chargings/Update.UpdateChargingRequest.cs
+++ b/src/Bluewater.Web/Chargings/Update.UpdateChargingRequest.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.Chargings;
+
+public class UpdateChargingRequest
+{
+  public const string Route = "/Chargings";
+
+  [Required]
+  public Guid Id { get; set; }
+
+  [Required]
+  public string? Name { get; set; }
+
+  public string? Description { get; set; }
+  public Guid? DepartmentId { get; set; }
+}

--- a/src/Bluewater.Web/Chargings/Update.UpdateChargingResponse.cs
+++ b/src/Bluewater.Web/Chargings/Update.UpdateChargingResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Chargings;
+
+public class UpdateChargingResponse(ChargingRecord Charging)
+{
+  public ChargingRecord Charging { get; set; } = Charging;
+}

--- a/src/Bluewater.Web/Chargings/Update.UpdateChargingValidator.cs
+++ b/src/Bluewater.Web/Chargings/Update.UpdateChargingValidator.cs
@@ -1,0 +1,18 @@
+using Bluewater.Infrastructure.Data.Config;
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Chargings;
+
+public class UpdateChargingValidator : Validator<UpdateChargingRequest>
+{
+  public UpdateChargingValidator()
+  {
+    RuleFor(x => x.Id)
+      .NotEmpty();
+
+    RuleFor(x => x.Name)
+      .NotEmpty()
+      .MaximumLength(DataSchemaConstants.DEFAULT_NAME_LENGTH);
+  }
+}

--- a/src/Bluewater.Web/Chargings/Update.cs
+++ b/src/Bluewater.Web/Chargings/Update.cs
@@ -1,0 +1,36 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Chargings;
+using Bluewater.UseCases.Chargings.Update;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Chargings;
+
+/// <summary>
+/// Update an existing charging definition.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Update(IMediator _mediator) : Endpoint<UpdateChargingRequest, UpdateChargingResponse>
+{
+  public override void Configure()
+  {
+    Put(UpdateChargingRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(UpdateChargingRequest req, CancellationToken ct)
+  {
+    var result = await _mediator.Send(new UpdateChargingCommand(req.Id, req.Name!, req.Description, req.DepartmentId), ct);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(ct);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      Response = new UpdateChargingResponse(new ChargingRecord(result.Value.Id, result.Value.Name, result.Value.Description, result.Value.DepartmentId));
+    }
+  }
+}

--- a/src/Bluewater.Web/EmployeeTypes/Create.CreateEmployeeTypeRequest.cs
+++ b/src/Bluewater.Web/EmployeeTypes/Create.CreateEmployeeTypeRequest.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.EmployeeTypes;
+
+public class CreateEmployeeTypeRequest
+{
+  public const string Route = "/EmployeeTypes";
+
+  [Required]
+  public string? Name { get; set; }
+
+  [Required]
+  public string? Value { get; set; }
+
+  public bool IsActive { get; set; }
+}

--- a/src/Bluewater.Web/EmployeeTypes/Create.CreateEmployeeTypeResponse.cs
+++ b/src/Bluewater.Web/EmployeeTypes/Create.CreateEmployeeTypeResponse.cs
@@ -1,0 +1,9 @@
+namespace Bluewater.Web.EmployeeTypes;
+
+public class CreateEmployeeTypeResponse(Guid Id, string Name, string Value, bool IsActive)
+{
+  public Guid Id { get; set; } = Id;
+  public string Name { get; set; } = Name;
+  public string Value { get; set; } = Value;
+  public bool IsActive { get; set; } = IsActive;
+}

--- a/src/Bluewater.Web/EmployeeTypes/Create.CreateEmployeeTypeValidator.cs
+++ b/src/Bluewater.Web/EmployeeTypes/Create.CreateEmployeeTypeValidator.cs
@@ -1,0 +1,19 @@
+using Bluewater.Infrastructure.Data.Config;
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.EmployeeTypes;
+
+public class CreateEmployeeTypeValidator : Validator<CreateEmployeeTypeRequest>
+{
+  public CreateEmployeeTypeValidator()
+  {
+    RuleFor(x => x.Name)
+      .NotEmpty()
+      .MaximumLength(DataSchemaConstants.DEFAULT_NAME_LENGTH);
+
+    RuleFor(x => x.Value)
+      .NotEmpty()
+      .MaximumLength(DataSchemaConstants.DEFAULT_NAME_LENGTH);
+  }
+}

--- a/src/Bluewater.Web/EmployeeTypes/Create.cs
+++ b/src/Bluewater.Web/EmployeeTypes/Create.cs
@@ -1,0 +1,28 @@
+using Bluewater.UseCases.EmployeeTypes.Create;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.EmployeeTypes;
+
+/// <summary>
+/// Create a new employee type.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Create(IMediator _mediator) : Endpoint<CreateEmployeeTypeRequest, CreateEmployeeTypeResponse>
+{
+  public override void Configure()
+  {
+    Post(CreateEmployeeTypeRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(CreateEmployeeTypeRequest req, CancellationToken ct)
+  {
+    var result = await _mediator.Send(new CreateEmployeeTypeCommand(req.Name!, req.Value!, req.IsActive), ct);
+
+    if (result.IsSuccess)
+    {
+      Response = new CreateEmployeeTypeResponse(result.Value, req.Name!, req.Value!, req.IsActive);
+    }
+  }
+}

--- a/src/Bluewater.Web/EmployeeTypes/Delete.DeleteEmployeeTypeRequest.cs
+++ b/src/Bluewater.Web/EmployeeTypes/Delete.DeleteEmployeeTypeRequest.cs
@@ -1,0 +1,8 @@
+namespace Bluewater.Web.EmployeeTypes;
+
+public class DeleteEmployeeTypeRequest
+{
+  public const string Route = "/EmployeeTypes/{EmployeeTypeId:guid}";
+
+  public Guid EmployeeTypeId { get; set; }
+}

--- a/src/Bluewater.Web/EmployeeTypes/Delete.DeleteEmployeeTypeValidator.cs
+++ b/src/Bluewater.Web/EmployeeTypes/Delete.DeleteEmployeeTypeValidator.cs
@@ -1,0 +1,14 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.EmployeeTypes;
+
+public class DeleteEmployeeTypeValidator : Validator<DeleteEmployeeTypeRequest>
+{
+  public DeleteEmployeeTypeValidator()
+  {
+    RuleFor(x => x.EmployeeTypeId)
+      .NotEmpty()
+      .WithMessage("EmployeeTypeId is required.");
+  }
+}

--- a/src/Bluewater.Web/EmployeeTypes/Delete.cs
+++ b/src/Bluewater.Web/EmployeeTypes/Delete.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.EmployeeTypes.Delete;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.EmployeeTypes;
+
+/// <summary>
+/// Delete an employee type.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Delete(IMediator _mediator) : Endpoint<DeleteEmployeeTypeRequest>
+{
+  public override void Configure()
+  {
+    Delete(DeleteEmployeeTypeRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(DeleteEmployeeTypeRequest req, CancellationToken ct)
+  {
+    var result = await _mediator.Send(new DeleteEmployeeTypeCommand(req.EmployeeTypeId), ct);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(ct);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      await SendNoContentAsync(ct);
+    }
+  }
+}

--- a/src/Bluewater.Web/EmployeeTypes/EmployeeTypeRecord.cs
+++ b/src/Bluewater.Web/EmployeeTypes/EmployeeTypeRecord.cs
@@ -1,0 +1,3 @@
+namespace Bluewater.Web.EmployeeTypes;
+
+public record EmployeeTypeRecord(Guid Id, string Name, string Value, bool IsActive);

--- a/src/Bluewater.Web/EmployeeTypes/GetById.GetEmployeeTypeByIdRequest.cs
+++ b/src/Bluewater.Web/EmployeeTypes/GetById.GetEmployeeTypeByIdRequest.cs
@@ -1,0 +1,8 @@
+namespace Bluewater.Web.EmployeeTypes;
+
+public class GetEmployeeTypeByIdRequest
+{
+  public const string Route = "/EmployeeTypes/{EmployeeTypeId:guid}";
+
+  public Guid EmployeeTypeId { get; set; }
+}

--- a/src/Bluewater.Web/EmployeeTypes/GetById.GetEmployeeTypeValidator.cs
+++ b/src/Bluewater.Web/EmployeeTypes/GetById.GetEmployeeTypeValidator.cs
@@ -1,0 +1,14 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.EmployeeTypes;
+
+public class GetEmployeeTypeValidator : Validator<GetEmployeeTypeByIdRequest>
+{
+  public GetEmployeeTypeValidator()
+  {
+    RuleFor(x => x.EmployeeTypeId)
+      .NotEmpty()
+      .WithMessage("EmployeeTypeId is required.");
+  }
+}

--- a/src/Bluewater.Web/EmployeeTypes/GetById.cs
+++ b/src/Bluewater.Web/EmployeeTypes/GetById.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.EmployeeTypes.Get;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.EmployeeTypes;
+
+/// <summary>
+/// Retrieve a specific employee type by its identifier.
+/// </summary>
+/// <param name="_mediator"></param>
+public class GetById(IMediator _mediator) : Endpoint<GetEmployeeTypeByIdRequest, EmployeeTypeRecord>
+{
+  public override void Configure()
+  {
+    Get(GetEmployeeTypeByIdRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(GetEmployeeTypeByIdRequest req, CancellationToken ct)
+  {
+    var result = await _mediator.Send(new GetEmployeeTypeQuery(req.EmployeeTypeId), ct);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(ct);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      Response = new EmployeeTypeRecord(result.Value.Id, result.Value.Name, result.Value.Value, result.Value.IsActive);
+    }
+  }
+}

--- a/src/Bluewater.Web/EmployeeTypes/List.EmployeeTypeListResponse.cs
+++ b/src/Bluewater.Web/EmployeeTypes/List.EmployeeTypeListResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.EmployeeTypes;
+
+public class EmployeeTypeListResponse
+{
+  public List<EmployeeTypeRecord> EmployeeTypes { get; set; } = new();
+}

--- a/src/Bluewater.Web/EmployeeTypes/List.cs
+++ b/src/Bluewater.Web/EmployeeTypes/List.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.EmployeeTypes;
+using Bluewater.UseCases.EmployeeTypes.List;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.EmployeeTypes;
+
+/// <summary>
+/// List all employee types.
+/// </summary>
+/// <param name="_mediator"></param>
+public class List(IMediator _mediator) : EndpointWithoutRequest<EmployeeTypeListResponse>
+{
+  public override void Configure()
+  {
+    Get("/EmployeeTypes");
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(CancellationToken ct)
+  {
+    Result<IEnumerable<EmployeeTypeDTO>> result = await _mediator.Send(new ListEmployeeTypeQuery(null, null), ct);
+
+    if (result.IsSuccess)
+    {
+      Response = new EmployeeTypeListResponse
+      {
+        EmployeeTypes = result.Value
+          .Select(t => new EmployeeTypeRecord(t.Id, t.Name, t.Value, t.IsActive))
+          .ToList()
+      };
+    }
+  }
+}

--- a/src/Bluewater.Web/EmployeeTypes/Update.UpdateEmployeeTypeRequest.cs
+++ b/src/Bluewater.Web/EmployeeTypes/Update.UpdateEmployeeTypeRequest.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.EmployeeTypes;
+
+public class UpdateEmployeeTypeRequest
+{
+  public const string Route = "/EmployeeTypes";
+
+  [Required]
+  public Guid Id { get; set; }
+
+  [Required]
+  public string? Name { get; set; }
+
+  [Required]
+  public string? Value { get; set; }
+
+  public bool IsActive { get; set; }
+}

--- a/src/Bluewater.Web/EmployeeTypes/Update.UpdateEmployeeTypeResponse.cs
+++ b/src/Bluewater.Web/EmployeeTypes/Update.UpdateEmployeeTypeResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.EmployeeTypes;
+
+public class UpdateEmployeeTypeResponse(EmployeeTypeRecord EmployeeType)
+{
+  public EmployeeTypeRecord EmployeeType { get; set; } = EmployeeType;
+}

--- a/src/Bluewater.Web/EmployeeTypes/Update.UpdateEmployeeTypeValidator.cs
+++ b/src/Bluewater.Web/EmployeeTypes/Update.UpdateEmployeeTypeValidator.cs
@@ -1,0 +1,22 @@
+using Bluewater.Infrastructure.Data.Config;
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.EmployeeTypes;
+
+public class UpdateEmployeeTypeValidator : Validator<UpdateEmployeeTypeRequest>
+{
+  public UpdateEmployeeTypeValidator()
+  {
+    RuleFor(x => x.Id)
+      .NotEmpty();
+
+    RuleFor(x => x.Name)
+      .NotEmpty()
+      .MaximumLength(DataSchemaConstants.DEFAULT_NAME_LENGTH);
+
+    RuleFor(x => x.Value)
+      .NotEmpty()
+      .MaximumLength(DataSchemaConstants.DEFAULT_NAME_LENGTH);
+  }
+}

--- a/src/Bluewater.Web/EmployeeTypes/Update.cs
+++ b/src/Bluewater.Web/EmployeeTypes/Update.cs
@@ -1,0 +1,36 @@
+using Ardalis.Result;
+using Bluewater.UseCases.EmployeeTypes;
+using Bluewater.UseCases.EmployeeTypes.Update;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.EmployeeTypes;
+
+/// <summary>
+/// Update an existing employee type.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Update(IMediator _mediator) : Endpoint<UpdateEmployeeTypeRequest, UpdateEmployeeTypeResponse>
+{
+  public override void Configure()
+  {
+    Put(UpdateEmployeeTypeRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(UpdateEmployeeTypeRequest req, CancellationToken ct)
+  {
+    var result = await _mediator.Send(new UpdateEmployeeTypeCommand(req.Id, req.Name!, req.Value!, req.IsActive), ct);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(ct);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      Response = new UpdateEmployeeTypeResponse(new EmployeeTypeRecord(result.Value.Id, result.Value.Name, result.Value.Value, result.Value.IsActive));
+    }
+  }
+}

--- a/src/Bluewater.Web/Employees/Create.CreateEmployeeRequest.cs
+++ b/src/Bluewater.Web/Employees/Create.CreateEmployeeRequest.cs
@@ -1,0 +1,85 @@
+using System.ComponentModel.DataAnnotations;
+using Bluewater.Core.EmployeeAggregate.Enum;
+
+namespace Bluewater.Web.Employees;
+
+public class CreateEmployeeRequest
+{
+  public const string Route = "/Employees";
+
+  [Required]
+  public string? FirstName { get; set; }
+
+  [Required]
+  public string? LastName { get; set; }
+
+  public string? MiddleName { get; set; }
+  public DateTime? DateOfBirth { get; set; }
+
+  [Required]
+  public Gender Gender { get; set; }
+
+  [Required]
+  public CivilStatus CivilStatus { get; set; }
+
+  [Required]
+  public BloodType BloodType { get; set; }
+
+  [Required]
+  public Status Status { get; set; }
+
+  public decimal? Height { get; set; }
+  public decimal? Weight { get; set; }
+  public byte[]? Image { get; set; }
+  public string? Remarks { get; set; }
+
+  public ContactInfoRequest? ContactInfo { get; set; }
+  public EducationInfoRequest? EducationInfo { get; set; }
+  public EmploymentInfoRequest? EmploymentInfo { get; set; }
+
+  public Guid? UserId { get; set; }
+  public Guid? PositionId { get; set; }
+  public Guid? PayId { get; set; }
+  public Guid? TypeId { get; set; }
+  public Guid? LevelId { get; set; }
+  public Guid? ChargingId { get; set; }
+  public int MealCredits { get; set; }
+  public Tenant Tenant { get; set; } = Tenant.Maribago;
+}
+
+public class ContactInfoRequest
+{
+  public string? Email { get; set; }
+  public string? TelNumber { get; set; }
+  public string? MobileNumber { get; set; }
+  public string? Address { get; set; }
+  public string? ProvincialAddress { get; set; }
+  public string? MothersMaidenName { get; set; }
+  public string? FathersName { get; set; }
+  public string? EmergencyContact { get; set; }
+  public string? RelationshipContact { get; set; }
+  public string? AddressContact { get; set; }
+  public string? TelNoContact { get; set; }
+  public string? MobileNoContact { get; set; }
+}
+
+public class EducationInfoRequest
+{
+  public EducationalAttainment EducationalAttainment { get; set; } = EducationalAttainment.NotSet;
+  public string? CourseGraduated { get; set; }
+  public string? UniversityGraduated { get; set; }
+}
+
+public class EmploymentInfoRequest
+{
+  public DateTime? DateHired { get; set; }
+  public DateTime? DateRegularized { get; set; }
+  public DateTime? DateResigned { get; set; }
+  public DateTime? DateTerminated { get; set; }
+  public string? TinNo { get; set; }
+  public string? SssNo { get; set; }
+  public string? HdmfNo { get; set; }
+  public string? PhicNo { get; set; }
+  public string? BankAccount { get; set; }
+  public bool HasServiceCharge { get; set; }
+}

--- a/src/Bluewater.Web/Employees/Create.CreateEmployeeResponse.cs
+++ b/src/Bluewater.Web/Employees/Create.CreateEmployeeResponse.cs
@@ -1,0 +1,12 @@
+using Bluewater.Core.EmployeeAggregate.Enum;
+
+namespace Bluewater.Web.Employees;
+
+public class CreateEmployeeResponse(Guid Id, string FirstName, string LastName, string? MiddleName, Tenant Tenant)
+{
+  public Guid Id { get; set; } = Id;
+  public string FirstName { get; set; } = FirstName;
+  public string LastName { get; set; } = LastName;
+  public string? MiddleName { get; set; } = MiddleName;
+  public Tenant Tenant { get; set; } = Tenant;
+}

--- a/src/Bluewater.Web/Employees/Create.CreateEmployeeValidator.cs
+++ b/src/Bluewater.Web/Employees/Create.CreateEmployeeValidator.cs
@@ -1,0 +1,40 @@
+using Bluewater.Core.EmployeeAggregate.Enum;
+using Bluewater.Infrastructure.Data.Config;
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Employees;
+
+public class CreateEmployeeValidator : Validator<CreateEmployeeRequest>
+{
+  public CreateEmployeeValidator()
+  {
+    RuleFor(x => x.FirstName)
+      .NotEmpty()
+      .MaximumLength(DataSchemaConstants.DEFAULT_NAME_LENGTH);
+
+    RuleFor(x => x.LastName)
+      .NotEmpty()
+      .MaximumLength(DataSchemaConstants.DEFAULT_NAME_LENGTH);
+
+    RuleFor(x => x.Gender)
+      .IsInEnum()
+      .Must(g => g != Gender.NotSet)
+      .WithMessage("Gender is required.");
+
+    RuleFor(x => x.CivilStatus)
+      .IsInEnum()
+      .Must(s => s != CivilStatus.NotSet)
+      .WithMessage("Civil status is required.");
+
+    RuleFor(x => x.BloodType)
+      .IsInEnum()
+      .Must(b => b != BloodType.NotSet)
+      .WithMessage("Blood type is required.");
+
+    RuleFor(x => x.Status)
+      .IsInEnum()
+      .Must(s => s != Status.NotSet)
+      .WithMessage("Status is required.");
+  }
+}

--- a/src/Bluewater.Web/Employees/Create.cs
+++ b/src/Bluewater.Web/Employees/Create.cs
@@ -1,0 +1,85 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Employees.Create;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Employees;
+
+/// <summary>
+/// Create a new employee record.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Create(IMediator _mediator) : Endpoint<CreateEmployeeRequest, CreateEmployeeResponse>
+{
+  public override void Configure()
+  {
+    Post(CreateEmployeeRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(CreateEmployeeRequest req, CancellationToken ct)
+  {
+    var command = new CreateEmployeeCommand(
+      req.FirstName!,
+      req.LastName!,
+      req.MiddleName,
+      req.DateOfBirth,
+      req.Gender,
+      req.CivilStatus,
+      req.BloodType,
+      req.Status,
+      req.Height,
+      req.Weight,
+      req.Image,
+      req.Remarks,
+      req.ContactInfo is null
+        ? null
+        : new CreateEmployeeCommand.ContactInfo(
+            req.ContactInfo.Email,
+            req.ContactInfo.TelNumber,
+            req.ContactInfo.MobileNumber,
+            req.ContactInfo.Address,
+            req.ContactInfo.ProvincialAddress,
+            req.ContactInfo.MothersMaidenName,
+            req.ContactInfo.FathersName,
+            req.ContactInfo.EmergencyContact,
+            req.ContactInfo.RelationshipContact,
+            req.ContactInfo.AddressContact,
+            req.ContactInfo.TelNoContact,
+            req.ContactInfo.MobileNoContact),
+      req.EducationInfo is null
+        ? null
+        : new CreateEmployeeCommand.EducationInfo(
+            req.EducationInfo.EducationalAttainment,
+            req.EducationInfo.CourseGraduated,
+            req.EducationInfo.UniversityGraduated),
+      req.EmploymentInfo is null
+        ? null
+        : new CreateEmployeeCommand.EmploymentInfo(
+            req.EmploymentInfo.DateHired,
+            req.EmploymentInfo.DateRegularized,
+            req.EmploymentInfo.DateResigned,
+            req.EmploymentInfo.DateTerminated,
+            req.EmploymentInfo.TinNo,
+            req.EmploymentInfo.SssNo,
+            req.EmploymentInfo.HdmfNo,
+            req.EmploymentInfo.PhicNo,
+            req.EmploymentInfo.BankAccount,
+            req.EmploymentInfo.HasServiceCharge),
+      req.UserId,
+      req.PositionId,
+      req.PayId,
+      req.TypeId,
+      req.LevelId,
+      req.ChargingId,
+      req.MealCredits,
+      req.Tenant);
+
+    Result<Guid> result = await _mediator.Send(command, ct);
+
+    if (result.IsSuccess)
+    {
+      Response = new CreateEmployeeResponse(result.Value, req.FirstName!, req.LastName!, req.MiddleName, req.Tenant);
+    }
+  }
+}

--- a/src/Bluewater.Web/Employees/Delete.DeleteEmployeeRequest.cs
+++ b/src/Bluewater.Web/Employees/Delete.DeleteEmployeeRequest.cs
@@ -1,0 +1,8 @@
+namespace Bluewater.Web.Employees;
+
+public class DeleteEmployeeRequest
+{
+  public const string Route = "/Employees/{EmployeeId:guid}";
+
+  public Guid EmployeeId { get; set; }
+}

--- a/src/Bluewater.Web/Employees/Delete.DeleteEmployeeValidator.cs
+++ b/src/Bluewater.Web/Employees/Delete.DeleteEmployeeValidator.cs
@@ -1,0 +1,14 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Employees;
+
+public class DeleteEmployeeValidator : Validator<DeleteEmployeeRequest>
+{
+  public DeleteEmployeeValidator()
+  {
+    RuleFor(x => x.EmployeeId)
+      .NotEmpty()
+      .WithMessage("EmployeeId is required.");
+  }
+}

--- a/src/Bluewater.Web/Employees/Delete.cs
+++ b/src/Bluewater.Web/Employees/Delete.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Employees.Delete;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Employees;
+
+/// <summary>
+/// Delete an existing employee.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Delete(IMediator _mediator) : Endpoint<DeleteEmployeeRequest>
+{
+  public override void Configure()
+  {
+    Delete(DeleteEmployeeRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(DeleteEmployeeRequest req, CancellationToken ct)
+  {
+    var result = await _mediator.Send(new DeleteEmployeeCommand(req.EmployeeId), ct);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(ct);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      await SendNoContentAsync(ct);
+    }
+  }
+}

--- a/src/Bluewater.Web/Employees/EmployeeMapper.cs
+++ b/src/Bluewater.Web/Employees/EmployeeMapper.cs
@@ -1,0 +1,87 @@
+using Bluewater.Core.EmployeeAggregate.Enum;
+using Bluewater.UseCases.Employees;
+
+namespace Bluewater.Web.Employees;
+
+internal static class EmployeeMapper
+{
+  public static EmployeeRecord ToRecord(EmployeeDTO dto)
+  {
+    return new EmployeeRecord(
+      dto.Id,
+      dto.FirstName,
+      dto.LastName,
+      dto.MiddleName,
+      dto.DateOfBirth,
+      dto.Gender,
+      dto.CivilStatus,
+      dto.BloodType,
+      dto.Status,
+      dto.Height,
+      dto.Weight,
+      dto.ImageUrl,
+      dto.Remarks,
+      dto.ContactInfo is null
+        ? null
+        : new ContactInfoRecord(
+            dto.ContactInfo.Email,
+            dto.ContactInfo.TelNumber,
+            dto.ContactInfo.MobileNumber,
+            dto.ContactInfo.Address,
+            dto.ContactInfo.ProvincialAddress,
+            dto.ContactInfo.MothersMaidenName,
+            dto.ContactInfo.FathersName,
+            dto.ContactInfo.EmergencyContact,
+            dto.ContactInfo.RelationshipContact,
+            dto.ContactInfo.AddressContact,
+            dto.ContactInfo.TelNoContact,
+            dto.ContactInfo.MobileNoContact),
+      dto.EducationInfo is null
+        ? null
+        : new EducationInfoRecord(
+            dto.EducationInfo.EducationalAttainment,
+            dto.EducationInfo.CourseGraduated,
+            dto.EducationInfo.UniversityGraduated),
+      dto.EmploymentInfo is null
+        ? null
+        : new EmploymentInfoRecord(
+            dto.EmploymentInfo.DateHired,
+            dto.EmploymentInfo.DateRegularized,
+            dto.EmploymentInfo.DateResigned,
+            dto.EmploymentInfo.DateTerminated,
+            dto.EmploymentInfo.TinNo,
+            dto.EmploymentInfo.SssNo,
+            dto.EmploymentInfo.HdmfNo,
+            dto.EmploymentInfo.PhicNo,
+            dto.EmploymentInfo.BankAccount,
+            dto.EmploymentInfo.HasServiceCharge),
+      dto.User is null
+        ? null
+        : new UserRecord(
+            dto.User.Id,
+            dto.User.Username,
+            dto.User.PasswordHash,
+            dto.User.Credential,
+            dto.User.SupervisedGroup,
+            dto.User.IsGlobalSupervisor),
+      dto.Position,
+      dto.Section,
+      dto.Department,
+      dto.Division,
+      dto.Charging,
+      dto.Pay is null
+        ? null
+        : new PayRecord(
+            dto.Pay.Id,
+            dto.Pay.BasicPay,
+            dto.Pay.DailyRate,
+            dto.Pay.HourlyRate,
+            dto.Pay.HDMF_Con,
+            dto.Pay.HDMF_Er,
+            dto.Pay.Cola),
+      dto.Type,
+      dto.Level,
+      dto.MealCredits,
+      dto.Tenant);
+  }
+}

--- a/src/Bluewater.Web/Employees/EmployeeRecord.cs
+++ b/src/Bluewater.Web/Employees/EmployeeRecord.cs
@@ -1,0 +1,87 @@
+using Bluewater.Core.EmployeeAggregate.Enum;
+using Bluewater.Core.UserAggregate.Enum;
+
+namespace Bluewater.Web.Employees;
+
+public record EmployeeRecord(
+  Guid Id,
+  string FirstName,
+  string LastName,
+  string? MiddleName,
+  DateTime? DateOfBirth,
+  Gender Gender,
+  CivilStatus CivilStatus,
+  BloodType BloodType,
+  Status Status,
+  decimal? Height,
+  decimal? Weight,
+  byte[]? Image,
+  string? Remarks,
+  ContactInfoRecord? ContactInfo,
+  EducationInfoRecord? EducationInfo,
+  EmploymentInfoRecord? EmploymentInfo,
+  UserRecord? User,
+  string? Position,
+  string? Section,
+  string? Department,
+  string? Division,
+  string? Charging,
+  PayRecord? Pay,
+  string? Type,
+  string? Level,
+  int MealCredits,
+  Tenant Tenant
+);
+
+public record ContactInfoRecord(
+  string? Email,
+  string? TelNumber,
+  string? MobileNumber,
+  string? Address,
+  string? ProvincialAddress,
+  string? MothersMaidenName,
+  string? FathersName,
+  string? EmergencyContact,
+  string? RelationshipContact,
+  string? AddressContact,
+  string? TelNoContact,
+  string? MobileNoContact
+);
+
+public record EducationInfoRecord(
+  EducationalAttainment EducationalAttainment,
+  string? CourseGraduated,
+  string? UniversityGraduated
+);
+
+public record EmploymentInfoRecord(
+  DateTime? DateHired,
+  DateTime? DateRegularized,
+  DateTime? DateResigned,
+  DateTime? DateTerminated,
+  string? TinNo,
+  string? SssNo,
+  string? HdmfNo,
+  string? PhicNo,
+  string? BankAccount,
+  bool HasServiceCharge
+);
+
+public record UserRecord(
+  Guid Id,
+  string Username,
+  string PasswordHash,
+  Credential Credential,
+  Guid? SupervisedGroup,
+  bool IsGlobalSupervisor
+);
+
+public record PayRecord(
+  Guid Id,
+  decimal? BasicPay,
+  decimal? DailyRate,
+  decimal? HourlyRate,
+  decimal? HdmfEmployeeContribution,
+  decimal? HdmfEmployerContribution,
+  decimal? Cola
+);

--- a/src/Bluewater.Web/Employees/GetById.GetEmployeeByIdRequest.cs
+++ b/src/Bluewater.Web/Employees/GetById.GetEmployeeByIdRequest.cs
@@ -1,0 +1,8 @@
+namespace Bluewater.Web.Employees;
+
+public class GetEmployeeByIdRequest
+{
+  public const string Route = "/Employees/{EmployeeId:guid}";
+
+  public Guid EmployeeId { get; set; }
+}

--- a/src/Bluewater.Web/Employees/GetById.GetEmployeeValidator.cs
+++ b/src/Bluewater.Web/Employees/GetById.GetEmployeeValidator.cs
@@ -1,0 +1,14 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Employees;
+
+public class GetEmployeeValidator : Validator<GetEmployeeByIdRequest>
+{
+  public GetEmployeeValidator()
+  {
+    RuleFor(x => x.EmployeeId)
+      .NotEmpty()
+      .WithMessage("EmployeeId is required.");
+  }
+}

--- a/src/Bluewater.Web/Employees/GetById.cs
+++ b/src/Bluewater.Web/Employees/GetById.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Employees.Get;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Employees;
+
+/// <summary>
+/// Retrieve a single employee by identifier.
+/// </summary>
+/// <param name="_mediator"></param>
+public class GetById(IMediator _mediator) : Endpoint<GetEmployeeByIdRequest, EmployeeRecord>
+{
+  public override void Configure()
+  {
+    Get(GetEmployeeByIdRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(GetEmployeeByIdRequest req, CancellationToken ct)
+  {
+    var result = await _mediator.Send(new GetEmployeeQuery(req.EmployeeId), ct);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(ct);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      Response = EmployeeMapper.ToRecord(result.Value);
+    }
+  }
+}

--- a/src/Bluewater.Web/Employees/List.EmployeeListRequest.cs
+++ b/src/Bluewater.Web/Employees/List.EmployeeListRequest.cs
@@ -1,0 +1,10 @@
+using Bluewater.Core.EmployeeAggregate.Enum;
+
+namespace Bluewater.Web.Employees;
+
+public class ListEmployeeRequest
+{
+  public int? Skip { get; set; }
+  public int? Take { get; set; }
+  public Tenant Tenant { get; set; } = Tenant.Maribago;
+}

--- a/src/Bluewater.Web/Employees/List.EmployeeListResponse.cs
+++ b/src/Bluewater.Web/Employees/List.EmployeeListResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Employees;
+
+public class EmployeeListResponse
+{
+  public List<EmployeeRecord> Employees { get; set; } = new();
+}

--- a/src/Bluewater.Web/Employees/List.cs
+++ b/src/Bluewater.Web/Employees/List.cs
@@ -1,0 +1,37 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Employees;
+using Bluewater.UseCases.Employees.List;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Employees;
+
+/// <summary>
+/// List employees with optional paging parameters.
+/// </summary>
+/// <param name="_mediator"></param>
+public class List(IMediator _mediator) : Endpoint<ListEmployeeRequest, EmployeeListResponse>
+{
+  public override void Configure()
+  {
+    Get("/Employees");
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(ListEmployeeRequest req, CancellationToken ct)
+  {
+    Result<IEnumerable<EmployeeDTO>> result = await _mediator.Send(
+      new ListEmployeeQuery(req.Skip, req.Take, req.Tenant),
+      ct);
+
+    if (result.IsSuccess)
+    {
+      Response = new EmployeeListResponse
+      {
+        Employees = result.Value
+          .Select(EmployeeMapper.ToRecord)
+          .ToList()
+      };
+    }
+  }
+}

--- a/src/Bluewater.Web/Employees/Update.UpdateEmployeeRequest.cs
+++ b/src/Bluewater.Web/Employees/Update.UpdateEmployeeRequest.cs
@@ -1,0 +1,63 @@
+using System.ComponentModel.DataAnnotations;
+using Bluewater.Core.EmployeeAggregate.Enum;
+
+namespace Bluewater.Web.Employees;
+
+public class UpdateEmployeeRequest
+{
+  public const string Route = "/Employees";
+
+  [Required]
+  public Guid Id { get; set; }
+
+  [Required]
+  public string? FirstName { get; set; }
+
+  [Required]
+  public string? LastName { get; set; }
+
+  public string? MiddleName { get; set; }
+  public DateTime? DateOfBirth { get; set; }
+
+  [Required]
+  public Gender Gender { get; set; }
+
+  [Required]
+  public CivilStatus CivilStatus { get; set; }
+
+  [Required]
+  public BloodType BloodType { get; set; }
+
+  [Required]
+  public Status Status { get; set; }
+
+  public decimal? Height { get; set; }
+  public decimal? Weight { get; set; }
+  public byte[]? Image { get; set; }
+  public string? Remarks { get; set; }
+
+  public ContactInfoRequest? ContactInfo { get; set; }
+  public EducationInfoRequest? EducationInfo { get; set; }
+  public EmploymentInfoRequest? EmploymentInfo { get; set; }
+
+  [Required]
+  public Guid UserId { get; set; }
+
+  [Required]
+  public Guid PositionId { get; set; }
+
+  [Required]
+  public Guid PayId { get; set; }
+
+  [Required]
+  public Guid TypeId { get; set; }
+
+  [Required]
+  public Guid LevelId { get; set; }
+
+  [Required]
+  public Guid ChargingId { get; set; }
+
+  public int MealCredits { get; set; }
+  public Tenant Tenant { get; set; } = Tenant.Maribago;
+}

--- a/src/Bluewater.Web/Employees/Update.UpdateEmployeeResponse.cs
+++ b/src/Bluewater.Web/Employees/Update.UpdateEmployeeResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Employees;
+
+public class UpdateEmployeeResponse(EmployeeRecord Employee)
+{
+  public EmployeeRecord Employee { get; set; } = Employee;
+}

--- a/src/Bluewater.Web/Employees/Update.UpdateEmployeeValidator.cs
+++ b/src/Bluewater.Web/Employees/Update.UpdateEmployeeValidator.cs
@@ -1,0 +1,61 @@
+using Bluewater.Core.EmployeeAggregate.Enum;
+using Bluewater.Infrastructure.Data.Config;
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Employees;
+
+public class UpdateEmployeeValidator : Validator<UpdateEmployeeRequest>
+{
+  public UpdateEmployeeValidator()
+  {
+    RuleFor(x => x.Id)
+      .NotEmpty();
+
+    RuleFor(x => x.FirstName)
+      .NotEmpty()
+      .MaximumLength(DataSchemaConstants.DEFAULT_NAME_LENGTH);
+
+    RuleFor(x => x.LastName)
+      .NotEmpty()
+      .MaximumLength(DataSchemaConstants.DEFAULT_NAME_LENGTH);
+
+    RuleFor(x => x.Gender)
+      .IsInEnum()
+      .Must(g => g != Gender.NotSet)
+      .WithMessage("Gender is required.");
+
+    RuleFor(x => x.CivilStatus)
+      .IsInEnum()
+      .Must(s => s != CivilStatus.NotSet)
+      .WithMessage("Civil status is required.");
+
+    RuleFor(x => x.BloodType)
+      .IsInEnum()
+      .Must(b => b != BloodType.NotSet)
+      .WithMessage("Blood type is required.");
+
+    RuleFor(x => x.Status)
+      .IsInEnum()
+      .Must(s => s != Status.NotSet)
+      .WithMessage("Status is required.");
+
+    RuleFor(x => x.UserId)
+      .NotEmpty();
+
+    RuleFor(x => x.PositionId)
+      .NotEmpty();
+
+    RuleFor(x => x.PayId)
+      .NotEmpty();
+
+    RuleFor(x => x.TypeId)
+      .NotEmpty();
+
+    RuleFor(x => x.LevelId)
+      .NotEmpty();
+
+    RuleFor(x => x.ChargingId)
+      .NotEmpty();
+  }
+}

--- a/src/Bluewater.Web/Employees/Update.cs
+++ b/src/Bluewater.Web/Employees/Update.cs
@@ -1,0 +1,93 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Employees;
+using Bluewater.UseCases.Employees.Update;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Employees;
+
+/// <summary>
+/// Update an existing employee.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Update(IMediator _mediator) : Endpoint<UpdateEmployeeRequest, UpdateEmployeeResponse>
+{
+  public override void Configure()
+  {
+    Put(UpdateEmployeeRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(UpdateEmployeeRequest req, CancellationToken ct)
+  {
+    var command = new UpdateEmployeeCommand(
+      req.Id,
+      req.FirstName!,
+      req.LastName!,
+      req.MiddleName,
+      req.DateOfBirth,
+      req.Gender,
+      req.CivilStatus,
+      req.BloodType,
+      req.Status,
+      req.Height,
+      req.Weight,
+      req.Image,
+      req.Remarks,
+      req.ContactInfo is null
+        ? null
+        : new UpdateEmployeeCommand.ContactInfo(
+            req.ContactInfo.Email,
+            req.ContactInfo.TelNumber,
+            req.ContactInfo.MobileNumber,
+            req.ContactInfo.Address,
+            req.ContactInfo.ProvincialAddress,
+            req.ContactInfo.MothersMaidenName,
+            req.ContactInfo.FathersName,
+            req.ContactInfo.EmergencyContact,
+            req.ContactInfo.RelationshipContact,
+            req.ContactInfo.AddressContact,
+            req.ContactInfo.TelNoContact,
+            req.ContactInfo.MobileNoContact),
+      req.EducationInfo is null
+        ? null
+        : new UpdateEmployeeCommand.EducationInfo(
+            req.EducationInfo.EducationalAttainment,
+            req.EducationInfo.CourseGraduated,
+            req.EducationInfo.UniversityGraduated),
+      req.EmploymentInfo is null
+        ? null
+        : new UpdateEmployeeCommand.EmploymentInfo(
+            req.EmploymentInfo.DateHired,
+            req.EmploymentInfo.DateRegularized,
+            req.EmploymentInfo.DateResigned,
+            req.EmploymentInfo.DateTerminated,
+            req.EmploymentInfo.TinNo,
+            req.EmploymentInfo.SssNo,
+            req.EmploymentInfo.HdmfNo,
+            req.EmploymentInfo.PhicNo,
+            req.EmploymentInfo.BankAccount,
+            req.EmploymentInfo.HasServiceCharge),
+      req.UserId,
+      req.PositionId,
+      req.PayId,
+      req.TypeId,
+      req.LevelId,
+      req.ChargingId,
+      req.MealCredits,
+      req.Tenant);
+
+    Result<EmployeeDTO> result = await _mediator.Send(command, ct);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(ct);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      Response = new UpdateEmployeeResponse(EmployeeMapper.ToRecord(result.Value));
+    }
+  }
+}

--- a/src/Bluewater.Web/Program.cs
+++ b/src/Bluewater.Web/Program.cs
@@ -1,16 +1,22 @@
 ﻿using System.Reflection;
 using Ardalis.ListStartupServices;
 using Ardalis.SharedKernel;
+using Bluewater.Core.ChargingAggregate;
 using Bluewater.Core.ContributorAggregate;
 using Bluewater.Core.DepartmentAggregate;
 using Bluewater.Core.DivisionAggregate;
+using Bluewater.Core.EmployeeAggregate;
+using Bluewater.Core.EmployeeTypeAggregate;
 using Bluewater.Core.Interfaces;
 using Bluewater.Infrastructure;
 using Bluewater.Infrastructure.Data;
 using Bluewater.Infrastructure.Email;
+using Bluewater.UseCases.Chargings.Create;
 using Bluewater.UseCases.Contributors.Create;
 using Bluewater.UseCases.Departments.Create;
 using Bluewater.UseCases.Divisions.Create;
+using Bluewater.UseCases.Employees.Create;
+using Bluewater.UseCases.EmployeeTypes.Create;
 using FastEndpoints;
 using FastEndpoints.Swagger;
 using MediatR;
@@ -120,7 +126,16 @@ void ConfigureMediatR()
   Assembly.GetAssembly(typeof(CreateDivisionCommand)), // UseCases
 
   Assembly.GetAssembly(typeof(Department)), // Core
-  Assembly.GetAssembly(typeof(CreateDepartmentCommand)) // UseCases
+  Assembly.GetAssembly(typeof(CreateDepartmentCommand)), // UseCases
+
+  Assembly.GetAssembly(typeof(Employee)), // Core
+  Assembly.GetAssembly(typeof(CreateEmployeeCommand)), // UseCases
+
+  Assembly.GetAssembly(typeof(EmployeeType)), // Core
+  Assembly.GetAssembly(typeof(CreateEmployeeTypeCommand)), // UseCases
+
+  Assembly.GetAssembly(typeof(Charging)), // Core
+  Assembly.GetAssembly(typeof(CreateChargingCommand)) // UseCases
 };
   builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(mediatRAssemblies!));
   builder.Services.AddScoped(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>));


### PR DESCRIPTION
## Summary
- add FastEndpoints CRUD APIs for employees with rich request/response validation and mapping helpers
- expose employee type CRUD endpoints leveraging existing use case commands and queries
- wire up charging CRUD endpoints and register associated MediatR assemblies in the web host

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d54e3d8b308329b47251d9efb96bc7