### PR TITLE
Add missing CRUD endpoints for meal credits, timesheets, and users

### DIFF
--- a/src/Bluewater.UseCases/MealCredits/Delete/DeleteMealCreditCommand.cs
+++ b/src/Bluewater.UseCases/MealCredits/Delete/DeleteMealCreditCommand.cs
@@ -1,0 +1,6 @@
+using Ardalis.Result;
+using Ardalis.SharedKernel;
+
+namespace Bluewater.UseCases.MealCredits.Delete;
+
+public record DeleteMealCreditCommand(Guid MealCreditId) : ICommand<Result>;

--- a/src/Bluewater.UseCases/MealCredits/Delete/DeleteMealCreditHandler.cs
+++ b/src/Bluewater.UseCases/MealCredits/Delete/DeleteMealCreditHandler.cs
@@ -1,0 +1,20 @@
+using Ardalis.Result;
+using Ardalis.SharedKernel;
+using Bluewater.Core.MealCreditAggregate;
+
+namespace Bluewater.UseCases.MealCredits.Delete;
+
+public class DeleteMealCreditHandler(IRepository<MealCredit> _repository) : ICommandHandler<DeleteMealCreditCommand, Result>
+{
+  public async Task<Result> Handle(DeleteMealCreditCommand request, CancellationToken cancellationToken)
+  {
+    MealCredit? aggregateToDelete = await _repository.GetByIdAsync(request.MealCreditId, cancellationToken);
+    if (aggregateToDelete is null)
+    {
+      return Result.NotFound();
+    }
+
+    await _repository.DeleteAsync(aggregateToDelete, cancellationToken);
+    return Result.Success();
+  }
+}

--- a/src/Bluewater.UseCases/MealCredits/Get/GetMealCreditHandler.cs
+++ b/src/Bluewater.UseCases/MealCredits/Get/GetMealCreditHandler.cs
@@ -1,0 +1,19 @@
+using Ardalis.Result;
+using Ardalis.SharedKernel;
+using Bluewater.Core.MealCreditAggregate;
+
+namespace Bluewater.UseCases.MealCredits.Get;
+
+public class GetMealCreditHandler(IRepository<MealCredit> _repository) : IQueryHandler<GetMealCreditQuery, Result<MealCreditDTO>>
+{
+  public async Task<Result<MealCreditDTO>> Handle(GetMealCreditQuery request, CancellationToken cancellationToken)
+  {
+    MealCredit? mealCredit = await _repository.GetByIdAsync(request.MealCreditId, cancellationToken);
+    if (mealCredit is null)
+    {
+      return Result.NotFound();
+    }
+
+    return Result.Success(new MealCreditDTO(mealCredit.Id, mealCredit.EmployeeId, mealCredit.Date, mealCredit.Count));
+  }
+}

--- a/src/Bluewater.UseCases/MealCredits/Get/GetMealCreditQuery.cs
+++ b/src/Bluewater.UseCases/MealCredits/Get/GetMealCreditQuery.cs
@@ -1,0 +1,6 @@
+using Ardalis.Result;
+using Ardalis.SharedKernel;
+
+namespace Bluewater.UseCases.MealCredits.Get;
+
+public record GetMealCreditQuery(Guid MealCreditId) : IQuery<Result<MealCreditDTO>>;

--- a/src/Bluewater.UseCases/MealCredits/Update/UpdateMealCreditCommand.cs
+++ b/src/Bluewater.UseCases/MealCredits/Update/UpdateMealCreditCommand.cs
@@ -1,0 +1,6 @@
+using Ardalis.Result;
+using Ardalis.SharedKernel;
+
+namespace Bluewater.UseCases.MealCredits.Update;
+
+public record UpdateMealCreditCommand(Guid MealCreditId, Guid? EmployeeId, DateOnly? Date, int? Count) : ICommand<Result<MealCreditDTO>>;

