### PR TITLE
Add CRUD endpoints for holidays, leave credits, leaves, and levels

### DIFF
--- a/src/Bluewater.Web/Holidays/Create.CreateHolidayRequest.cs
+++ b/src/Bluewater.Web/Holidays/Create.CreateHolidayRequest.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.Holidays;
+
+public class CreateHolidayRequest
+{
+  public const string Route = "/Holidays";
+
+  [Required]
+  public string? Name { get; set; }
+
+  public string? Description { get; set; }
+
+  [Required]
+  public DateTime Date { get; set; }
+
+  public bool IsRegular { get; set; }
+}

--- a/src/Bluewater.Web/Holidays/Create.CreateHolidayResponse.cs
+++ b/src/Bluewater.Web/Holidays/Create.CreateHolidayResponse.cs
@@ -1,0 +1,10 @@
+namespace Bluewater.Web.Holidays;
+
+public class CreateHolidayResponse(Guid Id, string Name, string? Description, DateTime Date, bool IsRegular)
+{
+  public Guid Id { get; set; } = Id;
+  public string Name { get; set; } = Name;
+  public string? Description { get; set; } = Description;
+  public DateTime Date { get; set; } = Date;
+  public bool IsRegular { get; set; } = IsRegular;
+}

--- a/src/Bluewater.Web/Holidays/Create.CreateHolidayValidator.cs
+++ b/src/Bluewater.Web/Holidays/Create.CreateHolidayValidator.cs
@@ -1,0 +1,21 @@
+using Bluewater.Infrastructure.Data.Config;
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Holidays;
+
+public class CreateHolidayValidator : Validator<CreateHolidayRequest>
+{
+  public CreateHolidayValidator()
+  {
+    RuleFor(x => x.Name)
+      .NotEmpty()
+      .WithMessage("Name is required.")
+      .MaximumLength(DataSchemaConstants.DEFAULT_NAME_LENGTH);
+
+    RuleFor(x => x.Date)
+      .NotEmpty()
+      .Must(date => date != default)
+      .WithMessage("Date is required.");
+  }
+}

