### PR TITLE
Add employee API client and display employees in MAUI app

### DIFF
--- a/src/Bluewater.App/Bluewater.App.csproj
+++ b/src/Bluewater.App/Bluewater.App.csproj
@@ -120,11 +120,12 @@
 	  </MauiXaml>
 	</ItemGroup>
 
-	<ItemGroup>
-	  <Folder Include="Converters\" />
-	  <Folder Include="Models\" />
-	  <Folder Include="Services\" />
-	</ItemGroup>
+        <ItemGroup>
+          <Folder Include="Converters\" />
+          <Folder Include="Interfaces\" />
+          <Folder Include="Models\" />
+          <Folder Include="Services\" />
+        </ItemGroup>
 
 	<ItemGroup>
 	  <Compile Update="Views\SettingPage.xaml.cs">

--- a/src/Bluewater.App/Interfaces/IApiClient.cs
+++ b/src/Bluewater.App/Interfaces/IApiClient.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.App.Interfaces;
+
+public interface IApiClient
+{
+  Task<T?> GetAsync<T>(string requestUri, CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.App/Interfaces/IEmployeeApiService.cs
+++ b/src/Bluewater.App/Interfaces/IEmployeeApiService.cs
@@ -1,0 +1,11 @@
+using Bluewater.App.Models;
+
+namespace Bluewater.App.Interfaces;
+
+public interface IEmployeeApiService
+{
+  Task<IReadOnlyList<EmployeeSummary>> GetEmployeesAsync(
+    int? skip = null,
+    int? take = null,
+    CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.App/MauiProgram.cs
+++ b/src/Bluewater.App/MauiProgram.cs
@@ -1,4 +1,8 @@
-﻿using Bluewater.App.ViewModels;
+﻿using System;
+using System.Net.Http;
+using Bluewater.App.Interfaces;
+using Bluewater.App.Services;
+using Bluewater.App.ViewModels;
 using Bluewater.App.Views;
 using CommunityToolkit.Maui;
 using Microsoft.Extensions.Logging;
@@ -9,6 +13,8 @@ public static class MauiProgram
 {
   public static MauiApp CreateMauiApp()
   {
+    const string ApiBaseAddress = "https://localhost:57679";
+
     var builder = MauiApp.CreateBuilder();
     builder
       .UseMauiApp<App>()
@@ -28,6 +34,27 @@ public static class MauiProgram
 #if DEBUG
 		builder.Logging.AddDebug();
 #endif
+
+    // services
+    builder.Services.AddSingleton(sp =>
+    {
+#if DEBUG
+      var handler = new HttpClientHandler
+      {
+        ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+      };
+#else
+      var handler = new HttpClientHandler();
+#endif
+
+      return new HttpClient(handler)
+      {
+        BaseAddress = new Uri(ApiBaseAddress)
+      };
+    });
+
+    builder.Services.AddSingleton<IApiClient, ApiClient>();
+    builder.Services.AddSingleton<IEmployeeApiService, EmployeeApiService>();
 
     // pages
     builder.Services.AddSingleton<AttendancePage>();

--- a/src/Bluewater.App/Models/EmployeeListResponseDto.cs
+++ b/src/Bluewater.App/Models/EmployeeListResponseDto.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+
+namespace Bluewater.App.Models;
+
+public class EmployeeListResponseDto
+{
+  public List<EmployeeDto> Employees { get; set; } = new();
+}
+
+public class EmployeeDto
+{
+  public Guid Id { get; set; }
+  public string FirstName { get; set; } = string.Empty;
+  public string LastName { get; set; } = string.Empty;
+  public string? MiddleName { get; set; }
+  public ContactInfoDto? ContactInfo { get; set; }
+  public string? Position { get; set; }
+  public string? Section { get; set; }
+  public string? Department { get; set; }
+  public string? Type { get; set; }
+  public string? Level { get; set; }
+}
+
+public class ContactInfoDto
+{
+  public string? Email { get; set; }
+  public string? TelNumber { get; set; }
+  public string? MobileNumber { get; set; }
+}

--- a/src/Bluewater.App/Models/EmployeeSummary.cs
+++ b/src/Bluewater.App/Models/EmployeeSummary.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Linq;
+
+namespace Bluewater.App.Models;
+
+public class EmployeeSummary
+{
+  public Guid Id { get; init; }
+  public string FirstName { get; init; } = string.Empty;
+  public string LastName { get; init; } = string.Empty;
+  public string? MiddleName { get; init; }
+  public string? Position { get; init; }
+  public string? Section { get; init; }
+  public string? Department { get; init; }
+  public string? Type { get; init; }
+  public string? Level { get; init; }
+  public string? Email { get; init; }
+
+  public string FullName
+  {
+    get
+    {
+      return string.Join(' ', new[] { FirstName, MiddleName, LastName }
+        .Where(part => !string.IsNullOrWhiteSpace(part)));
+    }
+  }
+
+  public string PositionDisplay => FormatDetail("Position", Position);
+
+  public string DepartmentDisplay => FormatDetail("Department", Department);
+
+  public string SectionDisplay => FormatDetail("Section", Section);
+
+  public string TypeLevelDisplay
+  {
+    get
+    {
+      if (string.IsNullOrWhiteSpace(Type) && string.IsNullOrWhiteSpace(Level))
+      {
+        return "";
+      }
+
+      if (string.IsNullOrWhiteSpace(Type))
+      {
+        return $"Level: {Level}";
+      }
+
+      if (string.IsNullOrWhiteSpace(Level))
+      {
+        return $"Type: {Type}";
+      }
+
+      return $"{Type} • {Level}";
+    }
+  }
+
+  public string EmailDisplay => string.IsNullOrWhiteSpace(Email) ? string.Empty : Email;
+
+  private static string FormatDetail(string label, string? value)
+  {
+    return string.IsNullOrWhiteSpace(value) ? string.Empty : $"{label}: {value}";
+  }
+}

--- a/src/Bluewater.App/Services/ApiClient.cs
+++ b/src/Bluewater.App/Services/ApiClient.cs
@@ -1,0 +1,46 @@
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Bluewater.App.Interfaces;
+
+namespace Bluewater.App.Services;
+
+public class ApiClient(HttpClient httpClient) : IApiClient
+{
+  private static readonly JsonSerializerOptions JsonOptions = new()
+  {
+    PropertyNameCaseInsensitive = true
+  };
+
+  public async Task<T?> GetAsync<T>(string requestUri, CancellationToken cancellationToken = default)
+  {
+    using HttpResponseMessage response = await httpClient.GetAsync(requestUri, cancellationToken);
+
+    if (response.StatusCode == HttpStatusCode.NotFound)
+    {
+      return default;
+    }
+
+    response.EnsureSuccessStatusCode();
+
+    if (IsContentEmpty(response.Content.Headers))
+    {
+      return default;
+    }
+
+    await using Stream contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+    return await JsonSerializer.DeserializeAsync<T>(contentStream, JsonOptions, cancellationToken);
+  }
+
+  private static bool IsContentEmpty(HttpContentHeaders headers)
+  {
+    if (headers?.ContentLength.HasValue == true && headers.ContentLength.Value == 0)
+    {
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/src/Bluewater.App/Services/EmployeeApiService.cs
+++ b/src/Bluewater.App/Services/EmployeeApiService.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Bluewater.App.Interfaces;
+using Bluewater.App.Models;
+
+namespace Bluewater.App.Services;
+
+public class EmployeeApiService(IApiClient apiClient) : IEmployeeApiService
+{
+  public async Task<IReadOnlyList<EmployeeSummary>> GetEmployeesAsync(
+    int? skip = null,
+    int? take = null,
+    CancellationToken cancellationToken = default)
+  {
+    string requestUri = BuildRequestUri(skip, take);
+
+    EmployeeListResponseDto? response = await apiClient.GetAsync<EmployeeListResponseDto>(requestUri, cancellationToken);
+
+    if (response?.Employees is not { Count: > 0 })
+    {
+      return Array.Empty<EmployeeSummary>();
+    }
+
+    return response.Employees
+      .Where(dto => dto is not null)
+      .Select(MapToSummary)
+      .ToList();
+  }
+
+  private static string BuildRequestUri(int? skip, int? take)
+  {
+    List<string> parameters = [];
+
+    if (skip.HasValue)
+    {
+      parameters.Add($"skip={skip.Value}");
+    }
+
+    if (take.HasValue)
+    {
+      parameters.Add($"take={take.Value}");
+    }
+
+    if (parameters.Count == 0)
+    {
+      return "Employees";
+    }
+
+    string query = string.Join('&', parameters);
+    return $"Employees?{query}";
+  }
+
+  private static EmployeeSummary MapToSummary(EmployeeDto dto)
+  {
+    return new EmployeeSummary
+    {
+      Id = dto.Id,
+      FirstName = dto.FirstName,
+      LastName = dto.LastName,
+      MiddleName = dto.MiddleName,
+      Department = dto.Department,
+      Section = dto.Section,
+      Position = dto.Position,
+      Type = dto.Type,
+      Level = dto.Level,
+      Email = dto.ContactInfo?.Email
+    };
+  }
+}

--- a/src/Bluewater.App/ViewModels/EmployeeViewModel.cs
+++ b/src/Bluewater.App/ViewModels/EmployeeViewModel.cs
@@ -1,7 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+using Bluewater.App.Interfaces;
+using Bluewater.App.Models;
 using Bluewater.App.ViewModels.Base;
 
 namespace Bluewater.App.ViewModels;
 
 public partial class EmployeeViewModel : BaseViewModel
 {
+  private readonly IEmployeeApiService employeeApiService;
+  private bool hasInitialized;
+
+  public EmployeeViewModel(IEmployeeApiService employeeApiService)
+  {
+    this.employeeApiService = employeeApiService;
+  }
+
+  public ObservableCollection<EmployeeSummary> Employees { get; } = new();
+
+  public override async Task InitializeAsync()
+  {
+    if (IsBusy || hasInitialized)
+    {
+      return;
+    }
+
+    try
+    {
+      IsBusy = true;
+      Employees.Clear();
+      IReadOnlyList<EmployeeSummary> employees = await employeeApiService.GetEmployeesAsync();
+
+      foreach (EmployeeSummary employee in employees
+        .OrderBy(e => e.LastName ?? string.Empty)
+        .ThenBy(e => e.FirstName ?? string.Empty))
+      {
+        Employees.Add(employee);
+      }
+
+      hasInitialized = true;
+    }
+    catch (Exception ex)
+    {
+      Debug.WriteLine($"Failed to load employees: {ex.Message}");
+    }
+    finally
+    {
+      IsBusy = false;
+    }
+  }
 }

--- a/src/Bluewater.App/Views/EmployeePage.xaml
+++ b/src/Bluewater.App/Views/EmployeePage.xaml
@@ -1,12 +1,103 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:models="clr-namespace:Bluewater.App.Models"
              x:Class="Bluewater.App.Views.EmployeePage"
-             Title="EmployeePage">
-    <VerticalStackLayout>
-        <Label 
-            Text="Welcome to .NET MAUI!"
-            VerticalOptions="Center" 
-            HorizontalOptions="Center" />
-    </VerticalStackLayout>
+             Title="Employees">
+  <Grid Padding="16" RowDefinitions="Auto,*" RowSpacing="16">
+    <Label Text="Employees"
+           FontAttributes="Bold"
+           FontSize="24" />
+
+    <Grid Grid.Row="1">
+      <CollectionView ItemsSource="{Binding Employees}"
+                      SelectionMode="None"
+                      VerticalOptions="FillAndExpand">
+        <CollectionView.EmptyView>
+          <VerticalStackLayout HorizontalOptions="Center"
+                               VerticalOptions="Center"
+                               Spacing="8">
+            <Label Text="No employees found" />
+            <Label Text="Employees will appear here once they are available." FontSize="12" />
+          </VerticalStackLayout>
+        </CollectionView.EmptyView>
+        <CollectionView.ItemTemplate>
+          <DataTemplate x:DataType="models:EmployeeSummary">
+            <Border StrokeThickness="1"
+                    Padding="12"
+                    Margin="0,0,0,12">
+              <Border.StrokeShape>
+                <RoundRectangle CornerRadius="12" />
+              </Border.StrokeShape>
+              <VerticalStackLayout Spacing="4">
+                <Label Text="{Binding FullName}" FontAttributes="Bold" FontSize="16" />
+
+                <Label Text="{Binding PositionDisplay}" FontSize="13" TextColor="{AppThemeBinding Light=#666666, Dark=#BBBBBB}">
+                  <Label.Triggers>
+                    <Trigger TargetType="Label" Property="Text" Value="{x:Null}">
+                      <Setter Property="IsVisible" Value="False" />
+                    </Trigger>
+                    <Trigger TargetType="Label" Property="Text" Value="">
+                      <Setter Property="IsVisible" Value="False" />
+                    </Trigger>
+                  </Label.Triggers>
+                </Label>
+
+                <Label Text="{Binding DepartmentDisplay}" FontSize="13" TextColor="{AppThemeBinding Light=#666666, Dark=#BBBBBB}">
+                  <Label.Triggers>
+                    <Trigger TargetType="Label" Property="Text" Value="{x:Null}">
+                      <Setter Property="IsVisible" Value="False" />
+                    </Trigger>
+                    <Trigger TargetType="Label" Property="Text" Value="">
+                      <Setter Property="IsVisible" Value="False" />
+                    </Trigger>
+                  </Label.Triggers>
+                </Label>
+
+                <Label Text="{Binding SectionDisplay}" FontSize="13" TextColor="{AppThemeBinding Light=#666666, Dark=#BBBBBB}">
+                  <Label.Triggers>
+                    <Trigger TargetType="Label" Property="Text" Value="{x:Null}">
+                      <Setter Property="IsVisible" Value="False" />
+                    </Trigger>
+                    <Trigger TargetType="Label" Property="Text" Value="">
+                      <Setter Property="IsVisible" Value="False" />
+                    </Trigger>
+                  </Label.Triggers>
+                </Label>
+
+                <Label Text="{Binding TypeLevelDisplay}" FontSize="13" TextColor="{AppThemeBinding Light=#666666, Dark=#BBBBBB}">
+                  <Label.Triggers>
+                    <Trigger TargetType="Label" Property="Text" Value="{x:Null}">
+                      <Setter Property="IsVisible" Value="False" />
+                    </Trigger>
+                    <Trigger TargetType="Label" Property="Text" Value="">
+                      <Setter Property="IsVisible" Value="False" />
+                    </Trigger>
+                  </Label.Triggers>
+                </Label>
+
+                <Label Text="{Binding EmailDisplay}"
+                       FontSize="13"
+                       TextColor="{AppThemeBinding Light=#0A84FF, Dark=#63A4FF}">
+                  <Label.Triggers>
+                    <Trigger TargetType="Label" Property="Text" Value="{x:Null}">
+                      <Setter Property="IsVisible" Value="False" />
+                    </Trigger>
+                    <Trigger TargetType="Label" Property="Text" Value="">
+                      <Setter Property="IsVisible" Value="False" />
+                    </Trigger>
+                  </Label.Triggers>
+                </Label>
+              </VerticalStackLayout>
+            </Border>
+          </DataTemplate>
+        </CollectionView.ItemTemplate>
+      </CollectionView>
+
+      <ActivityIndicator IsRunning="{Binding IsBusy}"
+                         IsVisible="{Binding IsBusy}"
+                         HorizontalOptions="Center"
+                         VerticalOptions="Center" />
+    </Grid>
+  </Grid>
 </ContentPage>

--- a/src/Bluewater.App/Views/EmployeePage.xaml.cs
+++ b/src/Bluewater.App/Views/EmployeePage.xaml.cs
@@ -9,4 +9,14 @@ public partial class EmployeePage : ContentPage
     InitializeComponent();
     BindingContext = vm;
   }
+
+  protected override async void OnAppearing()
+  {
+    base.OnAppearing();
+
+    if (BindingContext is EmployeeViewModel viewModel)
+    {
+      await viewModel.InitializeAsync();
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add HTTP client abstractions and an employee API service for Bluewater.Web endpoints
- hydrate the EmployeeViewModel via InitializeAsync using the new service
- update the Employee page UI to present employee details in a collection view

## Testing
- not run (dotnet CLI unavailable in execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68da640e21d08329a52495b8ec55df2b