--- a/src/Bluewater.UseCases/MealCredits/Update/UpdateMealCreditHandler.cs
+++ b/src/Bluewater.UseCases/MealCredits/Update/UpdateMealCreditHandler.cs
@@ -1,0 +1,22 @@
+using Ardalis.Result;
+using Ardalis.SharedKernel;
+using Bluewater.Core.MealCreditAggregate;
+
+namespace Bluewater.UseCases.MealCredits.Update;
+
+public class UpdateMealCreditHandler(IRepository<MealCredit> _repository) : ICommandHandler<UpdateMealCreditCommand, Result<MealCreditDTO>>
+{
+  public async Task<Result<MealCreditDTO>> Handle(UpdateMealCreditCommand request, CancellationToken cancellationToken)
+  {
+    MealCredit? existing = await _repository.GetByIdAsync(request.MealCreditId, cancellationToken);
+    if (existing is null)
+    {
+      return Result.NotFound();
+    }
+
+    existing.UpdateMealCredit(request.EmployeeId, request.Date, request.Count);
+    await _repository.UpdateAsync(existing, cancellationToken);
+
+    return Result.Success(new MealCreditDTO(existing.Id, existing.EmployeeId, existing.Date, existing.Count));
+  }
+}

--- a/src/Bluewater.Web/MealCredits/Delete.DeleteMealCreditRequest.cs
+++ b/src/Bluewater.Web/MealCredits/Delete.DeleteMealCreditRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.MealCredits;
+
+public class DeleteMealCreditRequest
+{
+  public const string Route = "/MealCredits/{MealCreditId:guid}";
+
+  [Required]
+  public Guid MealCreditId { get; set; }
+}

