### PR TITLE
Add web endpoints for HR data modules

### DIFF
--- a/src/Bluewater.Web/Attendances/AllAttendanceRecord.cs
+++ b/src/Bluewater.Web/Attendances/AllAttendanceRecord.cs
@@ -1,0 +1,17 @@
+namespace Bluewater.Web.Attendances;
+
+public record AllAttendanceRecord(
+  Guid EmployeeId,
+  string Barcode,
+  string Name,
+  string? Department,
+  string? Section,
+  string? Charging,
+  List<AttendanceRecord> Attendances,
+  decimal TotalWorkHrs,
+  int TotalAbsences,
+  decimal TotalLateHrs,
+  decimal TotalUnderHrs,
+  decimal TotalOverbreakHrs,
+  decimal TotalNightShiftHrs,
+  decimal TotalLeaves);

--- a/src/Bluewater.Web/Attendances/AttendanceMapper.cs
+++ b/src/Bluewater.Web/Attendances/AttendanceMapper.cs
@@ -1,0 +1,75 @@
+using Bluewater.UseCases.Attendances;
+using Bluewater.UseCases.Shifts;
+using Bluewater.UseCases.Timesheets;
+
+namespace Bluewater.Web.Attendances;
+
+public static class AttendanceMapper
+{
+  public static AttendanceRecord ToRecord(AttendanceDTO dto)
+  {
+    return new AttendanceRecord(
+      dto.Id,
+      dto.EmployeeId,
+      dto.ShiftId,
+      dto.TimesheetId,
+      dto.LeaveId,
+      dto.EntryDate,
+      dto.WorkHrs,
+      dto.LateHrs,
+      dto.UnderHrs,
+      dto.OverbreakHrs,
+      dto.NightShiftHours,
+      dto.IsLocked,
+      ToRecord(dto.Shift),
+      ToRecord(dto.Timesheet));
+  }
+
+  public static AllAttendanceRecord ToRecord(AllAttendancesDTO dto)
+  {
+    return new AllAttendanceRecord(
+      dto.EmployeeId,
+      dto.Barcode,
+      dto.Name,
+      dto.Department,
+      dto.Section,
+      dto.Charging,
+      dto.Attendances.Select(ToRecord).ToList(),
+      dto.TotalWorkHrs,
+      dto.TotalAbsences,
+      dto.TotalLateHrs,
+      dto.TotalUnderHrs,
+      dto.TotalOverbreakHrs,
+      dto.TotalNightShiftHrs,
+      dto.TotalLeaves);
+  }
+
+  private static ShiftRecord? ToRecord(ShiftDTO? shift)
+  {
+    if (shift is null) return null;
+
+    return new ShiftRecord(
+      shift.Id,
+      shift.Name,
+      shift.ShiftStartTime,
+      shift.ShiftBreakTime,
+      shift.ShiftBreakEndTime,
+      shift.ShiftEndTime,
+      shift.BreakHours);
+  }
+
+  private static TimesheetRecord? ToRecord(TimesheetDTO? timesheet)
+  {
+    if (timesheet is null) return null;
+
+    return new TimesheetRecord(
+      timesheet.Id,
+      timesheet.EmployeeId,
+      timesheet.TimeIn1,
+      timesheet.TimeOut1,
+      timesheet.TimeIn2,
+      timesheet.TimeOut2,
+      timesheet.EntryDate,
+      timesheet.IsEdited);
+  }
+}

--- a/src/Bluewater.Web/Attendances/AttendanceRecord.cs
+++ b/src/Bluewater.Web/Attendances/AttendanceRecord.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace Bluewater.Web.Attendances;
+
+public record AttendanceRecord(
+  Guid Id,
+  Guid EmployeeId,
+  Guid? ShiftId,
+  Guid? TimesheetId,
+  Guid? LeaveId,
+  DateOnly? EntryDate,
+  decimal? WorkHrs,
+  decimal? LateHrs,
+  decimal? UnderHrs,
+  decimal? OverbreakHrs,
+  decimal? NightShiftHours,
+  bool IsLocked,
+  ShiftRecord? Shift,
+  TimesheetRecord? Timesheet);
+
+public record ShiftRecord(
+  Guid Id,
+  string Name,
+  TimeOnly? ShiftStartTime,
+  TimeOnly? ShiftBreakTime,
+  TimeOnly? ShiftBreakEndTime,
+  TimeOnly? ShiftEndTime,
+  decimal BreakHours);
+
+public record TimesheetRecord(
+  Guid Id,
+  Guid EmployeeId,
+  DateTime? TimeIn1,
+  DateTime? TimeOut1,
+  DateTime? TimeIn2,
+  DateTime? TimeOut2,
+  DateOnly? EntryDate,
+  bool IsEdited);

--- a/src/Bluewater.Web/Attendances/Create.CreateAttendanceRequest.cs
+++ b/src/Bluewater.Web/Attendances/Create.CreateAttendanceRequest.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.Attendances;
+
+public class CreateAttendanceRequest
+{
+  public const string Route = "/Attendances";
+
+  [Required]
+  public Guid EmployeeId { get; set; }
+  public Guid? ShiftId { get; set; }
+  public Guid? TimesheetId { get; set; }
+  public Guid? LeaveId { get; set; }
+  public DateOnly? EntryDate { get; set; }
+  public decimal? WorkHrs { get; set; }
+  public decimal? LateHrs { get; set; }
+  public decimal? UnderHrs { get; set; }
+  public decimal? OverbreakHrs { get; set; }
+  public decimal? NightShiftHrs { get; set; }
+  public bool IsLocked { get; set; }
+}

--- a/src/Bluewater.Web/Attendances/Create.CreateAttendanceResponse.cs
+++ b/src/Bluewater.Web/Attendances/Create.CreateAttendanceResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Attendances;
+
+public class CreateAttendanceResponse(AttendanceRecord Attendance)
+{
+  public AttendanceRecord Attendance { get; set; } = Attendance;
+}

--- a/src/Bluewater.Web/Attendances/Create.CreateAttendanceValidator.cs
+++ b/src/Bluewater.Web/Attendances/Create.CreateAttendanceValidator.cs
@@ -1,0 +1,33 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Attendances;
+
+public class CreateAttendanceValidator : Validator<CreateAttendanceRequest>
+{
+  public CreateAttendanceValidator()
+  {
+    RuleFor(x => x.EmployeeId)
+      .NotEmpty().WithMessage("Employee ID is required.");
+
+    RuleFor(x => x.WorkHrs)
+      .GreaterThanOrEqualTo(0).When(x => x.WorkHrs.HasValue)
+      .WithMessage("Work hours cannot be negative.");
+
+    RuleFor(x => x.LateHrs)
+      .GreaterThanOrEqualTo(0).When(x => x.LateHrs.HasValue)
+      .WithMessage("Late hours cannot be negative.");
+
+    RuleFor(x => x.UnderHrs)
+      .GreaterThanOrEqualTo(0).When(x => x.UnderHrs.HasValue)
+      .WithMessage("Undertime hours cannot be negative.");
+
+    RuleFor(x => x.OverbreakHrs)
+      .GreaterThanOrEqualTo(0).When(x => x.OverbreakHrs.HasValue)
+      .WithMessage("Overbreak hours cannot be negative.");
+
+    RuleFor(x => x.NightShiftHrs)
+      .GreaterThanOrEqualTo(0).When(x => x.NightShiftHrs.HasValue)
+      .WithMessage("Night shift hours cannot be negative.");
+  }
+}