--- a/src/Bluewater.Web/Holidays/Create.cs
+++ b/src/Bluewater.Web/Holidays/Create.cs
@@ -1,0 +1,28 @@
+using Bluewater.UseCases.Holidays.Create;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Holidays;
+
+/// <summary>
+/// Create a new holiday.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Create(IMediator _mediator) : Endpoint<CreateHolidayRequest, CreateHolidayResponse>
+{
+  public override void Configure()
+  {
+    Post(CreateHolidayRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(CreateHolidayRequest req, CancellationToken ct)
+  {
+    var result = await _mediator.Send(new CreateHolidayCommand(req.Name!, req.Description, req.Date, req.IsRegular), ct);
+
+    if (result.IsSuccess)
+    {
+      Response = new CreateHolidayResponse(result.Value, req.Name!, req.Description, req.Date, req.IsRegular);
+    }
+  }
+}

--- a/src/Bluewater.Web/Holidays/Delete.DeleteHolidayRequest.cs
+++ b/src/Bluewater.Web/Holidays/Delete.DeleteHolidayRequest.cs
@@ -1,0 +1,9 @@
+namespace Bluewater.Web.Holidays;
+
+public class DeleteHolidayRequest
+{
+  public const string Route = "/Holidays/{HolidayId:guid}";
+  public static string BuildRoute(Guid holidayId) => Route.Replace("{HolidayId:guid}", holidayId.ToString());
+
+  public Guid HolidayId { get; set; }
+}

--- a/src/Bluewater.Web/Holidays/Delete.DeleteHolidayValidator.cs
+++ b/src/Bluewater.Web/Holidays/Delete.DeleteHolidayValidator.cs
@@ -1,0 +1,13 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Holidays;
+
+public class DeleteHolidayValidator : Validator<DeleteHolidayRequest>
+{
+  public DeleteHolidayValidator()
+  {
+    RuleFor(x => x.HolidayId)
+      .NotEmpty().WithMessage("Holiday ID is required and cannot be an empty GUID.");
+  }
+}

--- a/src/Bluewater.Web/Holidays/Delete.cs
+++ b/src/Bluewater.Web/Holidays/Delete.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Holidays.Delete;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Holidays;
+
+/// <summary>
+/// Delete a holiday.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Delete(IMediator _mediator) : Endpoint<DeleteHolidayRequest>
+{
+  public override void Configure()
+  {
+    Delete(DeleteHolidayRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(DeleteHolidayRequest req, CancellationToken ct)
+  {
+    var result = await _mediator.Send(new DeleteHolidayCommand(req.HolidayId), ct);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(ct);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      await SendNoContentAsync(ct);
+    }
+  }
+}

--- a/src/Bluewater.Web/Holidays/GetById.GetHolidayByIdRequest.cs
+++ b/src/Bluewater.Web/Holidays/GetById.GetHolidayByIdRequest.cs
@@ -1,0 +1,9 @@
+namespace Bluewater.Web.Holidays;
+
+public class GetHolidayByIdRequest
+{
+  public const string Route = "/Holidays/{HolidayId:guid}";
+  public static string BuildRoute(Guid holidayId) => Route.Replace("{HolidayId:guid}", holidayId.ToString());
+
+  public Guid HolidayId { get; set; }
+}

--- a/src/Bluewater.Web/Holidays/GetById.GetHolidayValidator.cs
+++ b/src/Bluewater.Web/Holidays/GetById.GetHolidayValidator.cs
@@ -1,0 +1,13 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Holidays;
+
+public class GetHolidayValidator : Validator<GetHolidayByIdRequest>
+{
+  public GetHolidayValidator()
+  {
+    RuleFor(x => x.HolidayId)
+      .NotEmpty().WithMessage("Holiday ID is required and cannot be an empty GUID.");
+  }
+}

--- a/src/Bluewater.Web/Holidays/GetById.cs
+++ b/src/Bluewater.Web/Holidays/GetById.cs
@@ -1,0 +1,36 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Holidays.Get;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Holidays;
+
+/// <summary>
+/// Get a holiday by ID.
+/// </summary>
+/// <param name="_mediator"></param>
+public class GetById(IMediator _mediator) : Endpoint<GetHolidayByIdRequest, HolidayRecord>
+{
+  public override void Configure()
+  {
+    Get(GetHolidayByIdRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(GetHolidayByIdRequest req, CancellationToken ct)
+  {
+    var result = await _mediator.Send(new GetHolidayQuery(req.HolidayId), ct);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(ct);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      var dto = result.Value;
+      Response = new HolidayRecord(dto.Id, dto.Name, dto.Description, dto.Date, dto.IsRegular);
+    }
+  }
+}

--- a/src/Bluewater.Web/Holidays/HolidayRecord.cs
+++ b/src/Bluewater.Web/Holidays/HolidayRecord.cs
@@ -1,0 +1,3 @@
+namespace Bluewater.Web.Holidays;
+
+public record HolidayRecord(Guid Id, string Name, string? Description, DateTime Date, bool IsRegular);

--- a/src/Bluewater.Web/Holidays/List.HolidayListResponse.cs
+++ b/src/Bluewater.Web/Holidays/List.HolidayListResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Holidays;
+
+public class HolidayListResponse
+{
+  public List<HolidayRecord> Holidays { get; set; } = [];
+}

--- a/src/Bluewater.Web/Holidays/List.cs
+++ b/src/Bluewater.Web/Holidays/List.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Holidays;
+using Bluewater.UseCases.Holidays.List;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Holidays;
+
+/// <summary>
+/// List all holidays.
+/// </summary>
+/// <param name="_mediator"></param>
+public class List(IMediator _mediator) : EndpointWithoutRequest<HolidayListResponse>
+{
+  public override void Configure()
+  {
+    Get("/Holidays");
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(CancellationToken ct)
+  {
+    Result<IEnumerable<HolidayDTO>> result = await _mediator.Send(new ListHolidayQuery(null, null), ct);
+
+    if (result.IsSuccess)
+    {
+      Response = new HolidayListResponse
+      {
+        Holidays = result.Value
+          .Select(h => new HolidayRecord(h.Id, h.Name, h.Description, h.Date, h.IsRegular))
+          .ToList()
+      };
+    }
+  }
+}

--- a/src/Bluewater.Web/Holidays/Update.UpdateHolidayRequest.cs
+++ b/src/Bluewater.Web/Holidays/Update.UpdateHolidayRequest.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.Holidays;
+
+public class UpdateHolidayRequest
+{
+  public const string Route = "/Holidays/{HolidayId:guid}";
+  public static string BuildRoute(Guid holidayId) => Route.Replace("{HolidayId:guid}", holidayId.ToString());
+
+  public Guid HolidayId { get; set; }
+
+  [Required]
+  public Guid Id { get; set; }
+
+  [Required]
+  public string? Name { get; set; }
+
+  public string? Description { get; set; }
+
+  [Required]
+  public DateTime Date { get; set; }
+
+  public bool IsRegular { get; set; }
+}

--- a/src/Bluewater.Web/Holidays/Update.UpdateHolidayResponse.cs
+++ b/src/Bluewater.Web/Holidays/Update.UpdateHolidayResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Holidays;
+
+public class UpdateHolidayResponse(HolidayRecord Holiday)
+{
+  public HolidayRecord Holiday { get; set; } = Holiday;
+}

--- a/src/Bluewater.Web/Holidays/Update.UpdateHolidayValidator.cs
+++ b/src/Bluewater.Web/Holidays/Update.UpdateHolidayValidator.cs
@@ -1,0 +1,27 @@
+using Bluewater.Infrastructure.Data.Config;
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Holidays;
+
+public class UpdateHolidayValidator : Validator<UpdateHolidayRequest>
+{
+  public UpdateHolidayValidator()
+  {
+    RuleFor(x => x.HolidayId)
+      .NotEmpty().WithMessage("Holiday ID is required and cannot be an empty GUID.");
+
+    RuleFor(x => x.Id)
+      .NotEmpty().WithMessage("Holiday ID is required.");
+
+    RuleFor(x => x.Name)
+      .NotEmpty()
+      .WithMessage("Name is required.")
+      .MaximumLength(DataSchemaConstants.DEFAULT_NAME_LENGTH);
+
+    RuleFor(x => x.Date)
+      .NotEmpty()
+      .Must(date => date != default)
+      .WithMessage("Date is required.");
+  }
+}

--- a/src/Bluewater.Web/Holidays/Update.cs
+++ b/src/Bluewater.Web/Holidays/Update.cs
@@ -1,0 +1,45 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Holidays.Get;
+using Bluewater.UseCases.Holidays.Update;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Holidays;
+
+/// <summary>
+/// Update an existing holiday.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Update(IMediator _mediator) : Endpoint<UpdateHolidayRequest, UpdateHolidayResponse>
+{
+  public override void Configure()
+  {
+    Put(UpdateHolidayRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(UpdateHolidayRequest req, CancellationToken ct)
+  {
+    var result = await _mediator.Send(new UpdateHolidayCommand(req.Id, req.Name!, req.Description, req.Date, req.IsRegular), ct);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(ct);
+      return;
+    }
+
+    var queryResult = await _mediator.Send(new GetHolidayQuery(req.Id), ct);
+
+    if (queryResult.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(ct);
+      return;
+    }
+
+    if (queryResult.IsSuccess)
+    {
+      var dto = queryResult.Value;
+      Response = new UpdateHolidayResponse(new HolidayRecord(dto.Id, dto.Name, dto.Description, dto.Date, dto.IsRegular));
+    }
+  }
+}

--- a/src/Bluewater.Web/LeaveCredits/Create.CreateLeaveCreditRequest.cs
+++ b/src/Bluewater.Web/LeaveCredits/Create.CreateLeaveCreditRequest.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.LeaveCredits;
+
+public class CreateLeaveCreditRequest
+{
+  public const string Route = "/LeaveCredits";
+
+  [Required]
+  public string? Code { get; set; }
+
+  [Required]
+  public string? Description { get; set; }
+
+  [Range(0, double.MaxValue)]
+  public decimal? Credit { get; set; }
+
+  public int? SortOrder { get; set; }
+
+  public bool IsLeaveWithPay { get; set; }
+
+  public bool IsCanCarryOver { get; set; }
+}

--- a/src/Bluewater.Web/LeaveCredits/Create.CreateLeaveCreditResponse.cs
+++ b/src/Bluewater.Web/LeaveCredits/Create.CreateLeaveCreditResponse.cs
@@ -1,0 +1,12 @@
+namespace Bluewater.Web.LeaveCredits;
+
+public class CreateLeaveCreditResponse(Guid Id, string Code, string Description, decimal DefaultCredits, int SortOrder, bool IsLeaveWithPay, bool IsCanCarryOver)
+{
+  public Guid Id { get; set; } = Id;
+  public string Code { get; set; } = Code;
+  public string Description { get; set; } = Description;
+  public decimal DefaultCredits { get; set; } = DefaultCredits;
+  public int SortOrder { get; set; } = SortOrder;
+  public bool IsLeaveWithPay { get; set; } = IsLeaveWithPay;
+  public bool IsCanCarryOver { get; set; } = IsCanCarryOver;
+}

--- a/src/Bluewater.Web/LeaveCredits/Create.CreateLeaveCreditValidator.cs
+++ b/src/Bluewater.Web/LeaveCredits/Create.CreateLeaveCreditValidator.cs
@@ -1,0 +1,30 @@
+using Bluewater.Infrastructure.Data.Config;
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.LeaveCredits;
+
+public class CreateLeaveCreditValidator : Validator<CreateLeaveCreditRequest>
+{
+  public CreateLeaveCreditValidator()
+  {
+    RuleFor(x => x.Code)
+      .NotEmpty()
+      .WithMessage("Code is required.")
+      .MaximumLength(DataSchemaConstants.DEFAULT_NAME_LENGTH);
+
+    RuleFor(x => x.Description)
+      .NotEmpty()
+      .WithMessage("Description is required.")
+      .MaximumLength(DataSchemaConstants.DEFAULT_NAME_LENGTH);
+
+    RuleFor(x => x.Credit)
+      .GreaterThanOrEqualTo(0)
+      .WithMessage("Credit cannot be negative.");
+
+    RuleFor(x => x.SortOrder)
+      .GreaterThanOrEqualTo(0)
+      .When(x => x.SortOrder.HasValue)
+      .WithMessage("Sort order cannot be negative.");
+  }
+}

--- a/src/Bluewater.Web/LeaveCredits/Create.cs
+++ b/src/Bluewater.Web/LeaveCredits/Create.cs
@@ -1,0 +1,43 @@
+using Bluewater.UseCases.LeaveCredits.Create;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.LeaveCredits;
+
+/// <summary>
+/// Create a new leave credit type.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Create(IMediator _mediator) : Endpoint<CreateLeaveCreditRequest, CreateLeaveCreditResponse>
+{
+  public override void Configure()
+  {
+    Post(CreateLeaveCreditRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(CreateLeaveCreditRequest req, CancellationToken ct)
+  {
+    var result = await _mediator.Send(
+      new CreateLeaveCreditCommand(
+        req.Code!,
+        req.Description ?? string.Empty,
+        req.Credit,
+        req.SortOrder,
+        req.IsLeaveWithPay,
+        req.IsCanCarryOver),
+      ct);
+
+    if (result.IsSuccess)
+    {
+      Response = new CreateLeaveCreditResponse(
+        result.Value,
+        req.Code!,
+        req.Description ?? string.Empty,
+        req.Credit ?? 0m,
+        req.SortOrder ?? 0,
+        req.IsLeaveWithPay,
+        req.IsCanCarryOver);
+    }
+  }
+}

--- a/src/Bluewater.Web/LeaveCredits/Delete.DeleteLeaveCreditRequest.cs
+++ b/src/Bluewater.Web/LeaveCredits/Delete.DeleteLeaveCreditRequest.cs
@@ -1,0 +1,9 @@
+namespace Bluewater.Web.LeaveCredits;
+
+public class DeleteLeaveCreditRequest
+{
+  public const string Route = "/LeaveCredits/{LeaveCreditId:guid}";
+  public static string BuildRoute(Guid leaveCreditId) => Route.Replace("{LeaveCreditId:guid}", leaveCreditId.ToString());
+
+  public Guid LeaveCreditId { get; set; }
+}

--- a/src/Bluewater.Web/LeaveCredits/Delete.DeleteLeaveCreditValidator.cs
+++ b/src/Bluewater.Web/LeaveCredits/Delete.DeleteLeaveCreditValidator.cs
@@ -1,0 +1,13 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.LeaveCredits;
+
+public class DeleteLeaveCreditValidator : Validator<DeleteLeaveCreditRequest>
+{
+  public DeleteLeaveCreditValidator()
+  {
+    RuleFor(x => x.LeaveCreditId)
+      .NotEmpty().WithMessage("Leave credit ID is required and cannot be an empty GUID.");
+  }
+}

--- a/src/Bluewater.Web/LeaveCredits/Delete.cs
+++ b/src/Bluewater.Web/LeaveCredits/Delete.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.LeaveCredits.Delete;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.LeaveCredits;
+
+/// <summary>
+/// Delete a leave credit.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Delete(IMediator _mediator) : Endpoint<DeleteLeaveCreditRequest>
+{
+  public override void Configure()
+  {
+    Delete(DeleteLeaveCreditRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(DeleteLeaveCreditRequest req, CancellationToken ct)
+  {
+    var result = await _mediator.Send(new DeleteLeaveCreditCommand(req.LeaveCreditId), ct);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(ct);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      await SendNoContentAsync(ct);
+    }
+  }
+}

--- a/src/Bluewater.Web/LeaveCredits/LeaveCreditRecord.cs
+++ b/src/Bluewater.Web/LeaveCredits/LeaveCreditRecord.cs
@@ -1,0 +1,3 @@
+namespace Bluewater.Web.LeaveCredits;
+
+public record LeaveCreditRecord(Guid Id, string Code, string Description, decimal DefaultCredits, int SortOrder, bool IsLeaveWithPay, bool IsCanCarryOver);

--- a/src/Bluewater.Web/LeaveCredits/List.LeaveCreditListResponse.cs
+++ b/src/Bluewater.Web/LeaveCredits/List.LeaveCreditListResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.LeaveCredits;
+
+public class LeaveCreditListResponse
+{
+  public List<LeaveCreditRecord> LeaveCredits { get; set; } = [];
+}

--- a/src/Bluewater.Web/LeaveCredits/List.cs
+++ b/src/Bluewater.Web/LeaveCredits/List.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.LeaveCredits;
+using Bluewater.UseCases.LeaveCredits.List;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.LeaveCredits;
+
+/// <summary>
+/// List all leave credits.
+/// </summary>
+/// <param name="_mediator"></param>
+public class List(IMediator _mediator) : EndpointWithoutRequest<LeaveCreditListResponse>
+{
+  public override void Configure()
+  {
+    Get("/LeaveCredits");
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(CancellationToken ct)
+  {
+    Result<IEnumerable<LeaveCreditDTO>> result = await _mediator.Send(new ListLeaveCreditQuery(null, null), ct);
+
+    if (result.IsSuccess)
+    {
+      Response = new LeaveCreditListResponse
+      {
+        LeaveCredits = result.Value
+          .Select(l => new LeaveCreditRecord(l.Id, l.Code, l.Description, l.DefaultCredits, l.SortOrder, l.IsLeaveWithPay, l.IsCanCarryOver))
+          .ToList()
+      };
+    }
+  }
+}

--- a/src/Bluewater.Web/Leaves/Create.CreateLeaveRequest.cs
+++ b/src/Bluewater.Web/Leaves/Create.CreateLeaveRequest.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.Leaves;
+
+public class CreateLeaveRequest
+{
+  public const string Route = "/Leaves";
+
+  [Required]
+  public DateTime? StartDate { get; set; }
+
+  [Required]
+  public DateTime? EndDate { get; set; }
+
+  public bool IsHalfDay { get; set; }
+
+  [Required]
+  public Guid EmployeeId { get; set; }
+
+  [Required]
+  public Guid LeaveCreditId { get; set; }
+}

--- a/src/Bluewater.Web/Leaves/Create.CreateLeaveResponse.cs
+++ b/src/Bluewater.Web/Leaves/Create.CreateLeaveResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Leaves;
+
+public class CreateLeaveResponse(LeaveRecord Leave)
+{
+  public LeaveRecord Leave { get; set; } = Leave;
+}

--- a/src/Bluewater.Web/Leaves/Create.CreateLeaveValidator.cs
+++ b/src/Bluewater.Web/Leaves/Create.CreateLeaveValidator.cs
@@ -1,0 +1,26 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Leaves;
+
+public class CreateLeaveValidator : Validator<CreateLeaveRequest>
+{
+  public CreateLeaveValidator()
+  {
+    RuleFor(x => x.StartDate)
+      .NotNull().WithMessage("Start date is required.");
+
+    RuleFor(x => x.EndDate)
+      .NotNull().WithMessage("End date is required.");
+
+    RuleFor(x => x)
+      .Must(x => !x.StartDate.HasValue || !x.EndDate.HasValue || x.EndDate >= x.StartDate)
+      .WithMessage("End date must be greater than or equal to start date.");
+
+    RuleFor(x => x.EmployeeId)
+      .NotEmpty().WithMessage("Employee ID is required and cannot be an empty GUID.");
+
+    RuleFor(x => x.LeaveCreditId)
+      .NotEmpty().WithMessage("Leave credit ID is required and cannot be an empty GUID.");
+  }
+}

--- a/src/Bluewater.Web/Leaves/Create.cs
+++ b/src/Bluewater.Web/Leaves/Create.cs
@@ -1,0 +1,41 @@
+using Bluewater.UseCases.Leaves.Create;
+using Bluewater.UserCases.Forms.Enum;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Leaves;
+
+/// <summary>
+/// Create a new leave request.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Create(IMediator _mediator) : Endpoint<CreateLeaveRequest, CreateLeaveResponse>
+{
+  public override void Configure()
+  {
+    Post(CreateLeaveRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(CreateLeaveRequest req, CancellationToken ct)
+  {
+    var result = await _mediator.Send(
+      new CreateLeaveCommand(req.StartDate, req.EndDate, req.IsHalfDay, req.EmployeeId, req.LeaveCreditId),
+      ct);
+
+    if (result.IsSuccess)
+    {
+      Response = new CreateLeaveResponse(
+        new LeaveRecord(
+          result.Value,
+          req.StartDate,
+          req.EndDate,
+          req.IsHalfDay,
+          ApplicationStatusDTO.NotSet,
+          req.EmployeeId,
+          req.LeaveCreditId,
+          string.Empty,
+          string.Empty));
+    }
+  }
+}

--- a/src/Bluewater.Web/Leaves/Delete.DeleteLeaveRequest.cs
+++ b/src/Bluewater.Web/Leaves/Delete.DeleteLeaveRequest.cs
@@ -1,0 +1,9 @@
+namespace Bluewater.Web.Leaves;
+
+public class DeleteLeaveRequest
+{
+  public const string Route = "/Leaves/{LeaveId:guid}";
+  public static string BuildRoute(Guid leaveId) => Route.Replace("{LeaveId:guid}", leaveId.ToString());
+
+  public Guid LeaveId { get; set; }
+}

--- a/src/Bluewater.Web/Leaves/Delete.DeleteLeaveValidator.cs
+++ b/src/Bluewater.Web/Leaves/Delete.DeleteLeaveValidator.cs
@@ -1,0 +1,13 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Leaves;
+
+public class DeleteLeaveValidator : Validator<DeleteLeaveRequest>
+{
+  public DeleteLeaveValidator()
+  {
+    RuleFor(x => x.LeaveId)
+      .NotEmpty().WithMessage("Leave ID is required and cannot be an empty GUID.");
+  }
+}

--- a/src/Bluewater.Web/Leaves/Delete.cs
+++ b/src/Bluewater.Web/Leaves/Delete.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Leaves.Delete;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Leaves;
+
+/// <summary>
+/// Delete a leave request.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Delete(IMediator _mediator) : Endpoint<DeleteLeaveRequest>
+{
+  public override void Configure()
+  {
+    Delete(DeleteLeaveRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(DeleteLeaveRequest req, CancellationToken ct)
+  {
+    var result = await _mediator.Send(new DeleteLeaveCommand(req.LeaveId), ct);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(ct);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      await SendNoContentAsync(ct);
+    }
+  }
+}

--- a/src/Bluewater.Web/Leaves/LeaveRecord.cs
+++ b/src/Bluewater.Web/Leaves/LeaveRecord.cs
@@ -1,0 +1,14 @@
+using Bluewater.UserCases.Forms.Enum;
+
+namespace Bluewater.Web.Leaves;
+
+public record LeaveRecord(
+  Guid Id,
+  DateTime? StartDate,
+  DateTime? EndDate,
+  bool IsHalfDay,
+  ApplicationStatusDTO Status,
+  Guid? EmployeeId,
+  Guid LeaveCreditId,
+  string EmployeeName,
+  string LeaveCreditName);

--- a/src/Bluewater.Web/Leaves/List.LeaveListRequest.cs
+++ b/src/Bluewater.Web/Leaves/List.LeaveListRequest.cs
@@ -1,0 +1,10 @@
+using Bluewater.Core.EmployeeAggregate.Enum;
+
+namespace Bluewater.Web.Leaves;
+
+public class LeaveListRequest
+{
+  public int? Skip { get; set; }
+  public int? Take { get; set; }
+  public Tenant Tenant { get; set; } = Tenant.Maribago;
+}

--- a/src/Bluewater.Web/Leaves/List.LeaveListResponse.cs
+++ b/src/Bluewater.Web/Leaves/List.LeaveListResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Leaves;
+
+public class LeaveListResponse
+{
+  public List<LeaveRecord> Leaves { get; set; } = [];
+}

--- a/src/Bluewater.Web/Leaves/List.cs
+++ b/src/Bluewater.Web/Leaves/List.cs
@@ -1,0 +1,44 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Leaves;
+using Bluewater.UseCases.Leaves.List;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Leaves;
+
+/// <summary>
+/// List leave requests.
+/// </summary>
+/// <param name="_mediator"></param>
+public class List(IMediator _mediator) : Endpoint<LeaveListRequest, LeaveListResponse>
+{
+  public override void Configure()
+  {
+    Get("/Leaves");
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(LeaveListRequest req, CancellationToken ct)
+  {
+    Result<IEnumerable<LeaveDTO>> result = await _mediator.Send(new ListLeaveQuery(req.Skip, req.Take, req.Tenant), ct);
+
+    if (result.IsSuccess)
+    {
+      Response = new LeaveListResponse
+      {
+        Leaves = result.Value
+          .Select(l => new LeaveRecord(
+            l.Id,
+            l.StartDate,
+            l.EndDate,
+            l.IsHalfDay,
+            l.Status,
+            l.EmployeeId,
+            l.LeaveCreditId,
+            l.EmployeeName,
+            l.LeaveCreditName))
+          .ToList()
+      };
+    }
+  }
+}

--- a/src/Bluewater.Web/Leaves/Update.UpdateLeaveRequest.cs
+++ b/src/Bluewater.Web/Leaves/Update.UpdateLeaveRequest.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel.DataAnnotations;
+using Bluewater.UserCases.Forms.Enum;
+
+namespace Bluewater.Web.Leaves;
+
+public class UpdateLeaveRequest
+{
+  public const string Route = "/Leaves/{LeaveId:guid}";
+  public static string BuildRoute(Guid leaveId) => Route.Replace("{LeaveId:guid}", leaveId.ToString());
+
+  public Guid LeaveId { get; set; }
+
+  [Required]
+  public Guid Id { get; set; }
+
+  [Required]
+  public DateTime StartDate { get; set; }
+
+  [Required]
+  public DateTime EndDate { get; set; }
+
+  public bool IsHalfDay { get; set; }
+
+  [Required]
+  public ApplicationStatusDTO Status { get; set; } = ApplicationStatusDTO.NotSet;
+
+  [Required]
+  public Guid EmployeeId { get; set; }
+
+  [Required]
+  public Guid LeaveCreditId { get; set; }
+}

--- a/src/Bluewater.Web/Leaves/Update.UpdateLeaveResponse.cs
+++ b/src/Bluewater.Web/Leaves/Update.UpdateLeaveResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Leaves;
+
+public class UpdateLeaveResponse(LeaveRecord Leave)
+{
+  public LeaveRecord Leave { get; set; } = Leave;
+}

--- a/src/Bluewater.Web/Leaves/Update.UpdateLeaveValidator.cs
+++ b/src/Bluewater.Web/Leaves/Update.UpdateLeaveValidator.cs
@@ -1,0 +1,32 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Leaves;
+
+public class UpdateLeaveValidator : Validator<UpdateLeaveRequest>
+{
+  public UpdateLeaveValidator()
+  {
+    RuleFor(x => x.LeaveId)
+      .NotEmpty().WithMessage("Leave ID is required and cannot be an empty GUID.");
+
+    RuleFor(x => x.Id)
+      .NotEmpty().WithMessage("Leave ID is required.");
+
+    RuleFor(x => x.StartDate)
+      .NotEmpty().WithMessage("Start date is required.");
+
+    RuleFor(x => x.EndDate)
+      .NotEmpty().WithMessage("End date is required.");
+
+    RuleFor(x => x)
+      .Must(x => x.EndDate >= x.StartDate)
+      .WithMessage("End date must be greater than or equal to start date.");
+
+    RuleFor(x => x.EmployeeId)
+      .NotEmpty().WithMessage("Employee ID is required and cannot be an empty GUID.");
+
+    RuleFor(x => x.LeaveCreditId)
+      .NotEmpty().WithMessage("Leave credit ID is required and cannot be an empty GUID.");
+  }
+}

--- a/src/Bluewater.Web/Leaves/Update.cs
+++ b/src/Bluewater.Web/Leaves/Update.cs
@@ -1,0 +1,48 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Leaves.Update;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Leaves;
+
+/// <summary>
+/// Update an existing leave request.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Update(IMediator _mediator) : Endpoint<UpdateLeaveRequest, UpdateLeaveResponse>
+{
+  public override void Configure()
+  {
+    Put(UpdateLeaveRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(UpdateLeaveRequest req, CancellationToken ct)
+  {
+    var result = await _mediator.Send(
+      new UpdateLeaveCommand(req.Id, req.StartDate, req.EndDate, req.IsHalfDay, req.Status, req.EmployeeId, req.LeaveCreditId),
+      ct);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(ct);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      var dto = result.Value;
+      Response = new UpdateLeaveResponse(
+        new LeaveRecord(
+          dto.Id,
+          dto.StartDate,
+          dto.EndDate,
+          dto.IsHalfDay,
+          dto.Status,
+          dto.EmployeeId,
+          dto.LeaveCreditId,
+          dto.EmployeeName,
+          dto.LeaveCreditName));
+    }
+  }
+}

--- a/src/Bluewater.Web/Levels/Create.CreateLevelRequest.cs
+++ b/src/Bluewater.Web/Levels/Create.CreateLevelRequest.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.Levels;
+
+public class CreateLevelRequest
+{
+  public const string Route = "/Levels";
+
+  [Required]
+  public string? Name { get; set; }
+
+  [Required]
+  public string? Value { get; set; }
+
+  public bool IsActive { get; set; } = true;
+}

--- a/src/Bluewater.Web/Levels/Create.CreateLevelResponse.cs
+++ b/src/Bluewater.Web/Levels/Create.CreateLevelResponse.cs
@@ -1,0 +1,9 @@
+namespace Bluewater.Web.Levels;
+
+public class CreateLevelResponse(Guid Id, string Name, string Value, bool IsActive)
+{
+  public Guid Id { get; set; } = Id;
+  public string Name { get; set; } = Name;
+  public string Value { get; set; } = Value;
+  public bool IsActive { get; set; } = IsActive;
+}

--- a/src/Bluewater.Web/Levels/Create.CreateLevelValidator.cs
+++ b/src/Bluewater.Web/Levels/Create.CreateLevelValidator.cs
@@ -1,0 +1,21 @@
+using Bluewater.Infrastructure.Data.Config;
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Levels;
+
+public class CreateLevelValidator : Validator<CreateLevelRequest>
+{
+  public CreateLevelValidator()
+  {
+    RuleFor(x => x.Name)
+      .NotEmpty()
+      .WithMessage("Name is required.")
+      .MaximumLength(DataSchemaConstants.DEFAULT_NAME_LENGTH);
+
+    RuleFor(x => x.Value)
+      .NotEmpty()
+      .WithMessage("Value is required.")
+      .MaximumLength(DataSchemaConstants.DEFAULT_NAME_LENGTH);
+  }
+}

--- a/src/Bluewater.Web/Levels/Create.cs
+++ b/src/Bluewater.Web/Levels/Create.cs
@@ -1,0 +1,28 @@
+using Bluewater.UseCases.Levels.Create;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Levels;
+
+/// <summary>
+/// Create a new employee level.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Create(IMediator _mediator) : Endpoint<CreateLevelRequest, CreateLevelResponse>
+{
+  public override void Configure()
+  {
+    Post(CreateLevelRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(CreateLevelRequest req, CancellationToken ct)
+  {
+    var result = await _mediator.Send(new CreateLevelCommand(req.Name!, req.Value!, req.IsActive), ct);
+
+    if (result.IsSuccess)
+    {
+      Response = new CreateLevelResponse(result.Value, req.Name!, req.Value!, req.IsActive);
+    }
+  }
+}

--- a/src/Bluewater.Web/Levels/Delete.DeleteLevelRequest.cs
+++ b/src/Bluewater.Web/Levels/Delete.DeleteLevelRequest.cs
@@ -1,0 +1,9 @@
+namespace Bluewater.Web.Levels;
+
+public class DeleteLevelRequest
+{
+  public const string Route = "/Levels/{LevelId:guid}";
+  public static string BuildRoute(Guid levelId) => Route.Replace("{LevelId:guid}", levelId.ToString());
+
+  public Guid LevelId { get; set; }
+}

--- a/src/Bluewater.Web/Levels/Delete.DeleteLevelValidator.cs
+++ b/src/Bluewater.Web/Levels/Delete.DeleteLevelValidator.cs
@@ -1,0 +1,13 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Levels;
+
+public class DeleteLevelValidator : Validator<DeleteLevelRequest>
+{
+  public DeleteLevelValidator()
+  {
+    RuleFor(x => x.LevelId)
+      .NotEmpty().WithMessage("Level ID is required and cannot be an empty GUID.");
+  }
+}

--- a/src/Bluewater.Web/Levels/Delete.cs
+++ b/src/Bluewater.Web/Levels/Delete.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Levels.Delete;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Levels;
+
+/// <summary>
+/// Delete an employee level.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Delete(IMediator _mediator) : Endpoint<DeleteLevelRequest>
+{
+  public override void Configure()
+  {
+    Delete(DeleteLevelRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(DeleteLevelRequest req, CancellationToken ct)
+  {
+    var result = await _mediator.Send(new DeleteLevelCommand(req.LevelId), ct);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(ct);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      await SendNoContentAsync(ct);
+    }
+  }
+}

--- a/src/Bluewater.Web/Levels/GetById.GetLevelByIdRequest.cs
+++ b/src/Bluewater.Web/Levels/GetById.GetLevelByIdRequest.cs
@@ -1,0 +1,9 @@
+namespace Bluewater.Web.Levels;
+
+public class GetLevelByIdRequest
+{
+  public const string Route = "/Levels/{LevelId:guid}";
+  public static string BuildRoute(Guid levelId) => Route.Replace("{LevelId:guid}", levelId.ToString());
+
+  public Guid LevelId { get; set; }
+}

--- a/src/Bluewater.Web/Levels/GetById.GetLevelValidator.cs
+++ b/src/Bluewater.Web/Levels/GetById.GetLevelValidator.cs
@@ -1,0 +1,13 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Levels;
+
+public class GetLevelValidator : Validator<GetLevelByIdRequest>
+{
+  public GetLevelValidator()
+  {
+    RuleFor(x => x.LevelId)
+      .NotEmpty().WithMessage("Level ID is required and cannot be an empty GUID.");
+  }
+}

--- a/src/Bluewater.Web/Levels/GetById.cs
+++ b/src/Bluewater.Web/Levels/GetById.cs
@@ -1,0 +1,36 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Levels.Get;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Levels;
+
+/// <summary>
+/// Get an employee level by ID.
+/// </summary>
+/// <param name="_mediator"></param>
+public class GetById(IMediator _mediator) : Endpoint<GetLevelByIdRequest, LevelRecord>
+{
+  public override void Configure()
+  {
+    Get(GetLevelByIdRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(GetLevelByIdRequest req, CancellationToken ct)
+  {
+    var result = await _mediator.Send(new GetLevelQuery(req.LevelId), ct);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(ct);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      var dto = result.Value;
+      Response = new LevelRecord(dto.Id, dto.Name, dto.Value, dto.IsActive);
+    }
+  }
+}

--- a/src/Bluewater.Web/Levels/LevelRecord.cs
+++ b/src/Bluewater.Web/Levels/LevelRecord.cs
@@ -1,0 +1,3 @@
+namespace Bluewater.Web.Levels;
+
+public record LevelRecord(Guid Id, string Name, string Value, bool IsActive);

--- a/src/Bluewater.Web/Levels/List.LevelListResponse.cs
+++ b/src/Bluewater.Web/Levels/List.LevelListResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Levels;
+
+public class LevelListResponse
+{
+  public List<LevelRecord> Levels { get; set; } = [];
+}

--- a/src/Bluewater.Web/Levels/List.cs
+++ b/src/Bluewater.Web/Levels/List.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Levels;
+using Bluewater.UseCases.Levels.List;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Levels;
+
+/// <summary>
+/// List employee levels.
+/// </summary>
+/// <param name="_mediator"></param>
+public class List(IMediator _mediator) : EndpointWithoutRequest<LevelListResponse>
+{
+  public override void Configure()
+  {
+    Get("/Levels");
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(CancellationToken ct)
+  {
+    Result<IEnumerable<LevelDTO>> result = await _mediator.Send(new ListLevelQuery(null, null), ct);
+
+    if (result.IsSuccess)
+    {
+      Response = new LevelListResponse
+      {
+        Levels = result.Value
+          .Select(l => new LevelRecord(l.Id, l.Name, l.Value, l.IsActive))
+          .ToList()
+      };
+    }
+  }
+}

--- a/src/Bluewater.Web/Levels/Update.UpdateLevelRequest.cs
+++ b/src/Bluewater.Web/Levels/Update.UpdateLevelRequest.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.Levels;
+
+public class UpdateLevelRequest
+{
+  public const string Route = "/Levels/{LevelId:guid}";
+  public static string BuildRoute(Guid levelId) => Route.Replace("{LevelId:guid}", levelId.ToString());
+
+  public Guid LevelId { get; set; }
+
+  [Required]
+  public Guid Id { get; set; }
+
+  [Required]
+  public string? Name { get; set; }
+
+  [Required]
+  public string? Value { get; set; }
+
+  public bool IsActive { get; set; }
+}

--- a/src/Bluewater.Web/Levels/Update.UpdateLevelResponse.cs
+++ b/src/Bluewater.Web/Levels/Update.UpdateLevelResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Levels;
+
+public class UpdateLevelResponse(LevelRecord Level)
+{
+  public LevelRecord Level { get; set; } = Level;
+}

--- a/src/Bluewater.Web/Levels/Update.UpdateLevelValidator.cs
+++ b/src/Bluewater.Web/Levels/Update.UpdateLevelValidator.cs
@@ -1,0 +1,27 @@
+using Bluewater.Infrastructure.Data.Config;
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Levels;
+
+public class UpdateLevelValidator : Validator<UpdateLevelRequest>
+{
+  public UpdateLevelValidator()
+  {
+    RuleFor(x => x.LevelId)
+      .NotEmpty().WithMessage("Level ID is required and cannot be an empty GUID.");
+
+    RuleFor(x => x.Id)
+      .NotEmpty().WithMessage("Level ID is required.");
+
+    RuleFor(x => x.Name)
+      .NotEmpty()
+      .WithMessage("Name is required.")
+      .MaximumLength(DataSchemaConstants.DEFAULT_NAME_LENGTH);
+
+    RuleFor(x => x.Value)
+      .NotEmpty()
+      .WithMessage("Value is required.")
+      .MaximumLength(DataSchemaConstants.DEFAULT_NAME_LENGTH);
+  }
+}

--- a/src/Bluewater.Web/Levels/Update.cs
+++ b/src/Bluewater.Web/Levels/Update.cs
@@ -1,0 +1,45 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Levels.Get;
+using Bluewater.UseCases.Levels.Update;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Levels;
+
+/// <summary>
+/// Update an existing employee level.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Update(IMediator _mediator) : Endpoint<UpdateLevelRequest, UpdateLevelResponse>
+{
+  public override void Configure()
+  {
+    Put(UpdateLevelRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(UpdateLevelRequest req, CancellationToken ct)
+  {
+    var result = await _mediator.Send(new UpdateLevelCommand(req.Id, req.Name!, req.Value!, req.IsActive), ct);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(ct);
+      return;
+    }
+
+    var queryResult = await _mediator.Send(new GetLevelQuery(req.Id), ct);
+
+    if (queryResult.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(ct);
+      return;
+    }
+
+    if (queryResult.IsSuccess)
+    {
+      var dto = queryResult.Value;
+      Response = new UpdateLevelResponse(new LevelRecord(dto.Id, dto.Name, dto.Value, dto.IsActive));
+    }
+  }
+}

--- a/src/Bluewater.Web/Program.cs
+++ b/src/Bluewater.Web/Program.cs
@@ -7,7 +7,11 @@ using Bluewater.Core.DepartmentAggregate;
 using Bluewater.Core.DivisionAggregate;
 using Bluewater.Core.EmployeeAggregate;
 using Bluewater.Core.EmployeeTypeAggregate;
+using Bluewater.Core.Forms.LeaveAggregate;
+using Bluewater.Core.HolidayAggregate;
 using Bluewater.Core.Interfaces;
+using Bluewater.Core.LeaveCreditAggregate;
+using Bluewater.Core.LevelAggregate;
 using Bluewater.Infrastructure;
 using Bluewater.Infrastructure.Data;
 using Bluewater.Infrastructure.Email;
@@ -17,6 +21,10 @@ using Bluewater.UseCases.Departments.Create;
 using Bluewater.UseCases.Divisions.Create;
 using Bluewater.UseCases.Employees.Create;
 using Bluewater.UseCases.EmployeeTypes.Create;
+using Bluewater.UseCases.Holidays.Create;
+using Bluewater.UseCases.LeaveCredits.Create;
+using Bluewater.UseCases.Leaves.Create;
+using Bluewater.UseCases.Levels.Create;
 using FastEndpoints;
 using FastEndpoints.Swagger;
 using MediatR;
@@ -135,7 +143,19 @@ void ConfigureMediatR()
   Assembly.GetAssembly(typeof(CreateEmployeeTypeCommand)), // UseCases
 
   Assembly.GetAssembly(typeof(Charging)), // Core
-  Assembly.GetAssembly(typeof(CreateChargingCommand)) // UseCases
+  Assembly.GetAssembly(typeof(CreateChargingCommand)), // UseCases
+
+  Assembly.GetAssembly(typeof(Holiday)), // Core
+  Assembly.GetAssembly(typeof(CreateHolidayCommand)), // UseCases
+
+  Assembly.GetAssembly(typeof(LeaveCredit)), // Core
+  Assembly.GetAssembly(typeof(CreateLeaveCreditCommand)), // UseCases
+
+  Assembly.GetAssembly(typeof(Leave)), // Core
+  Assembly.GetAssembly(typeof(CreateLeaveCommand)), // UseCases
+
+  Assembly.GetAssembly(typeof(Level)), // Core
+  Assembly.GetAssembly(typeof(CreateLevelCommand)) // UseCases
 };
   builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(mediatRAssemblies!));
   builder.Services.AddScoped(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>));


### PR DESCRIPTION
## Summary
- add FastEndpoints CRUD endpoints for holidays, leave credits, leaves, and levels mapped to the existing use case commands
- introduce request/response DTOs and validators to shape the API contracts for the new endpoints
- register the new core and use case assemblies with MediatR so the endpoints can resolve their handlers

## Testing
- `dotnet build` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c40488b48329b5a6422ef0c515f2