--- a/src/Bluewater.Web/MealCredits/Delete.cs
+++ b/src/Bluewater.Web/MealCredits/Delete.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.MealCredits.Delete;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.MealCredits;
+
+/// <summary>
+/// Delete a MealCredit entry by identifier.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Delete(IMediator _mediator) : Endpoint<DeleteMealCreditRequest>
+{
+  public override void Configure()
+  {
+    Delete(DeleteMealCreditRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(DeleteMealCreditRequest request, CancellationToken cancellationToken)
+  {
+    Result result = await _mediator.Send(new DeleteMealCreditCommand(request.MealCreditId), cancellationToken);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      await SendNoContentAsync(cancellationToken);
+    }
+  }
+}

--- a/src/Bluewater.Web/MealCredits/Get.GetMealCreditRequest.cs
+++ b/src/Bluewater.Web/MealCredits/Get.GetMealCreditRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.MealCredits;
+
+public class GetMealCreditRequest
+{
+  public const string Route = "/MealCredits/{MealCreditId:guid}";
+
+  [Required]
+  public Guid MealCreditId { get; set; }
+}

--- a/src/Bluewater.Web/MealCredits/Get.GetMealCreditResponse.cs
+++ b/src/Bluewater.Web/MealCredits/Get.GetMealCreditResponse.cs
@@ -1,0 +1,3 @@
+namespace Bluewater.Web.MealCredits;
+
+public record GetMealCreditResponse(MealCreditRecord? MealCredit);

--- a/src/Bluewater.Web/MealCredits/Get.cs
+++ b/src/Bluewater.Web/MealCredits/Get.cs
@@ -1,0 +1,37 @@
+using Ardalis.Result;
+using Bluewater.UseCases.MealCredits;
+using Bluewater.UseCases.MealCredits.Get;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.MealCredits;
+
+/// <summary>
+/// Retrieve a single MealCredit by identifier.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Get(IMediator _mediator) : Endpoint<GetMealCreditRequest, GetMealCreditResponse>
+{
+  public override void Configure()
+  {
+    Get(GetMealCreditRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(GetMealCreditRequest request, CancellationToken cancellationToken)
+  {
+    Result<MealCreditDTO> result = await _mediator.Send(new GetMealCreditQuery(request.MealCreditId), cancellationToken);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      MealCreditDTO mealCredit = result.Value;
+      Response = new GetMealCreditResponse(new MealCreditRecord(mealCredit.Id, mealCredit.EmployeeId, mealCredit.Date, mealCredit.Count));
+    }
+  }
+}

--- a/src/Bluewater.Web/MealCredits/Update.UpdateMealCreditRequest.cs
+++ b/src/Bluewater.Web/MealCredits/Update.UpdateMealCreditRequest.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.MealCredits;
+
+public class UpdateMealCreditRequest
+{
+  public const string Route = "/MealCredits";
+
+  [Required]
+  public Guid Id { get; set; }
+
+  public Guid? EmployeeId { get; set; }
+
+  public DateOnly? Date { get; set; }
+
+  public int? Count { get; set; }
+}

--- a/src/Bluewater.Web/MealCredits/Update.UpdateMealCreditResponse.cs
+++ b/src/Bluewater.Web/MealCredits/Update.UpdateMealCreditResponse.cs
@@ -1,0 +1,3 @@
+namespace Bluewater.Web.MealCredits;
+
+public record UpdateMealCreditResponse(MealCreditRecord MealCredit);

--- a/src/Bluewater.Web/MealCredits/Update.cs
+++ b/src/Bluewater.Web/MealCredits/Update.cs
@@ -1,0 +1,38 @@
+using Ardalis.Result;
+using Bluewater.UseCases.MealCredits;
+using Bluewater.UseCases.MealCredits.Update;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.MealCredits;
+
+/// <summary>
+/// Update an existing MealCredit record.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Update(IMediator _mediator) : Endpoint<UpdateMealCreditRequest, UpdateMealCreditResponse>
+{
+  public override void Configure()
+  {
+    Put(UpdateMealCreditRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(UpdateMealCreditRequest request, CancellationToken cancellationToken)
+  {
+    var command = new UpdateMealCreditCommand(request.Id, request.EmployeeId, request.Date, request.Count);
+    Result<MealCreditDTO> result = await _mediator.Send(command, cancellationToken);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      MealCreditDTO mealCredit = result.Value;
+      Response = new UpdateMealCreditResponse(new MealCreditRecord(mealCredit.Id, mealCredit.EmployeeId, mealCredit.Date, mealCredit.Count));
+    }
+  }
+}

--- a/src/Bluewater.Web/Timesheets/Delete.DeleteTimesheetRequest.cs
+++ b/src/Bluewater.Web/Timesheets/Delete.DeleteTimesheetRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.Timesheets;
+
+public class DeleteTimesheetRequest
+{
+  public const string Route = "/Timesheets/{TimesheetId:guid}";
+
+  [Required]
+  public Guid TimesheetId { get; set; }
+}

--- a/src/Bluewater.Web/Timesheets/Delete.cs
+++ b/src/Bluewater.Web/Timesheets/Delete.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Timesheets.Delete;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Timesheets;
+
+/// <summary>
+/// Delete a timesheet entry.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Delete(IMediator _mediator) : Endpoint<DeleteTimesheetRequest>
+{
+  public override void Configure()
+  {
+    Delete(DeleteTimesheetRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(DeleteTimesheetRequest request, CancellationToken cancellationToken)
+  {
+    Result result = await _mediator.Send(new DeleteTimesheetCommand(request.TimesheetId), cancellationToken);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      await SendNoContentAsync(cancellationToken);
+    }
+  }
+}

--- a/src/Bluewater.Web/Timesheets/Get.GetTimesheetRequest.cs
+++ b/src/Bluewater.Web/Timesheets/Get.GetTimesheetRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.Timesheets;
+
+public class GetTimesheetRequest
+{
+  public const string Route = "/Timesheets/{TimesheetId:guid}";
+
+  [Required]
+  public Guid TimesheetId { get; set; }
+}

--- a/src/Bluewater.Web/Timesheets/Get.GetTimesheetResponse.cs
+++ b/src/Bluewater.Web/Timesheets/Get.GetTimesheetResponse.cs
@@ -1,0 +1,3 @@
+namespace Bluewater.Web.Timesheets;
+
+public record GetTimesheetResponse(TimesheetRecord? Timesheet);

--- a/src/Bluewater.Web/Timesheets/Get.cs
+++ b/src/Bluewater.Web/Timesheets/Get.cs
@@ -1,0 +1,36 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Timesheets;
+using Bluewater.UseCases.Timesheets.Get;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Timesheets;
+
+/// <summary>
+/// Retrieve an individual timesheet record.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Get(IMediator _mediator) : Endpoint<GetTimesheetRequest, GetTimesheetResponse>
+{
+  public override void Configure()
+  {
+    Get(GetTimesheetRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(GetTimesheetRequest request, CancellationToken cancellationToken)
+  {
+    Result<TimesheetDTO> result = await _mediator.Send(new GetTimesheetQuery(request.TimesheetId), cancellationToken);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      Response = new GetTimesheetResponse(TimesheetMapper.ToRecord(result.Value));
+    }
+  }
+}

--- a/src/Bluewater.Web/Timesheets/List.TimesheetListRequest.cs
+++ b/src/Bluewater.Web/Timesheets/List.TimesheetListRequest.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.Timesheets;
+
+public class TimesheetListRequest
+{
+  [Range(0, int.MaxValue)]
+  public int? Skip { get; set; }
+
+  [Range(1, int.MaxValue)]
+  public int? Take { get; set; }
+
+  [Required]
+  public string Name { get; set; } = string.Empty;
+
+  [Required]
+  public DateOnly StartDate { get; set; }
+
+  [Required]
+  public DateOnly EndDate { get; set; }
+}

--- a/src/Bluewater.Web/Timesheets/List.TimesheetListResponse.cs
+++ b/src/Bluewater.Web/Timesheets/List.TimesheetListResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Timesheets;
+
+public class TimesheetListResponse
+{
+  public EmployeeTimesheetRecord? Employee { get; set; }
+}

--- a/src/Bluewater.Web/Timesheets/List.cs
+++ b/src/Bluewater.Web/Timesheets/List.cs
@@ -1,0 +1,41 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Timesheets;
+using Bluewater.UseCases.Timesheets.List;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Timesheets;
+
+/// <summary>
+/// Retrieve timesheets for a specific employee over a date range.
+/// </summary>
+/// <param name="_mediator"></param>
+public class List(IMediator _mediator) : Endpoint<TimesheetListRequest, TimesheetListResponse>
+{
+  public override void Configure()
+  {
+    Get("/Timesheets");
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(TimesheetListRequest request, CancellationToken cancellationToken)
+  {
+    Result<EmployeeTimesheetDTO> result = await _mediator.Send(
+      new ListTimesheetQuery(request.Skip, request.Take, request.Name, request.StartDate, request.EndDate),
+      cancellationToken);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      Response = new TimesheetListResponse
+      {
+        Employee = TimesheetMapper.ToRecord(result.Value)
+      };
+    }
+  }
+}

--- a/src/Bluewater.Web/Timesheets/ListAll.TimesheetListAllRequest.cs
+++ b/src/Bluewater.Web/Timesheets/ListAll.TimesheetListAllRequest.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+using Bluewater.Core.EmployeeAggregate.Enum;
+
+namespace Bluewater.Web.Timesheets;
+
+public class TimesheetListAllRequest
+{
+  [Range(0, int.MaxValue)]
+  public int? Skip { get; set; }
+
+  [Range(1, int.MaxValue)]
+  public int? Take { get; set; }
+
+  [Required]
+  public DateOnly StartDate { get; set; }
+
+  [Required]
+  public DateOnly EndDate { get; set; }
+
+  [Required]
+  public Tenant Tenant { get; set; }
+}

--- a/src/Bluewater.Web/Timesheets/ListAll.TimesheetListAllResponse.cs
+++ b/src/Bluewater.Web/Timesheets/ListAll.TimesheetListAllResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Timesheets;
+
+public class TimesheetListAllResponse
+{
+  public List<AllEmployeeTimesheetRecord> Employees { get; set; } = new();
+}

--- a/src/Bluewater.Web/Timesheets/ListAll.cs
+++ b/src/Bluewater.Web/Timesheets/ListAll.cs
@@ -1,0 +1,36 @@
+using System.Linq;
+using Ardalis.Result;
+using Bluewater.UseCases.Timesheets;
+using Bluewater.UseCases.Timesheets.List;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Timesheets;
+
+/// <summary>
+/// Retrieve timesheet summaries for all employees within a tenant and date range.
+/// </summary>
+/// <param name="_mediator"></param>
+public class ListAll(IMediator _mediator) : Endpoint<TimesheetListAllRequest, TimesheetListAllResponse>
+{
+  public override void Configure()
+  {
+    Get("/Timesheets/All");
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(TimesheetListAllRequest request, CancellationToken cancellationToken)
+  {
+    Result<IEnumerable<AllEmployeeTimesheetDTO>> result = await _mediator.Send(
+      new ListAllTimesheetQuery(request.Skip, request.Take, request.StartDate, request.EndDate, request.Tenant),
+      cancellationToken);
+
+    if (result.IsSuccess)
+    {
+      Response = new TimesheetListAllResponse
+      {
+        Employees = result.Value.Select(TimesheetMapper.ToRecord).ToList()
+      };
+    }
+  }
+}

--- a/src/Bluewater.Web/Timesheets/TimesheetRecord.cs
+++ b/src/Bluewater.Web/Timesheets/TimesheetRecord.cs
@@ -1,0 +1,75 @@
+using System.Linq;
+using Bluewater.UseCases.Timesheets;
+
+namespace Bluewater.Web.Timesheets;
+
+public record TimesheetRecord(
+  Guid Id,
+  Guid EmployeeId,
+  DateTime? TimeIn1,
+  DateTime? TimeOut1,
+  DateTime? TimeIn2,
+  DateTime? TimeOut2,
+  DateOnly? EntryDate,
+  bool IsEdited);
+
+public record TimesheetInfoRecord(
+  Guid TimesheetId,
+  DateTime? TimeIn1,
+  DateTime? TimeOut1,
+  DateTime? TimeIn2,
+  DateTime? TimeOut2,
+  DateOnly? EntryDate,
+  bool IsEdited);
+
+public record EmployeeTimesheetRecord(
+  Guid EmployeeId,
+  string Name,
+  string Department,
+  string Section,
+  string Charging,
+  List<TimesheetInfoRecord> Timesheets);
+
+public record AllEmployeeTimesheetRecord(
+  Guid EmployeeId,
+  string Name,
+  string Department,
+  string Section,
+  string Charging,
+  List<TimesheetInfoRecord> Timesheets,
+  decimal TotalWorkHours,
+  decimal TotalBreak,
+  decimal TotalLates,
+  int TotalAbsents)
+  : EmployeeTimesheetRecord(EmployeeId, Name, Department, Section, Charging, Timesheets);
+
+public static class TimesheetMapper
+{
+  public static TimesheetRecord ToRecord(TimesheetDTO dto) =>
+    new(dto.Id, dto.EmployeeId, dto.TimeIn1, dto.TimeOut1, dto.TimeIn2, dto.TimeOut2, dto.EntryDate, dto.IsEdited);
+
+  public static TimesheetInfoRecord ToRecord(TimesheetInfo dto) =>
+    new(dto.TimesheetId, dto.TimeIn1, dto.TimeOut1, dto.TimeIn2, dto.TimeOut2, dto.EntryDate, dto.IsEdited);
+
+  public static EmployeeTimesheetRecord ToRecord(EmployeeTimesheetDTO dto) =>
+    new(
+      dto.EmployeeId,
+      dto.Name,
+      dto.Department,
+      dto.Section,
+      dto.Charging,
+      dto.Timesheets.Select(ToRecord).ToList());
+
+  public static AllEmployeeTimesheetRecord ToRecord(AllEmployeeTimesheetDTO dto) =>
+    new(
+      dto.EmployeeId,
+      dto.Name,
+      dto.Department,
+      dto.Section,
+      dto.Charging,
+      dto.Timesheets.Select(ToRecord).ToList(),
+      dto.TotalWorkHours,
+      dto.TotalBreak,
+      dto.TotalLates,
+      dto.TotalAbsents);
+}

--- a/src/Bluewater.Web/Timesheets/Update.UpdateTimesheetRequest.cs
+++ b/src/Bluewater.Web/Timesheets/Update.UpdateTimesheetRequest.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.Timesheets;
+
+public class UpdateTimesheetRequest
+{
+  public const string Route = "/Timesheets";
+
+  [Required]
+  public Guid Id { get; set; }
+
+  [Required]
+  public Guid EmployeeId { get; set; }
+
+  public DateTime? TimeIn1 { get; set; }
+
+  public DateTime? TimeOut1 { get; set; }
+
+  public DateTime? TimeIn2 { get; set; }
+
+  public DateTime? TimeOut2 { get; set; }
+
+  public DateOnly? EntryDate { get; set; }
+
+  public bool IsLocked { get; set; }
+}

--- a/src/Bluewater.Web/Timesheets/Update.UpdateTimesheetResponse.cs
+++ b/src/Bluewater.Web/Timesheets/Update.UpdateTimesheetResponse.cs
@@ -1,0 +1,3 @@
+namespace Bluewater.Web.Timesheets;
+
+public record UpdateTimesheetResponse(TimesheetRecord Timesheet);

--- a/src/Bluewater.Web/Timesheets/Update.cs
+++ b/src/Bluewater.Web/Timesheets/Update.cs
@@ -1,0 +1,46 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Timesheets;
+using Bluewater.UseCases.Timesheets.Update;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Timesheets;
+
+/// <summary>
+/// Update an existing timesheet entry.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Update(IMediator _mediator) : Endpoint<UpdateTimesheetRequest, UpdateTimesheetResponse>
+{
+  public override void Configure()
+  {
+    Put(UpdateTimesheetRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(UpdateTimesheetRequest request, CancellationToken cancellationToken)
+  {
+    var command = new UpdateTimesheetCommand(
+      request.Id,
+      request.EmployeeId,
+      request.TimeIn1,
+      request.TimeOut1,
+      request.TimeIn2,
+      request.TimeOut2,
+      request.EntryDate,
+      request.IsLocked);
+
+    Result<TimesheetDTO> result = await _mediator.Send(command, cancellationToken);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      Response = new UpdateTimesheetResponse(TimesheetMapper.ToRecord(result.Value));
+    }
+  }
+}

--- a/src/Bluewater.Web/Users/Create.CreateUserRequest.cs
+++ b/src/Bluewater.Web/Users/Create.CreateUserRequest.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+using Bluewater.Core.UserAggregate.Enum;
+
+namespace Bluewater.Web.Users;
+
+public class CreateUserRequest
+{
+  public const string Route = "/Users";
+
+  [Required]
+  public string Username { get; set; } = string.Empty;
+
+  [Required]
+  public string PasswordHash { get; set; } = string.Empty;
+
+  public Credential Credential { get; set; } = Credential.None;
+
+  public Guid? SupervisedGroup { get; set; }
+
+  public bool IsGlobalSupervisor { get; set; }
+}

--- a/src/Bluewater.Web/Users/Create.CreateUserResponse.cs
+++ b/src/Bluewater.Web/Users/Create.CreateUserResponse.cs
@@ -1,0 +1,3 @@
+namespace Bluewater.Web.Users;
+
+public record CreateUserResponse(Guid Id);

--- a/src/Bluewater.Web/Users/Create.cs
+++ b/src/Bluewater.Web/Users/Create.cs
@@ -1,0 +1,31 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Users.Create;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Users;
+
+/// <summary>
+/// Create a new application user.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Create(IMediator _mediator) : Endpoint<CreateUserRequest, CreateUserResponse>
+{
+  public override void Configure()
+  {
+    Post(CreateUserRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(CreateUserRequest request, CancellationToken cancellationToken)
+  {
+    var command = new CreateUserCommand(request.Username, request.PasswordHash, request.Credential, request.SupervisedGroup, request.IsGlobalSupervisor);
+
+    Result<Guid> result = await _mediator.Send(command, cancellationToken);
+
+    if (result.IsSuccess)
+    {
+      Response = new CreateUserResponse(result.Value);
+    }
+  }
+}

--- a/src/Bluewater.Web/Users/Delete.DeleteUserRequest.cs
+++ b/src/Bluewater.Web/Users/Delete.DeleteUserRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.Users;
+
+public class DeleteUserRequest
+{
+  public const string Route = "/Users/{UserId:guid}";
+
+  [Required]
+  public Guid UserId { get; set; }
+}

--- a/src/Bluewater.Web/Users/Delete.cs
+++ b/src/Bluewater.Web/Users/Delete.cs
@@ -1,0 +1,35 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Users.Delete;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Users;
+
+/// <summary>
+/// Delete a user by identifier.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Delete(IMediator _mediator) : Endpoint<DeleteUserRequest>
+{
+  public override void Configure()
+  {
+    Delete(DeleteUserRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(DeleteUserRequest request, CancellationToken cancellationToken)
+  {
+    Result result = await _mediator.Send(new DeleteUserCommand(request.UserId), cancellationToken);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      await SendNoContentAsync(cancellationToken);
+    }
+  }
+}

--- a/src/Bluewater.Web/Users/Get.GetUserRequest.cs
+++ b/src/Bluewater.Web/Users/Get.GetUserRequest.cs
@@ -4,7 +4,7 @@ namespace Bluewater.Web.Users;
 
 public class GetUserRequest
 {
-  public const string Route = "/Users/{barcode}";
+  public const string Route = "/Users/barcode/{barcode}";
 
   [Required]
   public string barcode { get; set; } = null!;

--- a/src/Bluewater.Web/Users/GetById.GetUserByIdRequest.cs
+++ b/src/Bluewater.Web/Users/GetById.GetUserByIdRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.Users;
+
+public class GetUserByIdRequest
+{
+  public const string Route = "/Users/{UserId:guid}";
+
+  [Required]
+  public Guid UserId { get; set; }
+}

--- a/src/Bluewater.Web/Users/GetById.GetUserByIdResponse.cs
+++ b/src/Bluewater.Web/Users/GetById.GetUserByIdResponse.cs
@@ -1,0 +1,3 @@
+namespace Bluewater.Web.Users;
+
+public record GetUserByIdResponse(UserRecord? User);

--- a/src/Bluewater.Web/Users/GetById.cs
+++ b/src/Bluewater.Web/Users/GetById.cs
@@ -1,0 +1,36 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Users;
+using Bluewater.UseCases.Users.Get;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Users;
+
+/// <summary>
+/// Retrieve a user by identifier.
+/// </summary>
+/// <param name="_mediator"></param>
+public class GetById(IMediator _mediator) : Endpoint<GetUserByIdRequest, GetUserByIdResponse>
+{
+  public override void Configure()
+  {
+    Get(GetUserByIdRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(GetUserByIdRequest request, CancellationToken cancellationToken)
+  {
+    Result<UserDTO> result = await _mediator.Send(new GetUserQuery(request.UserId), cancellationToken);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      Response = new GetUserByIdResponse(UserMapper.ToRecord(result.Value));
+    }
+  }
+}

--- a/src/Bluewater.Web/Users/List.UserListRequest.cs
+++ b/src/Bluewater.Web/Users/List.UserListRequest.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Bluewater.Web.Users;
+
+public class UserListRequest
+{
+  [Range(0, int.MaxValue)]
+  public int? Skip { get; set; }
+
+  [Range(1, int.MaxValue)]
+  public int? Take { get; set; }
+}

--- a/src/Bluewater.Web/Users/List.UserListResponse.cs
+++ b/src/Bluewater.Web/Users/List.UserListResponse.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.Web.Users;
+
+public class UserListResponse
+{
+  public List<UserRecord> Users { get; set; } = new();
+}

--- a/src/Bluewater.Web/Users/List.cs
+++ b/src/Bluewater.Web/Users/List.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using Ardalis.Result;
+using Bluewater.UseCases.Users;
+using Bluewater.UseCases.Users.List;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Users;
+
+/// <summary>
+/// List application users with optional paging.
+/// </summary>
+/// <param name="_mediator"></param>
+public class List(IMediator _mediator) : Endpoint<UserListRequest, UserListResponse>
+{
+  public override void Configure()
+  {
+    Get("/Users");
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(UserListRequest request, CancellationToken cancellationToken)
+  {
+    Result<IEnumerable<UserDTO>> result = await _mediator.Send(new ListUserQuery(request.Skip, request.Take), cancellationToken);
+
+    if (result.IsSuccess)
+    {
+      Response = new UserListResponse
+      {
+        Users = result.Value.Select(UserMapper.ToRecord).ToList()
+      };
+    }
+  }
+}

--- a/src/Bluewater.Web/Users/Update.UpdateUserRequest.cs
+++ b/src/Bluewater.Web/Users/Update.UpdateUserRequest.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+using Bluewater.Core.UserAggregate.Enum;
+
+namespace Bluewater.Web.Users;
+
+public class UpdateUserRequest
+{
+  public const string Route = "/Users";
+
+  [Required]
+  public Guid Id { get; set; }
+
+  [Required]
+  public string Username { get; set; } = string.Empty;
+
+  [Required]
+  public string PasswordHash { get; set; } = string.Empty;
+
+  [Required]
+  public Credential Credential { get; set; }
+
+  public Guid? SupervisedGroup { get; set; }
+
+  public bool IsGlobalSupervisor { get; set; }
+}

--- a/src/Bluewater.Web/Users/Update.UpdateUserResponse.cs
+++ b/src/Bluewater.Web/Users/Update.UpdateUserResponse.cs
@@ -1,0 +1,3 @@
+namespace Bluewater.Web.Users;
+
+public record UpdateUserResponse(UserRecord User);

--- a/src/Bluewater.Web/Users/Update.cs
+++ b/src/Bluewater.Web/Users/Update.cs
@@ -1,0 +1,44 @@
+using Ardalis.Result;
+using Bluewater.UseCases.Users;
+using Bluewater.UseCases.Users.Update;
+using FastEndpoints;
+using MediatR;
+
+namespace Bluewater.Web.Users;
+
+/// <summary>
+/// Update an existing user.
+/// </summary>
+/// <param name="_mediator"></param>
+public class Update(IMediator _mediator) : Endpoint<UpdateUserRequest, UpdateUserResponse>
+{
+  public override void Configure()
+  {
+    Put(UpdateUserRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(UpdateUserRequest request, CancellationToken cancellationToken)
+  {
+    var command = new UpdateUserCommand(
+      request.Id,
+      request.Username,
+      request.PasswordHash,
+      request.Credential,
+      request.SupervisedGroup,
+      request.IsGlobalSupervisor);
+
+    Result<UserDTO> result = await _mediator.Send(command, cancellationToken);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      Response = new UpdateUserResponse(UserMapper.ToRecord(result.Value));
+    }
+  }
+}

--- a/src/Bluewater.Web/Users/UserRecord.cs
+++ b/src/Bluewater.Web/Users/UserRecord.cs
@@ -1,0 +1,18 @@
+using Bluewater.Core.UserAggregate.Enum;
+using Bluewater.UseCases.Users;
+
+namespace Bluewater.Web.Users;
+
+public record UserRecord(
+  Guid Id,
+  string Username,
+  string PasswordHash,
+  Credential Credential,
+  Guid? SupervisedGroup,
+  bool IsGlobalSupervisor);
+
+public static class UserMapper
+{
+  public static UserRecord ToRecord(UserDTO dto) =>
+    new(dto.Id, dto.Username, dto.PasswordHash, dto.Credential, dto.SupervisedGroup, dto.IsGlobalSupervisor);
+}


### PR DESCRIPTION
## Summary
- add query/command handlers to support retrieving, updating, and deleting meal credits and expose the corresponding API endpoints
- implement list, aggregate, get, update, and delete API endpoints for timesheets along with response mappers
- add full CRUD endpoints for users, including mapping helpers and a non-conflicting barcode lookup route

## Testing
- dotnet build *(fails: dotnet CLI not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6fe0e886c8329aed22b6224282c92