--- a/src/Bluewater.Web/Attendances/Create.cs
+++ b/src/Bluewater.Web/Attendances/Create.cs
@@ -1,0 +1,70 @@
+using Bluewater.UseCases.Attendances.Create;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Attendances;
+
+/// <summary>
+/// Creates a new attendance entry.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Create(IMediator _mediator) : Endpoint<CreateAttendanceRequest, CreateAttendanceResponse>
+{
+  public override void Configure()
+  {
+    Post(CreateAttendanceRequest.Route);
+    AllowAnonymous();
+    Summary(s =>
+    {
+      s.Summary = "Creates a new attendance record.";
+      s.Description = "Creates a new attendance record using the provided information.";
+      s.ExampleRequest = new CreateAttendanceRequest
+      {
+        EmployeeId = Guid.NewGuid(),
+        ShiftId = Guid.NewGuid(),
+        TimesheetId = Guid.NewGuid(),
+        EntryDate = DateOnly.FromDateTime(DateTime.Today),
+        WorkHrs = 8,
+        IsLocked = false
+      };
+    });
+  }
+
+  public override async Task HandleAsync(CreateAttendanceRequest request, CancellationToken cancellationToken)
+  {
+    var command = new CreateAttendanceCommand(
+      request.EmployeeId,
+      request.ShiftId,
+      request.TimesheetId,
+      request.LeaveId,
+      request.EntryDate,
+      request.WorkHrs,
+      request.LateHrs,
+      request.UnderHrs,
+      request.OverbreakHrs,
+      request.NightShiftHrs,
+      request.IsLocked);
+
+    var result = await _mediator.Send(command, cancellationToken);
+
+    if (result.IsSuccess)
+    {
+      Response = new CreateAttendanceResponse(
+        new AttendanceRecord(
+          result.Value,
+          request.EmployeeId,
+          request.ShiftId,
+          request.TimesheetId,
+          request.LeaveId,
+          request.EntryDate,
+          request.WorkHrs,
+          request.LateHrs,
+          request.UnderHrs,
+          request.OverbreakHrs,
+          request.NightShiftHrs,
+          request.IsLocked,
+          null,
+          null));
+    }
+  }
+}

--- a/src/Bluewater.Web/Attendances/Delete.DeleteAttendanceRequest.cs
+++ b/src/Bluewater.Web/Attendances/Delete.DeleteAttendanceRequest.cs
@@ -1,0 +1,9 @@
+namespace Bluewater.Web.Attendances;
+
+public class DeleteAttendanceRequest
+{
+  public const string Route = "/Attendances/{AttendanceId:guid}";
+  public static string BuildRoute(Guid attendanceId) => Route.Replace("{AttendanceId:guid}", attendanceId.ToString());
+
+  public Guid AttendanceId { get; set; }
+}

--- a/src/Bluewater.Web/Attendances/Delete.DeleteAttendanceValidator.cs
+++ b/src/Bluewater.Web/Attendances/Delete.DeleteAttendanceValidator.cs
@@ -1,0 +1,13 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Attendances;
+
+public class DeleteAttendanceValidator : Validator<DeleteAttendanceRequest>
+{
+  public DeleteAttendanceValidator()
+  {
+    RuleFor(x => x.AttendanceId)
+      .NotEmpty().WithMessage("Attendance ID is required.");
+  }
+}

--- a/src/Bluewater.Web/Attendances/Delete.cs
+++ b/src/Bluewater.Web/Attendances/Delete.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Attendances.Delete;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Attendances;
+
+/// <summary>
+/// Deletes an attendance entry.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Delete(IMediator _mediator) : Endpoint<DeleteAttendanceRequest>
+{
+  public override void Configure()
+  {
+    Delete(DeleteAttendanceRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(DeleteAttendanceRequest request, CancellationToken cancellationToken)
+  {
+    var result = await _mediator.Send(new DeleteAttendanceCommand(request.AttendanceId), cancellationToken);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      await SendNoContentAsync(cancellationToken);
+    }
+  }
+}

--- a/src/Bluewater.Web/Attendances/Get.GetAttendanceByIdRequest.cs
+++ b/src/Bluewater.Web/Attendances/Get.GetAttendanceByIdRequest.cs
@@ -1,0 +1,9 @@
+namespace Bluewater.Web.Attendances;
+
+public class GetAttendanceByIdRequest
+{
+  public const string Route = "/Attendances/{AttendanceId:guid}";
+  public static string BuildRoute(Guid attendanceId) => Route.Replace("{AttendanceId:guid}", attendanceId.ToString());
+
+  public Guid AttendanceId { get; set; }
+}

--- a/src/Bluewater.Web/Attendances/Get.GetAttendanceValidator.cs
+++ b/src/Bluewater.Web/Attendances/Get.GetAttendanceValidator.cs
@@ -1,0 +1,13 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Attendances;
+
+public class GetAttendanceValidator : Validator<GetAttendanceByIdRequest>
+{
+  public GetAttendanceValidator()
+  {
+    RuleFor(x => x.AttendanceId)
+      .NotEmpty().WithMessage("Attendance ID is required.");
+  }
+}

--- a/src/Bluewater.Web/Attendances/Get.cs
+++ b/src/Bluewater.Web/Attendances/Get.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Attendances.Get;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Attendances;
+
+/// <summary>
+/// Retrieves a specific attendance entry by identifier.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Get(IMediator _mediator) : Endpoint<GetAttendanceByIdRequest, AttendanceRecord>
+{
+  public override void Configure()
+  {
+    Get(GetAttendanceByIdRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(GetAttendanceByIdRequest request, CancellationToken cancellationToken)
+  {
+    var result = await _mediator.Send(new GetAttendanceQuery(request.AttendanceId), cancellationToken);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      Response = AttendanceMapper.ToRecord(result.Value);
+    }
+  }
+}

--- a/src/Bluewater.Web/Attendances/List.AttendanceListRequest.cs
+++ b/src/Bluewater.Web/Attendances/List.AttendanceListRequest.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.Attendances;
+
+public class AttendanceListRequest
+{
+  [Range(0, int.MaxValue)]
+  public int? Skip { get; set; }
+
+  [Range(1, int.MaxValue)]
+  public int? Take { get; set; }
+
+  [Required]
+  public Guid EmployeeId { get; set; }
+
+  [Required]
+  public DateOnly StartDate { get; set; }
+
+  [Required]
+  public DateOnly EndDate { get; set; }
+}

--- a/src/Bluewater.Web/Attendances/List.AttendanceListResponse.cs
+++ b/src/Bluewater.Web/Attendances/List.AttendanceListResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Attendances;
+
+public class AttendanceListResponse
+{
+  public List<AttendanceRecord> Attendances { get; set; } = new();
+}

--- a/src/Bluewater.Web/Attendances/List.cs
+++ b/src/Bluewater.Web/Attendances/List.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Attendances;
+using Bluewater.UseCases.Attendances.List;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Attendances;
+
+/// <summary>
+/// Lists attendance entries for a specific employee.
+/// </summary>
+/// <param name="_mediator"></param>
+public class List(IMediator _mediator) : Endpoint<AttendanceListRequest, AttendanceListResponse>
+{
+  public override void Configure()
+  {
+    Get("/Attendances");
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(AttendanceListRequest request, CancellationToken cancellationToken)
+  {
+    Result<IEnumerable<AttendanceDTO>> result = await _mediator.Send(
+      new ListAttendanceQuery(request.Skip, request.Take, request.EmployeeId, request.StartDate, request.EndDate),
+      cancellationToken);
+
+    if (result.IsSuccess)
+    {
+      Response = new AttendanceListResponse
+      {
+        Attendances = result.Value.Select(AttendanceMapper.ToRecord).ToList()
+      };
+    }
+  }
+}

--- a/src/Bluewater.Web/Attendances/ListAll.AttendanceListAllRequest.cs
+++ b/src/Bluewater.Web/Attendances/ListAll.AttendanceListAllRequest.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+using Bluewater.Core.EmployeeAggregate.Enum;
+
+namespace Bluewater.Web.Attendances;
+
+public class AttendanceListAllRequest
+{
+  [Range(0, int.MaxValue)]
+  public int? Skip { get; set; }
+
+  [Range(1, int.MaxValue)]
+  public int? Take { get; set; }
+
+  [Required]
+  public string Charging { get; set; } = string.Empty;
+
+  [Required]
+  public DateOnly StartDate { get; set; }
+
+  [Required]
+  public DateOnly EndDate { get; set; }
+
+  public Tenant Tenant { get; set; } = Tenant.Maribago;
+}

--- a/src/Bluewater.Web/Attendances/ListAll.AttendanceListAllResponse.cs
+++ b/src/Bluewater.Web/Attendances/ListAll.AttendanceListAllResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Attendances;
+
+public class AttendanceListAllResponse
+{
+  public List<AllAttendanceRecord> Employees { get; set; } = new();
+}

--- a/src/Bluewater.Web/Attendances/ListAll.cs
+++ b/src/Bluewater.Web/Attendances/ListAll.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Attendances;
+using Bluewater.UseCases.Attendances.List;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Attendances;
+
+/// <summary>
+/// Lists attendance summaries for all employees within a charging and date range.
+/// </summary>
+/// <param name="_mediator"></param>
+public class ListAll(IMediator _mediator) : Endpoint<AttendanceListAllRequest, AttendanceListAllResponse>
+{
+  public override void Configure()
+  {
+    Get("/Attendances/All");
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(AttendanceListAllRequest request, CancellationToken cancellationToken)
+  {
+    Result<IEnumerable<AllAttendancesDTO>> result = await _mediator.Send(
+      new ListAllAttendancesQuery(request.Skip, request.Take, request.Charging, request.StartDate, request.EndDate, request.Tenant),
+      cancellationToken);
+
+    if (result.IsSuccess)
+    {
+      Response = new AttendanceListAllResponse
+      {
+        Employees = result.Value.Select(AttendanceMapper.ToRecord).ToList()
+      };
+    }
+  }
+}

--- a/src/Bluewater.Web/Attendances/Update.UpdateAttendanceRequest.cs
+++ b/src/Bluewater.Web/Attendances/Update.UpdateAttendanceRequest.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.Attendances;
+
+public class UpdateAttendanceRequest
+{
+  public const string Route = "/Attendances";
+
+  [Required]
+  public Guid EmployeeId { get; set; }
+
+  [Required]
+  public DateOnly? EntryDate { get; set; }
+
+  public Guid? ShiftId { get; set; }
+  public Guid? TimesheetId { get; set; }
+  public Guid? LeaveId { get; set; }
+  public bool IsLocked { get; set; }
+}

--- a/src/Bluewater.Web/Attendances/Update.UpdateAttendanceResponse.cs
+++ b/src/Bluewater.Web/Attendances/Update.UpdateAttendanceResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Attendances;
+
+public class UpdateAttendanceResponse(AttendanceRecord Attendance)
+{
+  public AttendanceRecord Attendance { get; set; } = Attendance;
+}

--- a/src/Bluewater.Web/Attendances/Update.UpdateAttendanceValidator.cs
+++ b/src/Bluewater.Web/Attendances/Update.UpdateAttendanceValidator.cs
@@ -1,0 +1,16 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Attendances;
+
+public class UpdateAttendanceValidator : Validator<UpdateAttendanceRequest>
+{
+  public UpdateAttendanceValidator()
+  {
+    RuleFor(x => x.EmployeeId)
+      .NotEmpty().WithMessage("Employee ID is required.");
+
+    RuleFor(x => x.EntryDate)
+      .NotNull().WithMessage("Entry date is required.");
+  }
+}

--- a/src/Bluewater.Web/Attendances/Update.cs
+++ b/src/Bluewater.Web/Attendances/Update.cs
@@ -1,0 +1,43 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Attendances.Update;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Attendances;
+
+/// <summary>
+/// Updates an existing attendance entry identified by employee and date.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Update(IMediator _mediator) : Endpoint<UpdateAttendanceRequest, UpdateAttendanceResponse>
+{
+  public override void Configure()
+  {
+    Put(UpdateAttendanceRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(UpdateAttendanceRequest request, CancellationToken cancellationToken)
+  {
+    var result = await _mediator.Send(
+      new UpdateAttendanceCommand(
+        request.EmployeeId,
+        request.ShiftId,
+        request.TimesheetId,
+        request.LeaveId,
+        request.EntryDate,
+        request.IsLocked),
+      cancellationToken);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      Response = new UpdateAttendanceResponse(AttendanceMapper.ToRecord(result.Value));
+    }
+  }
+}

--- a/src/Bluewater.Web/Payrolls/Create.CreatePayrollRequest.cs
+++ b/src/Bluewater.Web/Payrolls/Create.CreatePayrollRequest.cs
@@ -1,0 +1,125 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.Payrolls;
+
+public class CreatePayrollRequest
+{
+  public const string Route = "/Payrolls";
+
+  [Required]
+  public Guid EmployeeId { get; set; }
+
+  [Required]
+  public DateOnly Date { get; set; }
+
+  [Range(0, double.MaxValue)]
+  public decimal GrossPayAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal NetAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal BasicPayAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal SssAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal SssERAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal PagibigAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal PagibigERAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal PhilhealthAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal PhilhealthERAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal RestDayAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal RestDayHrs { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal RegularHolidayAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal RegularHolidayHrs { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal SpecialHolidayAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal SpecialHolidayHrs { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal OvertimeAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal OvertimeHrs { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal NightDiffAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal NightDiffHrs { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal NightDiffOvertimeAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal NightDiffOvertimeHrs { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal NightDiffRegularHolidayAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal NightDiffRegularHolidayHrs { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal NightDiffSpecialHolidayAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal NightDiffSpecialHolidayHrs { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal OvertimeRestDayAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal OvertimeRestDayHrs { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal OvertimeRegularHolidayAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal OvertimeRegularHolidayHrs { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal OvertimeSpecialHolidayAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal OvertimeSpecialHolidayHrs { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal UnionDues { get; set; }
+  [Range(0, int.MaxValue)]
+  public int Absences { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal AbsencesAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal Leaves { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal LeavesAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal Lates { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal LatesAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal Undertime { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal UndertimeAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal Overbreak { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal OverbreakAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal SvcCharge { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal CostOfLivingAllowanceAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal MonthlyAllowanceAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal SalaryUnderpaymentAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal RefundAbsencesAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal RefundUndertimeAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal RefundOvertimeAmount { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal LaborHoursIncome { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal LaborHrs { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal TaxDeductions { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal TotalConstantDeductions { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal TotalLoanDeductions { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal TotalDeductions { get; set; }
+}

--- a/src/Bluewater.Web/Payrolls/Create.CreatePayrollResponse.cs
+++ b/src/Bluewater.Web/Payrolls/Create.CreatePayrollResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Payrolls;
+
+public class CreatePayrollResponse(Guid PayrollId)
+{
+  public Guid PayrollId { get; set; } = PayrollId;
+}

--- a/src/Bluewater.Web/Payrolls/Create.CreatePayrollValidator.cs
+++ b/src/Bluewater.Web/Payrolls/Create.CreatePayrollValidator.cs
@@ -1,0 +1,16 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Payrolls;
+
+public class CreatePayrollValidator : Validator<CreatePayrollRequest>
+{
+  public CreatePayrollValidator()
+  {
+    RuleFor(x => x.EmployeeId)
+      .NotEmpty().WithMessage("Employee ID is required.");
+
+    RuleFor(x => x.Date)
+      .NotEmpty().WithMessage("Date is required.");
+  }
+}

--- a/src/Bluewater.Web/Payrolls/Create.cs
+++ b/src/Bluewater.Web/Payrolls/Create.cs
@@ -1,0 +1,85 @@
+using Bluewater.UseCases.Payrolls.Create;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Payrolls;
+
+/// <summary>
+/// Creates a payroll entry.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Create(IMediator _mediator) : Endpoint<CreatePayrollRequest, CreatePayrollResponse>
+{
+  public override void Configure()
+  {
+    Post(CreatePayrollRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(CreatePayrollRequest request, CancellationToken cancellationToken)
+  {
+    var result = await _mediator.Send(new CreatePayrollCommand(
+      request.EmployeeId,
+      request.Date,
+      request.GrossPayAmount,
+      request.NetAmount,
+      request.BasicPayAmount,
+      request.SssAmount,
+      request.SssERAmount,
+      request.PagibigAmount,
+      request.PagibigERAmount,
+      request.PhilhealthAmount,
+      request.PhilhealthERAmount,
+      request.RestDayAmount,
+      request.RestDayHrs,
+      request.RegularHolidayAmount,
+      request.RegularHolidayHrs,
+      request.SpecialHolidayAmount,
+      request.SpecialHolidayHrs,
+      request.OvertimeAmount,
+      request.OvertimeHrs,
+      request.NightDiffAmount,
+      request.NightDiffHrs,
+      request.NightDiffOvertimeAmount,
+      request.NightDiffOvertimeHrs,
+      request.NightDiffRegularHolidayAmount,
+      request.NightDiffRegularHolidayHrs,
+      request.NightDiffSpecialHolidayAmount,
+      request.NightDiffSpecialHolidayHrs,
+      request.OvertimeRestDayAmount,
+      request.OvertimeRestDayHrs,
+      request.OvertimeRegularHolidayAmount,
+      request.OvertimeRegularHolidayHrs,
+      request.OvertimeSpecialHolidayAmount,
+      request.OvertimeSpecialHolidayHrs,
+      request.UnionDues,
+      request.Absences,
+      request.AbsencesAmount,
+      request.Leaves,
+      request.LeavesAmount,
+      request.Lates,
+      request.LatesAmount,
+      request.Undertime,
+      request.UndertimeAmount,
+      request.Overbreak,
+      request.OverbreakAmount,
+      request.SvcCharge,
+      request.CostOfLivingAllowanceAmount,
+      request.MonthlyAllowanceAmount,
+      request.SalaryUnderpaymentAmount,
+      request.RefundAbsencesAmount,
+      request.RefundUndertimeAmount,
+      request.RefundOvertimeAmount,
+      request.LaborHoursIncome,
+      request.LaborHrs,
+      request.TaxDeductions,
+      request.TotalConstantDeductions,
+      request.TotalLoanDeductions,
+      request.TotalDeductions), cancellationToken);
+
+    if (result.IsSuccess)
+    {
+      Response = new CreatePayrollResponse(result.Value);
+    }
+  }
+}

--- a/src/Bluewater.Web/Payrolls/List.PayrollListRequest.cs
+++ b/src/Bluewater.Web/Payrolls/List.PayrollListRequest.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+using Bluewater.Core.EmployeeAggregate.Enum;
+
+namespace Bluewater.Web.Payrolls;
+
+public class PayrollListRequest
+{
+  [Range(0, int.MaxValue)]
+  public int? Skip { get; set; }
+
+  [Range(1, int.MaxValue)]
+  public int? Take { get; set; }
+
+  public string? ChargingName { get; set; }
+
+  [Required]
+  public DateOnly StartDate { get; set; }
+
+  [Required]
+  public DateOnly EndDate { get; set; }
+
+  public Tenant Tenant { get; set; } = Tenant.Maribago;
+}

--- a/src/Bluewater.Web/Payrolls/List.PayrollListResponse.cs
+++ b/src/Bluewater.Web/Payrolls/List.PayrollListResponse.cs
@@ -1,0 +1,8 @@
+using Bluewater.UseCases.Payrolls;
+
+namespace Bluewater.Web.Payrolls;
+
+public class PayrollListResponse
+{
+  public List<PayrollDTO> Payrolls { get; set; } = new();
+}

--- a/src/Bluewater.Web/Payrolls/List.cs
+++ b/src/Bluewater.Web/Payrolls/List.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Payrolls;
+using Bluewater.UseCases.Payrolls.List;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Payrolls;
+
+/// <summary>
+/// Lists payroll details for the specified filters.
+/// </summary>
+/// <param name="_mediator"></param>
+public class List(IMediator _mediator) : Endpoint<PayrollListRequest, PayrollListResponse>
+{
+  public override void Configure()
+  {
+    Get("/Payrolls");
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(PayrollListRequest request, CancellationToken cancellationToken)
+  {
+    Result<IEnumerable<PayrollDTO>> result = await _mediator.Send(
+      new ListPayrollQuery(request.Skip, request.Take, request.ChargingName, request.StartDate, request.EndDate, request.Tenant),
+      cancellationToken);
+
+    if (result.IsSuccess)
+    {
+      Response = new PayrollListResponse
+      {
+        Payrolls = result.Value.ToList()
+      };
+    }
+  }
+}

--- a/src/Bluewater.Web/Payrolls/ListGrouped.PayrollGroupedListRequest.cs
+++ b/src/Bluewater.Web/Payrolls/ListGrouped.PayrollGroupedListRequest.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.Payrolls;
+
+public class PayrollGroupedListRequest
+{
+  [Range(0, int.MaxValue)]
+  public int? Skip { get; set; }
+
+  [Range(1, int.MaxValue)]
+  public int? Take { get; set; }
+}

--- a/src/Bluewater.Web/Payrolls/ListGrouped.PayrollGroupedListResponse.cs
+++ b/src/Bluewater.Web/Payrolls/ListGrouped.PayrollGroupedListResponse.cs
@@ -1,0 +1,8 @@
+using Bluewater.UseCases.Payrolls;
+
+namespace Bluewater.Web.Payrolls;
+
+public class PayrollGroupedListResponse
+{
+  public List<PayrollSummaryDTO> Payrolls { get; set; } = new();
+}

--- a/src/Bluewater.Web/Payrolls/ListGrouped.cs
+++ b/src/Bluewater.Web/Payrolls/ListGrouped.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Payrolls;
+using Bluewater.UseCases.Payrolls.List;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Payrolls;
+
+/// <summary>
+/// Lists grouped payroll summaries.
+/// </summary>
+/// <param name="_mediator"></param>
+public class ListGrouped(IMediator _mediator) : Endpoint<PayrollGroupedListRequest, PayrollGroupedListResponse>
+{
+  public override void Configure()
+  {
+    Get("/Payrolls/Grouped");
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(PayrollGroupedListRequest request, CancellationToken cancellationToken)
+  {
+    Result<IEnumerable<PayrollSummaryDTO>> result = await _mediator.Send(
+      new ListGroupedPayrollQuery(request.Skip, request.Take),
+      cancellationToken);
+
+    if (result.IsSuccess)
+    {
+      Response = new PayrollGroupedListResponse
+      {
+        Payrolls = result.Value.ToList()
+      };
+    }
+  }
+}

--- a/src/Bluewater.Web/Pays/Create.CreatePayRequest.cs
+++ b/src/Bluewater.Web/Pays/Create.CreatePayRequest.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.Pays;
+
+public class CreatePayRequest
+{
+  public const string Route = "/Pays";
+
+  [Range(0, double.MaxValue)]
+  public decimal BasicPay { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal DailyRate { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal HourlyRate { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal HdmfCon { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal HdmfEr { get; set; }
+}

--- a/src/Bluewater.Web/Pays/Create.CreatePayResponse.cs
+++ b/src/Bluewater.Web/Pays/Create.CreatePayResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Pays;
+
+public class CreatePayResponse(PayRecord Pay)
+{
+  public PayRecord Pay { get; set; } = Pay;
+}

--- a/src/Bluewater.Web/Pays/Create.CreatePayValidator.cs
+++ b/src/Bluewater.Web/Pays/Create.CreatePayValidator.cs
@@ -1,0 +1,16 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Pays;
+
+public class CreatePayValidator : Validator<CreatePayRequest>
+{
+  public CreatePayValidator()
+  {
+    RuleFor(x => x.BasicPay).GreaterThanOrEqualTo(0);
+    RuleFor(x => x.DailyRate).GreaterThanOrEqualTo(0);
+    RuleFor(x => x.HourlyRate).GreaterThanOrEqualTo(0);
+    RuleFor(x => x.HdmfCon).GreaterThanOrEqualTo(0);
+    RuleFor(x => x.HdmfEr).GreaterThanOrEqualTo(0);
+  }
+}

--- a/src/Bluewater.Web/Pays/Create.cs
+++ b/src/Bluewater.Web/Pays/Create.cs
@@ -1,0 +1,28 @@
+using Bluewater.UseCases.Pays.Create;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Pays;
+
+/// <summary>
+/// Creates a pay template.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Create(IMediator _mediator) : Endpoint<CreatePayRequest, CreatePayResponse>
+{
+  public override void Configure()
+  {
+    Post(CreatePayRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(CreatePayRequest request, CancellationToken cancellationToken)
+  {
+    var result = await _mediator.Send(new CreatePayCommand(request.BasicPay, request.DailyRate, request.HourlyRate, request.HdmfCon, request.HdmfEr), cancellationToken);
+
+    if (result.IsSuccess)
+    {
+      Response = new CreatePayResponse(new PayRecord(result.Value, request.BasicPay, request.DailyRate, request.HourlyRate, request.HdmfCon, request.HdmfEr, 0));
+    }
+  }
+}

--- a/src/Bluewater.Web/Pays/Delete.DeletePayRequest.cs
+++ b/src/Bluewater.Web/Pays/Delete.DeletePayRequest.cs
@@ -1,0 +1,9 @@
+namespace Bluewater.Web.Pays;
+
+public class DeletePayRequest
+{
+  public const string Route = "/Pays/{PayId:guid}";
+  public static string BuildRoute(Guid payId) => Route.Replace("{PayId:guid}", payId.ToString());
+
+  public Guid PayId { get; set; }
+}

--- a/src/Bluewater.Web/Pays/Delete.DeletePayValidator.cs
+++ b/src/Bluewater.Web/Pays/Delete.DeletePayValidator.cs
@@ -1,0 +1,12 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Pays;
+
+public class DeletePayValidator : Validator<DeletePayRequest>
+{
+  public DeletePayValidator()
+  {
+    RuleFor(x => x.PayId).NotEmpty().WithMessage("Pay ID is required.");
+  }
+}

--- a/src/Bluewater.Web/Pays/Delete.cs
+++ b/src/Bluewater.Web/Pays/Delete.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Pays.Delete;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Pays;
+
+/// <summary>
+/// Deletes a pay template.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Delete(IMediator _mediator) : Endpoint<DeletePayRequest>
+{
+  public override void Configure()
+  {
+    Delete(DeletePayRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(DeletePayRequest request, CancellationToken cancellationToken)
+  {
+    var result = await _mediator.Send(new DeletePayCommand(request.PayId), cancellationToken);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      await SendNoContentAsync(cancellationToken);
+    }
+  }
+}

--- a/src/Bluewater.Web/Pays/Get.GetPayRequest.cs
+++ b/src/Bluewater.Web/Pays/Get.GetPayRequest.cs
@@ -1,0 +1,9 @@
+namespace Bluewater.Web.Pays;
+
+public class GetPayRequest
+{
+  public const string Route = "/Pays/{PayId:guid}";
+  public static string BuildRoute(Guid payId) => Route.Replace("{PayId:guid}", payId.ToString());
+
+  public Guid PayId { get; set; }
+}

--- a/src/Bluewater.Web/Pays/Get.GetPayValidator.cs
+++ b/src/Bluewater.Web/Pays/Get.GetPayValidator.cs
@@ -1,0 +1,12 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Pays;
+
+public class GetPayValidator : Validator<GetPayRequest>
+{
+  public GetPayValidator()
+  {
+    RuleFor(x => x.PayId).NotEmpty().WithMessage("Pay ID is required.");
+  }
+}

--- a/src/Bluewater.Web/Pays/Get.cs
+++ b/src/Bluewater.Web/Pays/Get.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Pays.Get;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Pays;
+
+/// <summary>
+/// Retrieves a pay template by identifier.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Get(IMediator _mediator) : Endpoint<GetPayRequest, PayRecord>
+{
+  public override void Configure()
+  {
+    Get(GetPayRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(GetPayRequest request, CancellationToken cancellationToken)
+  {
+    var result = await _mediator.Send(new GetPayQuery(request.PayId), cancellationToken);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      Response = PayMapper.ToRecord(result.Value);
+    }
+  }
+}

--- a/src/Bluewater.Web/Pays/List.PayListRequest.cs
+++ b/src/Bluewater.Web/Pays/List.PayListRequest.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.Pays;
+
+public class PayListRequest
+{
+  [Range(0, int.MaxValue)]
+  public int? Skip { get; set; }
+
+  [Range(1, int.MaxValue)]
+  public int? Take { get; set; }
+}

--- a/src/Bluewater.Web/Pays/List.PayListResponse.cs
+++ b/src/Bluewater.Web/Pays/List.PayListResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Pays;
+
+public class PayListResponse
+{
+  public List<PayRecord> Pays { get; set; } = new();
+}

--- a/src/Bluewater.Web/Pays/List.cs
+++ b/src/Bluewater.Web/Pays/List.cs
@@ -1,0 +1,33 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Pays;
+using Bluewater.UseCases.Pays.List;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Pays;
+
+/// <summary>
+/// Lists pay templates.
+/// </summary>
+/// <param name="_mediator"></param>
+public class List(IMediator _mediator) : Endpoint<PayListRequest, PayListResponse>
+{
+  public override void Configure()
+  {
+    Get("/Pays");
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(PayListRequest request, CancellationToken cancellationToken)
+  {
+    Result<IEnumerable<PayDTO>> result = await _mediator.Send(new ListPayQuery(request.Skip, request.Take), cancellationToken);
+
+    if (result.IsSuccess)
+    {
+      Response = new PayListResponse
+      {
+        Pays = result.Value.Select(PayMapper.ToRecord).ToList()
+      };
+    }
+  }
+}

--- a/src/Bluewater.Web/Pays/PayMapper.cs
+++ b/src/Bluewater.Web/Pays/PayMapper.cs
@@ -1,0 +1,18 @@
+using Bluewater.UseCases.Pays;
+
+namespace Bluewater.Web.Pays;
+
+public static class PayMapper
+{
+  public static PayRecord ToRecord(PayDTO dto)
+  {
+    return new PayRecord(
+      dto.Id,
+      dto.BasicPay,
+      dto.DailyRate,
+      dto.HourlyRate,
+      dto.HDMF_Con,
+      dto.HDMF_Er,
+      dto.Cola);
+  }
+}

--- a/src/Bluewater.Web/Pays/PayRecord.cs
+++ b/src/Bluewater.Web/Pays/PayRecord.cs
@@ -1,0 +1,10 @@
+namespace Bluewater.Web.Pays;
+
+public record PayRecord(
+  Guid Id,
+  decimal? BasicPay,
+  decimal? DailyRate,
+  decimal? HourlyRate,
+  decimal? HdmfEmployeeContribution,
+  decimal? HdmfEmployerContribution,
+  decimal? Cola);

--- a/src/Bluewater.Web/Pays/Update.UpdatePayRequest.cs
+++ b/src/Bluewater.Web/Pays/Update.UpdatePayRequest.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.Pays;
+
+public class UpdatePayRequest
+{
+  public const string Route = "/Pays/{PayId:guid}";
+  public static string BuildRoute(Guid payId) => Route.Replace("{PayId:guid}", payId.ToString());
+
+  [Required]
+  public Guid PayId { get; set; }
+
+  [Range(0, double.MaxValue)]
+  public decimal BasicPay { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal DailyRate { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal HourlyRate { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal HdmfCon { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal HdmfEr { get; set; }
+  [Range(0, double.MaxValue)]
+  public decimal Cola { get; set; }
+}

--- a/src/Bluewater.Web/Pays/Update.UpdatePayResponse.cs
+++ b/src/Bluewater.Web/Pays/Update.UpdatePayResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Pays;
+
+public class UpdatePayResponse(PayRecord Pay)
+{
+  public PayRecord Pay { get; set; } = Pay;
+}

--- a/src/Bluewater.Web/Pays/Update.UpdatePayValidator.cs
+++ b/src/Bluewater.Web/Pays/Update.UpdatePayValidator.cs
@@ -1,0 +1,18 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Pays;
+
+public class UpdatePayValidator : Validator<UpdatePayRequest>
+{
+  public UpdatePayValidator()
+  {
+    RuleFor(x => x.PayId).NotEmpty().WithMessage("Pay ID is required.");
+    RuleFor(x => x.BasicPay).GreaterThanOrEqualTo(0);
+    RuleFor(x => x.DailyRate).GreaterThanOrEqualTo(0);
+    RuleFor(x => x.HourlyRate).GreaterThanOrEqualTo(0);
+    RuleFor(x => x.HdmfCon).GreaterThanOrEqualTo(0);
+    RuleFor(x => x.HdmfEr).GreaterThanOrEqualTo(0);
+    RuleFor(x => x.Cola).GreaterThanOrEqualTo(0);
+  }
+}

--- a/src/Bluewater.Web/Pays/Update.cs
+++ b/src/Bluewater.Web/Pays/Update.cs
@@ -1,0 +1,37 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Pays.Update;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Pays;
+
+/// <summary>
+/// Updates a pay template.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Update(IMediator _mediator) : Endpoint<UpdatePayRequest, UpdatePayResponse>
+{
+  public override void Configure()
+  {
+    Put(UpdatePayRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(UpdatePayRequest request, CancellationToken cancellationToken)
+  {
+    var result = await _mediator.Send(
+      new UpdatePayCommand(request.PayId, request.BasicPay, request.DailyRate, request.HourlyRate, request.HdmfCon, request.HdmfEr, request.Cola),
+      cancellationToken);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      Response = new UpdatePayResponse(PayMapper.ToRecord(result.Value));
+    }
+  }
+}

--- a/src/Bluewater.Web/Schedules/Create.CreateScheduleRequest.cs
+++ b/src/Bluewater.Web/Schedules/Create.CreateScheduleRequest.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.Schedules;
+
+public class CreateScheduleRequest
+{
+  public const string Route = "/Schedules";
+
+  [Required]
+  public Guid EmployeeId { get; set; }
+
+  [Required]
+  public Guid ShiftId { get; set; }
+
+  [Required]
+  public DateOnly ScheduleDate { get; set; }
+
+  public bool IsDefault { get; set; }
+}

--- a/src/Bluewater.Web/Schedules/Create.CreateScheduleResponse.cs
+++ b/src/Bluewater.Web/Schedules/Create.CreateScheduleResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Schedules;
+
+public class CreateScheduleResponse(Guid ScheduleId)
+{
+  public Guid ScheduleId { get; set; } = ScheduleId;
+}

--- a/src/Bluewater.Web/Schedules/Create.CreateScheduleValidator.cs
+++ b/src/Bluewater.Web/Schedules/Create.CreateScheduleValidator.cs
@@ -1,0 +1,14 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Schedules;
+
+public class CreateScheduleValidator : Validator<CreateScheduleRequest>
+{
+  public CreateScheduleValidator()
+  {
+    RuleFor(x => x.EmployeeId).NotEmpty().WithMessage("Employee ID is required.");
+    RuleFor(x => x.ShiftId).NotEmpty().WithMessage("Shift ID is required.");
+    RuleFor(x => x.ScheduleDate).NotEmpty().WithMessage("Schedule date is required.");
+  }
+}

--- a/src/Bluewater.Web/Schedules/Create.cs
+++ b/src/Bluewater.Web/Schedules/Create.cs
@@ -1,0 +1,28 @@
+using Bluewater.UseCases.Schedules.Create;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Schedules;
+
+/// <summary>
+/// Creates a schedule entry.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Create(IMediator _mediator) : Endpoint<CreateScheduleRequest, CreateScheduleResponse>
+{
+  public override void Configure()
+  {
+    Post(CreateScheduleRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(CreateScheduleRequest request, CancellationToken cancellationToken)
+  {
+    var result = await _mediator.Send(new CreateScheduleCommand(request.EmployeeId, request.ShiftId, request.ScheduleDate, request.IsDefault), cancellationToken);
+
+    if (result.IsSuccess)
+    {
+      Response = new CreateScheduleResponse(result.Value);
+    }
+  }
+}

--- a/src/Bluewater.Web/Schedules/Delete.DeleteScheduleRequest.cs
+++ b/src/Bluewater.Web/Schedules/Delete.DeleteScheduleRequest.cs
@@ -1,0 +1,9 @@
+namespace Bluewater.Web.Schedules;
+
+public class DeleteScheduleRequest
+{
+  public const string Route = "/Schedules/{ScheduleId:guid}";
+  public static string BuildRoute(Guid scheduleId) => Route.Replace("{ScheduleId:guid}", scheduleId.ToString());
+
+  public Guid ScheduleId { get; set; }
+}

--- a/src/Bluewater.Web/Schedules/Delete.DeleteScheduleValidator.cs
+++ b/src/Bluewater.Web/Schedules/Delete.DeleteScheduleValidator.cs
@@ -1,0 +1,12 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Schedules;
+
+public class DeleteScheduleValidator : Validator<DeleteScheduleRequest>
+{
+  public DeleteScheduleValidator()
+  {
+    RuleFor(x => x.ScheduleId).NotEmpty().WithMessage("Schedule ID is required.");
+  }
+}

--- a/src/Bluewater.Web/Schedules/Delete.cs
+++ b/src/Bluewater.Web/Schedules/Delete.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Schedules.Delete;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Schedules;
+
+/// <summary>
+/// Deletes a schedule entry.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Delete(IMediator _mediator) : Endpoint<DeleteScheduleRequest>
+{
+  public override void Configure()
+  {
+    Delete(DeleteScheduleRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(DeleteScheduleRequest request, CancellationToken cancellationToken)
+  {
+    var result = await _mediator.Send(new DeleteScheduleCommand(request.ScheduleId), cancellationToken);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      await SendNoContentAsync(cancellationToken);
+    }
+  }
+}

--- a/src/Bluewater.Web/Schedules/Get.GetScheduleRequest.cs
+++ b/src/Bluewater.Web/Schedules/Get.GetScheduleRequest.cs
@@ -1,0 +1,9 @@
+namespace Bluewater.Web.Schedules;
+
+public class GetScheduleRequest
+{
+  public const string Route = "/Schedules/{ScheduleId:guid}";
+  public static string BuildRoute(Guid scheduleId) => Route.Replace("{ScheduleId:guid}", scheduleId.ToString());
+
+  public Guid ScheduleId { get; set; }
+}

--- a/src/Bluewater.Web/Schedules/Get.GetScheduleValidator.cs
+++ b/src/Bluewater.Web/Schedules/Get.GetScheduleValidator.cs
@@ -1,0 +1,12 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Schedules;
+
+public class GetScheduleValidator : Validator<GetScheduleRequest>
+{
+  public GetScheduleValidator()
+  {
+    RuleFor(x => x.ScheduleId).NotEmpty().WithMessage("Schedule ID is required.");
+  }
+}

--- a/src/Bluewater.Web/Schedules/Get.cs
+++ b/src/Bluewater.Web/Schedules/Get.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Schedules.Get;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Schedules;
+
+/// <summary>
+/// Retrieves a schedule entry by identifier.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Get(IMediator _mediator) : Endpoint<GetScheduleRequest, ScheduleRecord>
+{
+  public override void Configure()
+  {
+    Get(GetScheduleRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(GetScheduleRequest request, CancellationToken cancellationToken)
+  {
+    var result = await _mediator.Send(new GetScheduleQuery(request.ScheduleId), cancellationToken);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      Response = ScheduleMapper.ToRecord(result.Value);
+    }
+  }
+}

--- a/src/Bluewater.Web/Schedules/List.ScheduleListRequest.cs
+++ b/src/Bluewater.Web/Schedules/List.ScheduleListRequest.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+using Bluewater.Core.EmployeeAggregate.Enum;
+
+namespace Bluewater.Web.Schedules;
+
+public class ScheduleListRequest
+{
+  [Range(0, int.MaxValue)]
+  public int? Skip { get; set; }
+
+  [Range(1, int.MaxValue)]
+  public int? Take { get; set; }
+
+  [Required]
+  public string ChargingName { get; set; } = string.Empty;
+
+  [Required]
+  public DateOnly StartDate { get; set; }
+
+  [Required]
+  public DateOnly EndDate { get; set; }
+
+  public Tenant Tenant { get; set; } = Tenant.Maribago;
+}

--- a/src/Bluewater.Web/Schedules/List.ScheduleListResponse.cs
+++ b/src/Bluewater.Web/Schedules/List.ScheduleListResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Schedules;
+
+public class ScheduleListResponse
+{
+  public List<EmployeeScheduleRecord> Employees { get; set; } = new();
+}

--- a/src/Bluewater.Web/Schedules/List.cs
+++ b/src/Bluewater.Web/Schedules/List.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Schedules;
+using Bluewater.UseCases.Schedules.List;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Schedules;
+
+/// <summary>
+/// Lists schedules grouped by employee for a given charging and date range.
+/// </summary>
+/// <param name="_mediator"></param>
+public class List(IMediator _mediator) : Endpoint<ScheduleListRequest, ScheduleListResponse>
+{
+  public override void Configure()
+  {
+    Get("/Schedules");
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(ScheduleListRequest request, CancellationToken cancellationToken)
+  {
+    Result<IEnumerable<EmployeeScheduleDTO>> result = await _mediator.Send(
+      new ListScheduleQuery(request.Skip, request.Take, request.ChargingName, request.StartDate, request.EndDate, request.Tenant),
+      cancellationToken);
+
+    if (result.IsSuccess)
+    {
+      Response = new ScheduleListResponse
+      {
+        Employees = result.Value.Select(ScheduleMapper.ToRecord).ToList()
+      };
+    }
+  }
+}

--- a/src/Bluewater.Web/Schedules/ScheduleMapper.cs
+++ b/src/Bluewater.Web/Schedules/ScheduleMapper.cs
@@ -1,0 +1,49 @@
+using Bluewater.UseCases.Schedules;
+using Bluewater.UseCases.Shifts;
+
+namespace Bluewater.Web.Schedules;
+
+public static class ScheduleMapper
+{
+  public static ScheduleRecord ToRecord(ScheduleDTO dto)
+  {
+    return new ScheduleRecord(
+      dto.Id,
+      dto.EmployeeId,
+      dto.Name,
+      dto.ShiftId,
+      dto.ScheduleDate,
+      dto.IsDefault,
+      ToRecord(dto.Shift));
+  }
+
+  public static EmployeeScheduleRecord ToRecord(EmployeeScheduleDTO dto)
+  {
+    return new EmployeeScheduleRecord(
+      dto.EmployeeId,
+      dto.Barcode,
+      dto.Name,
+      dto.Section,
+      dto.Charging,
+      dto.Shifts.Select(shift => new ShiftInfoRecord(
+        shift.ScheduleId,
+        ToRecord(shift.Shift),
+        shift.ScheduleDate,
+        shift.IsDefault,
+        shift.IsUpdated)).ToList());
+  }
+
+  private static ShiftDetailsRecord? ToRecord(ShiftDTO? shift)
+  {
+    if (shift is null) return null;
+
+    return new ShiftDetailsRecord(
+      shift.Id,
+      shift.Name,
+      shift.ShiftStartTime,
+      shift.ShiftBreakTime,
+      shift.ShiftBreakEndTime,
+      shift.ShiftEndTime,
+      shift.BreakHours);
+  }
+}

--- a/src/Bluewater.Web/Schedules/ScheduleRecord.cs
+++ b/src/Bluewater.Web/Schedules/ScheduleRecord.cs
@@ -1,0 +1,34 @@
+namespace Bluewater.Web.Schedules;
+
+public record ScheduleRecord(
+  Guid Id,
+  Guid EmployeeId,
+  string Name,
+  Guid ShiftId,
+  DateOnly ScheduleDate,
+  bool IsDefault,
+  ShiftDetailsRecord? Shift);
+
+public record ShiftDetailsRecord(
+  Guid Id,
+  string Name,
+  TimeOnly? ShiftStartTime,
+  TimeOnly? ShiftBreakTime,
+  TimeOnly? ShiftBreakEndTime,
+  TimeOnly? ShiftEndTime,
+  decimal BreakHours);
+
+public record EmployeeScheduleRecord(
+  Guid EmployeeId,
+  string Barcode,
+  string Name,
+  string Section,
+  string Charging,
+  List<ShiftInfoRecord> Shifts);
+
+public record ShiftInfoRecord(
+  Guid ScheduleId,
+  ShiftDetailsRecord? Shift,
+  DateOnly ScheduleDate,
+  bool IsDefault,
+  bool IsUpdated);

--- a/src/Bluewater.Web/Schedules/Update.UpdateScheduleRequest.cs
+++ b/src/Bluewater.Web/Schedules/Update.UpdateScheduleRequest.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.Schedules;
+
+public class UpdateScheduleRequest
+{
+  public const string Route = "/Schedules/{ScheduleId:guid}";
+  public static string BuildRoute(Guid scheduleId) => Route.Replace("{ScheduleId:guid}", scheduleId.ToString());
+
+  [Required]
+  public Guid ScheduleId { get; set; }
+
+  [Required]
+  public Guid EmployeeId { get; set; }
+
+  [Required]
+  public Guid ShiftId { get; set; }
+
+  [Required]
+  public DateOnly ScheduleDate { get; set; }
+
+  public bool IsDefault { get; set; }
+}

--- a/src/Bluewater.Web/Schedules/Update.UpdateScheduleResponse.cs
+++ b/src/Bluewater.Web/Schedules/Update.UpdateScheduleResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Schedules;
+
+public class UpdateScheduleResponse(ScheduleRecord Schedule)
+{
+  public ScheduleRecord Schedule { get; set; } = Schedule;
+}

--- a/src/Bluewater.Web/Schedules/Update.UpdateScheduleValidator.cs
+++ b/src/Bluewater.Web/Schedules/Update.UpdateScheduleValidator.cs
@@ -1,0 +1,15 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.Schedules;
+
+public class UpdateScheduleValidator : Validator<UpdateScheduleRequest>
+{
+  public UpdateScheduleValidator()
+  {
+    RuleFor(x => x.ScheduleId).NotEmpty().WithMessage("Schedule ID is required.");
+    RuleFor(x => x.EmployeeId).NotEmpty().WithMessage("Employee ID is required.");
+    RuleFor(x => x.ShiftId).NotEmpty().WithMessage("Shift ID is required.");
+    RuleFor(x => x.ScheduleDate).NotEmpty().WithMessage("Schedule date is required.");
+  }
+}

--- a/src/Bluewater.Web/Schedules/Update.cs
+++ b/src/Bluewater.Web/Schedules/Update.cs
@@ -1,0 +1,37 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Schedules.Update;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Schedules;
+
+/// <summary>
+/// Updates a schedule entry.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Update(IMediator _mediator) : Endpoint<UpdateScheduleRequest, UpdateScheduleResponse>
+{
+  public override void Configure()
+  {
+    Put(UpdateScheduleRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(UpdateScheduleRequest request, CancellationToken cancellationToken)
+  {
+    var result = await _mediator.Send(
+      new UpdateScheduleCommand(request.ScheduleId, request.EmployeeId, request.ShiftId, request.ScheduleDate, request.IsDefault),
+      cancellationToken);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      Response = new UpdateScheduleResponse(ScheduleMapper.ToRecord(result.Value));
+    }
+  }
+}

--- a/src/Bluewater.Web/ServiceCharges/Create.CreateServiceChargeRequest.cs
+++ b/src/Bluewater.Web/ServiceCharges/Create.CreateServiceChargeRequest.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.ServiceCharges;
+
+public class CreateServiceChargeRequest
+{
+  public const string Route = "/ServiceCharges";
+
+  [Required]
+  public string Username { get; set; } = string.Empty;
+
+  [Range(0, double.MaxValue)]
+  public decimal Amount { get; set; }
+
+  [Required]
+  public DateOnly Date { get; set; }
+}

--- a/src/Bluewater.Web/ServiceCharges/Create.CreateServiceChargeResponse.cs
+++ b/src/Bluewater.Web/ServiceCharges/Create.CreateServiceChargeResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.ServiceCharges;
+
+public class CreateServiceChargeResponse(ServiceChargeRecord ServiceCharge)
+{
+  public ServiceChargeRecord ServiceCharge { get; set; } = ServiceCharge;
+}

--- a/src/Bluewater.Web/ServiceCharges/Create.CreateServiceChargeValidator.cs
+++ b/src/Bluewater.Web/ServiceCharges/Create.CreateServiceChargeValidator.cs
@@ -1,0 +1,19 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.ServiceCharges;
+
+public class CreateServiceChargeValidator : Validator<CreateServiceChargeRequest>
+{
+  public CreateServiceChargeValidator()
+  {
+    RuleFor(x => x.Username)
+      .NotEmpty().WithMessage("Username is required.");
+
+    RuleFor(x => x.Amount)
+      .GreaterThanOrEqualTo(0).WithMessage("Amount must be greater than or equal to zero.");
+
+    RuleFor(x => x.Date)
+      .NotEmpty().WithMessage("Date is required.");
+  }
+}

--- a/src/Bluewater.Web/ServiceCharges/Create.cs
+++ b/src/Bluewater.Web/ServiceCharges/Create.cs
@@ -1,0 +1,28 @@
+using Bluewater.UseCases.ServiceCharges.Create;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.ServiceCharges;
+
+/// <summary>
+/// Creates a service charge entry.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Create(IMediator _mediator) : Endpoint<CreateServiceChargeRequest, CreateServiceChargeResponse>
+{
+  public override void Configure()
+  {
+    Post(CreateServiceChargeRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(CreateServiceChargeRequest request, CancellationToken cancellationToken)
+  {
+    var result = await _mediator.Send(new CreateServiceChargeCommand(request.Username, request.Amount, request.Date), cancellationToken);
+
+    if (result.IsSuccess)
+    {
+      Response = new CreateServiceChargeResponse(new ServiceChargeRecord(result.Value, request.Username, request.Amount, request.Date));
+    }
+  }
+}

--- a/src/Bluewater.Web/ServiceCharges/Delete.DeleteServiceChargeRequest.cs
+++ b/src/Bluewater.Web/ServiceCharges/Delete.DeleteServiceChargeRequest.cs
@@ -1,0 +1,9 @@
+namespace Bluewater.Web.ServiceCharges;
+
+public class DeleteServiceChargeRequest
+{
+  public const string Route = "/ServiceCharges/{ServiceChargeId:guid}";
+  public static string BuildRoute(Guid serviceChargeId) => Route.Replace("{ServiceChargeId:guid}", serviceChargeId.ToString());
+
+  public Guid ServiceChargeId { get; set; }
+}

--- a/src/Bluewater.Web/ServiceCharges/Delete.DeleteServiceChargeValidator.cs
+++ b/src/Bluewater.Web/ServiceCharges/Delete.DeleteServiceChargeValidator.cs
@@ -1,0 +1,12 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.ServiceCharges;
+
+public class DeleteServiceChargeValidator : Validator<DeleteServiceChargeRequest>
+{
+  public DeleteServiceChargeValidator()
+  {
+    RuleFor(x => x.ServiceChargeId).NotEmpty().WithMessage("Service charge ID is required.");
+  }
+}

--- a/src/Bluewater.Web/ServiceCharges/Delete.cs
+++ b/src/Bluewater.Web/ServiceCharges/Delete.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.ServiceCharges.Delete;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.ServiceCharges;
+
+/// <summary>
+/// Deletes a service charge entry.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Delete(IMediator _mediator) : Endpoint<DeleteServiceChargeRequest>
+{
+  public override void Configure()
+  {
+    Delete(DeleteServiceChargeRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(DeleteServiceChargeRequest request, CancellationToken cancellationToken)
+  {
+    var result = await _mediator.Send(new DeleteServiceChargeCommand(request.ServiceChargeId), cancellationToken);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      await SendNoContentAsync(cancellationToken);
+    }
+  }
+}

--- a/src/Bluewater.Web/ServiceCharges/Get.GetServiceChargeRequest.cs
+++ b/src/Bluewater.Web/ServiceCharges/Get.GetServiceChargeRequest.cs
@@ -1,0 +1,9 @@
+namespace Bluewater.Web.ServiceCharges;
+
+public class GetServiceChargeRequest
+{
+  public const string Route = "/ServiceCharges/{ServiceChargeId:guid}";
+  public static string BuildRoute(Guid serviceChargeId) => Route.Replace("{ServiceChargeId:guid}", serviceChargeId.ToString());
+
+  public Guid ServiceChargeId { get; set; }
+}

--- a/src/Bluewater.Web/ServiceCharges/Get.GetServiceChargeValidator.cs
+++ b/src/Bluewater.Web/ServiceCharges/Get.GetServiceChargeValidator.cs
@@ -1,0 +1,12 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Bluewater.Web.ServiceCharges;
+
+public class GetServiceChargeValidator : Validator<GetServiceChargeRequest>
+{
+  public GetServiceChargeValidator()
+  {
+    RuleFor(x => x.ServiceChargeId).NotEmpty().WithMessage("Service charge ID is required.");
+  }
+}

--- a/src/Bluewater.Web/ServiceCharges/Get.cs
+++ b/src/Bluewater.Web/ServiceCharges/Get.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.ServiceCharges.Get;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.ServiceCharges;
+
+/// <summary>
+/// Retrieves a service charge entry by identifier.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Get(IMediator _mediator) : Endpoint<GetServiceChargeRequest, ServiceChargeRecord>
+{
+  public override void Configure()
+  {
+    Get(GetServiceChargeRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(GetServiceChargeRequest request, CancellationToken cancellationToken)
+  {
+    var result = await _mediator.Send(new GetServiceChargeQuery(request.ServiceChargeId), cancellationToken);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      Response = ServiceChargeMapper.ToRecord(result.Value);
+    }
+  }
+}

--- a/src/Bluewater.Web/ServiceCharges/List.ServiceChargeListRequest.cs
+++ b/src/Bluewater.Web/ServiceCharges/List.ServiceChargeListRequest.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.ServiceCharges;
+
+public class ServiceChargeListRequest
+{
+  [Range(0, int.MaxValue)]
+  public int? Skip { get; set; }
+
+  [Range(1, int.MaxValue)]
+  public int? Take { get; set; }
+
+  [Required]
+  public DateOnly Date { get; set; }
+}

--- a/src/Bluewater.Web/ServiceCharges/List.ServiceChargeListResponse.cs
+++ b/src/Bluewater.Web/ServiceCharges/List.ServiceChargeListResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.ServiceCharges;
+
+public class ServiceChargeListResponse
+{
+  public List<ServiceChargeRecord> ServiceCharges { get; set; } = new();
+}

--- a/src/Bluewater.Web/ServiceCharges/List.cs
+++ b/src/Bluewater.Web/ServiceCharges/List.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.ServiceCharges;
+using Bluewater.UseCases.ServiceCharges.List;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.ServiceCharges;
+
+/// <summary>
+/// Lists service charge entries for a specific date.
+/// </summary>
+/// <param name="_mediator"></param>
+public class List(IMediator _mediator) : Endpoint<ServiceChargeListRequest, ServiceChargeListResponse>
+{
+  public override void Configure()
+  {
+    Get("/ServiceCharges");
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(ServiceChargeListRequest request, CancellationToken cancellationToken)
+  {
+    Result<IEnumerable<ServiceChargeDTO>> result = await _mediator.Send(
+      new ListServiceChargeQuery(request.Skip, request.Take, request.Date),
+      cancellationToken);
+
+    if (result.IsSuccess)
+    {
+      Response = new ServiceChargeListResponse
+      {
+        ServiceCharges = result.Value.Select(ServiceChargeMapper.ToRecord).ToList()
+      };
+    }
+  }
+}

--- a/src/Bluewater.Web/ServiceCharges/ServiceChargeMapper.cs
+++ b/src/Bluewater.Web/ServiceCharges/ServiceChargeMapper.cs
@@ -1,0 +1,11 @@
+using Bluewater.UseCases.ServiceCharges;
+
+namespace Bluewater.Web.ServiceCharges;
+
+public static class ServiceChargeMapper
+{
+  public static ServiceChargeRecord ToRecord(ServiceChargeDTO dto)
+  {
+    return new ServiceChargeRecord(dto.Id, dto.Username, dto.Amount, dto.Date);
+  }
+}

--- a/src/Bluewater.Web/ServiceCharges/ServiceChargeRecord.cs
+++ b/src/Bluewater.Web/ServiceCharges/ServiceChargeRecord.cs
@@ -1,0 +1,7 @@
+namespace Bluewater.Web.ServiceCharges;
+
+public record ServiceChargeRecord(
+  Guid Id,
+  string Username,
+  decimal Amount,
+  DateOnly Date);


### PR DESCRIPTION
## Summary
- implement FastEndpoints CRUD handlers for attendances, pays, schedules, and service charges using the existing use case commands and queries
- add create and listing endpoints for payrolls including grouped summaries and request/response models
- introduce mapping helpers and record types to shape API responses for the new endpoints

## Testing
- dotnet build *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d63539f4a483299f9f979af9010e3c