### PR TITLE
Add shift API integration and editable shifts page

### DIFF
--- a/src/Bluewater.App/Interfaces/IApiClient.cs
+++ b/src/Bluewater.App/Interfaces/IApiClient.cs
@@ -3,4 +3,12 @@ namespace Bluewater.App.Interfaces;
 public interface IApiClient
 {
   Task<T?> GetAsync<T>(string requestUri, CancellationToken cancellationToken = default);
+  Task<TResponse?> PostAsync<TRequest, TResponse>(
+    string requestUri,
+    TRequest request,
+    CancellationToken cancellationToken = default);
+  Task<TResponse?> PutAsync<TRequest, TResponse>(
+    string requestUri,
+    TRequest request,
+    CancellationToken cancellationToken = default);
 }

--- a/src/Bluewater.App/Interfaces/IShiftApiService.cs
+++ b/src/Bluewater.App/Interfaces/IShiftApiService.cs
@@ -1,0 +1,10 @@
+using Bluewater.App.Models;
+
+namespace Bluewater.App.Interfaces;
+
+public interface IShiftApiService
+{
+  Task<IReadOnlyList<ShiftSummary>> GetShiftsAsync(CancellationToken cancellationToken = default);
+  Task<ShiftSummary?> CreateShiftAsync(ShiftSummary shift, CancellationToken cancellationToken = default);
+  Task<ShiftSummary?> UpdateShiftAsync(ShiftSummary shift, CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.App/MauiProgram.cs
+++ b/src/Bluewater.App/MauiProgram.cs
@@ -55,6 +55,7 @@ public static class MauiProgram
 
     builder.Services.AddSingleton<IApiClient, ApiClient>();
     builder.Services.AddSingleton<IEmployeeApiService, EmployeeApiService>();
+    builder.Services.AddSingleton<IShiftApiService, ShiftApiService>();
 
     // pages
     builder.Services.AddSingleton<AttendancePage>();

--- a/src/Bluewater.App/Models/ShiftListResponseDto.cs
+++ b/src/Bluewater.App/Models/ShiftListResponseDto.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+
+namespace Bluewater.App.Models;
+
+public class ShiftListResponseDto
+{
+  public List<ShiftDto> Shifts { get; set; } = new();
+}
+
+public class ShiftDto
+{
+  public Guid Id { get; set; }
+  public string Name { get; set; } = string.Empty;
+  public TimeOnly? ShiftStartTime { get; set; }
+  public TimeOnly? ShiftBreakTime { get; set; }
+  public TimeOnly? ShiftBreakEndTime { get; set; }
+  public TimeOnly? ShiftEndTime { get; set; }
+  public decimal BreakHours { get; set; }
+}
+
+public class CreateShiftRequestDto
+{
+  public string? Name { get; set; }
+  public TimeOnly? ShiftStartTime { get; set; }
+  public TimeOnly? ShiftBreakTime { get; set; }
+  public TimeOnly? ShiftBreakEndTime { get; set; }
+  public TimeOnly? ShiftEndTime { get; set; }
+  public decimal BreakHours { get; set; }
+}
+
+public class UpdateShiftRequestDto
+{
+  public Guid ShiftId { get; set; }
+  public Guid Id { get; set; }
+  public string? Name { get; set; }
+  public TimeOnly? ShiftStartTime { get; set; }
+  public TimeOnly? ShiftBreakTime { get; set; }
+  public TimeOnly? ShiftBreakEndTime { get; set; }
+  public TimeOnly? ShiftEndTime { get; set; }
+  public decimal BreakHours { get; set; }
+
+  public static string BuildRoute(Guid shiftId) => $"Shifts/{shiftId}";
+}
+
+public class UpdateShiftResponseDto
+{
+  public ShiftDto? Shift { get; set; }
+}

--- a/src/Bluewater.App/Models/ShiftSummary.cs
+++ b/src/Bluewater.App/Models/ShiftSummary.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Bluewater.App.Models;
+
+public class ShiftSummary
+{
+  public Guid Id { get; set; }
+  public string Name { get; set; } = string.Empty;
+  public string? ShiftStartTime { get; set; }
+  public string? ShiftBreakTime { get; set; }
+  public string? ShiftBreakEndTime { get; set; }
+  public string? ShiftEndTime { get; set; }
+  public decimal BreakHours { get; set; }
+
+  public string BreakHoursDisplay => BreakHours.ToString("0.##");
+}

--- a/src/Bluewater.App/Services/ApiClient.cs
+++ b/src/Bluewater.App/Services/ApiClient.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
 using System.Text.Json;
 using Bluewater.App.Interfaces;
 
@@ -34,6 +35,51 @@ public class ApiClient(HttpClient httpClient) : IApiClient
     return await JsonSerializer.DeserializeAsync<T>(contentStream, JsonOptions, cancellationToken);
   }
 
+  public async Task<TResponse?> PostAsync<TRequest, TResponse>(
+    string requestUri,
+    TRequest request,
+    CancellationToken cancellationToken = default)
+  {
+    using HttpContent content = CreateJsonContent(request);
+    using var message = new HttpRequestMessage(HttpMethod.Post, requestUri) { Content = content };
+    return await SendAsync<TResponse>(message, cancellationToken);
+  }
+
+  public async Task<TResponse?> PutAsync<TRequest, TResponse>(
+    string requestUri,
+    TRequest request,
+    CancellationToken cancellationToken = default)
+  {
+    using HttpContent content = CreateJsonContent(request);
+    using var message = new HttpRequestMessage(HttpMethod.Put, requestUri) { Content = content };
+    return await SendAsync<TResponse>(message, cancellationToken);
+  }
+
+  private async Task<T?> SendAsync<T>(HttpRequestMessage message, CancellationToken cancellationToken)
+  {
+    using HttpResponseMessage response = await httpClient.SendAsync(message, cancellationToken);
+
+    if (response.StatusCode == HttpStatusCode.NotFound)
+    {
+      return default;
+    }
+
+    if (response.StatusCode == HttpStatusCode.NoContent)
+    {
+      return default;
+    }
+
+    response.EnsureSuccessStatusCode();
+
+    if (IsContentEmpty(response.Content.Headers))
+    {
+      return default;
+    }
+
+    await using Stream contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+    return await JsonSerializer.DeserializeAsync<T>(contentStream, JsonOptions, cancellationToken);
+  }
+
   private static bool IsContentEmpty(HttpContentHeaders headers)
   {
     if (headers?.ContentLength.HasValue == true && headers.ContentLength.Value == 0)
@@ -42,5 +88,11 @@ public class ApiClient(HttpClient httpClient) : IApiClient
     }
 
     return false;
+  }
+
+  private static HttpContent CreateJsonContent<T>(T value)
+  {
+    string json = JsonSerializer.Serialize(value, JsonOptions);
+    return new StringContent(json, Encoding.UTF8, "application/json");
   }
 }

--- a/src/Bluewater.App/Services/ShiftApiService.cs
+++ b/src/Bluewater.App/Services/ShiftApiService.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Bluewater.App.Interfaces;
+using Bluewater.App.Models;
+
+namespace Bluewater.App.Services;
+
+public class ShiftApiService(IApiClient apiClient) : IShiftApiService
+{
+  public async Task<IReadOnlyList<ShiftSummary>> GetShiftsAsync(CancellationToken cancellationToken = default)
+  {
+    ShiftListResponseDto? response = await apiClient.GetAsync<ShiftListResponseDto>("Shifts", cancellationToken);
+
+    if (response?.Shifts is not { Count: > 0 })
+    {
+      return Array.Empty<ShiftSummary>();
+    }
+
+    return response.Shifts
+      .Where(shift => shift is not null)
+      .Select(MapToSummary)
+      .ToList();
+  }
+
+  public async Task<ShiftSummary?> CreateShiftAsync(ShiftSummary shift, CancellationToken cancellationToken = default)
+  {
+    CreateShiftRequestDto request = new()
+    {
+      Name = shift.Name,
+      ShiftStartTime = ParseTimeOrNull(shift.ShiftStartTime),
+      ShiftBreakTime = ParseTimeOrNull(shift.ShiftBreakTime),
+      ShiftBreakEndTime = ParseTimeOrNull(shift.ShiftBreakEndTime),
+      ShiftEndTime = ParseTimeOrNull(shift.ShiftEndTime),
+      BreakHours = shift.BreakHours
+    };
+
+    ShiftDto? response = await apiClient.PostAsync<CreateShiftRequestDto, ShiftDto>("Shifts", request, cancellationToken);
+
+    return response is null ? null : MapToSummary(response);
+  }
+
+  public async Task<ShiftSummary?> UpdateShiftAsync(ShiftSummary shift, CancellationToken cancellationToken = default)
+  {
+    UpdateShiftRequestDto request = new()
+    {
+      ShiftId = shift.Id,
+      Id = shift.Id,
+      Name = shift.Name,
+      ShiftStartTime = ParseTimeOrNull(shift.ShiftStartTime),
+      ShiftBreakTime = ParseTimeOrNull(shift.ShiftBreakTime),
+      ShiftBreakEndTime = ParseTimeOrNull(shift.ShiftBreakEndTime),
+      ShiftEndTime = ParseTimeOrNull(shift.ShiftEndTime),
+      BreakHours = shift.BreakHours
+    };
+
+    UpdateShiftResponseDto? response = await apiClient.PutAsync<UpdateShiftRequestDto, UpdateShiftResponseDto>(
+      UpdateShiftRequestDto.BuildRoute(shift.Id),
+      request,
+      cancellationToken);
+
+    return response?.Shift is null ? null : MapToSummary(response.Shift);
+  }
+
+  private static ShiftSummary MapToSummary(ShiftDto dto)
+  {
+    return new ShiftSummary
+    {
+      Id = dto.Id,
+      Name = dto.Name,
+      ShiftStartTime = FormatTime(dto.ShiftStartTime),
+      ShiftBreakTime = FormatTime(dto.ShiftBreakTime),
+      ShiftBreakEndTime = FormatTime(dto.ShiftBreakEndTime),
+      ShiftEndTime = FormatTime(dto.ShiftEndTime),
+      BreakHours = dto.BreakHours
+    };
+  }
+
+  private static string? FormatTime(TimeOnly? time)
+  {
+    return time?.ToString("HH:mm");
+  }
+
+  private static TimeOnly? ParseTimeOrNull(string? value)
+  {
+    if (string.IsNullOrWhiteSpace(value))
+    {
+      return null;
+    }
+
+    return TimeOnly.TryParse(value, out TimeOnly parsed) ? parsed : null;
+  }
+}

--- a/src/Bluewater.App/ViewModels/ShiftsViewModel.cs
+++ b/src/Bluewater.App/ViewModels/ShiftsViewModel.cs
@@ -1,7 +1,182 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+using Bluewater.App.Interfaces;
+using Bluewater.App.Models;
 using Bluewater.App.ViewModels.Base;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 
 namespace Bluewater.App.ViewModels;
 
 public partial class ShiftsViewModel : BaseViewModel
 {
+  private readonly IShiftApiService shiftApiService;
+  private bool hasInitialized;
+
+  public ShiftsViewModel(IShiftApiService shiftApiService)
+  {
+    this.shiftApiService = shiftApiService;
+  }
+
+  public ObservableCollection<ShiftSummary> Shifts { get; } = new();
+
+  [ObservableProperty]
+  private ShiftSummary? selectedShift;
+
+  public bool CanSaveSelectedShift => SelectedShift is not null && SelectedShift.Id == Guid.Empty;
+
+  public bool CanUpdateSelectedShift => SelectedShift is not null && SelectedShift.Id != Guid.Empty;
+
+  public override async Task InitializeAsync()
+  {
+    if (IsBusy || hasInitialized)
+    {
+      return;
+    }
+
+    await LoadShiftsAsync();
+  }
+
+  [RelayCommand]
+  private void AddShift()
+  {
+    var newShift = new ShiftSummary
+    {
+      Id = Guid.Empty,
+      Name = string.Empty,
+      ShiftStartTime = string.Empty,
+      ShiftBreakTime = string.Empty,
+      ShiftBreakEndTime = string.Empty,
+      ShiftEndTime = string.Empty,
+      BreakHours = 0m
+    };
+
+    Shifts.Add(newShift);
+    SelectedShift = newShift;
+  }
+
+  [RelayCommand(CanExecute = nameof(CanSaveSelectedShift))]
+  private async Task SaveShiftAsync()
+  {
+    if (SelectedShift is null)
+    {
+      return;
+    }
+
+    await PersistShiftAsync(SelectedShift, isNew: true);
+  }
+
+  [RelayCommand(CanExecute = nameof(CanUpdateSelectedShift))]
+  private async Task UpdateShiftAsync()
+  {
+    if (SelectedShift is null)
+    {
+      return;
+    }
+
+    await PersistShiftAsync(SelectedShift, isNew: false);
+  }
+
+  private async Task PersistShiftAsync(ShiftSummary shift, bool isNew)
+  {
+    if (IsBusy)
+    {
+      return;
+    }
+
+    try
+    {
+      IsBusy = true;
+
+      ShiftSummary? result = isNew
+        ? await shiftApiService.CreateShiftAsync(shift)
+        : await shiftApiService.UpdateShiftAsync(shift);
+
+      if (result is null)
+      {
+        return;
+      }
+
+      int index = Shifts.IndexOf(shift);
+
+      if (index >= 0)
+      {
+        Shifts[index] = result;
+        SelectedShift = result;
+      }
+      else
+      {
+        Shifts.Add(result);
+        SelectedShift = result;
+      }
+
+      hasInitialized = false;
+      await LoadShiftsAsync(result.Id);
+    }
+    catch (Exception ex)
+    {
+      Debug.WriteLine($"Failed to persist shift: {ex.Message}");
+    }
+    finally
+    {
+      IsBusy = false;
+      OnPropertyChanged(nameof(CanSaveSelectedShift));
+      OnPropertyChanged(nameof(CanUpdateSelectedShift));
+      SaveShiftCommand.NotifyCanExecuteChanged();
+      UpdateShiftCommand.NotifyCanExecuteChanged();
+    }
+  }
+
+  private async Task LoadShiftsAsync(Guid? preferredShiftId = null)
+  {
+    try
+    {
+      IsBusy = true;
+      Guid? targetShiftId = preferredShiftId ?? SelectedShift?.Id;
+      SelectedShift = null;
+      Shifts.Clear();
+
+      IReadOnlyList<ShiftSummary> shifts = await shiftApiService.GetShiftsAsync();
+
+      foreach (ShiftSummary shift in shifts.OrderBy(s => s.Name, StringComparer.OrdinalIgnoreCase))
+      {
+        Shifts.Add(shift);
+      }
+
+      hasInitialized = true;
+
+      if (targetShiftId.HasValue)
+      {
+        ShiftSummary? matchingShift = Shifts.FirstOrDefault(s => s.Id == targetShiftId.Value);
+        SelectedShift = matchingShift ?? (Shifts.Count > 0 ? Shifts[0] : null);
+      }
+      else
+      {
+        SelectedShift = Shifts.Count > 0 ? Shifts[0] : null;
+      }
+    }
+    catch (Exception ex)
+    {
+      Debug.WriteLine($"Failed to load shifts: {ex.Message}");
+    }
+    finally
+    {
+      IsBusy = false;
+      OnPropertyChanged(nameof(CanSaveSelectedShift));
+      OnPropertyChanged(nameof(CanUpdateSelectedShift));
+      SaveShiftCommand.NotifyCanExecuteChanged();
+      UpdateShiftCommand.NotifyCanExecuteChanged();
+    }
+  }
+
+  partial void OnSelectedShiftChanged(ShiftSummary? value)
+  {
+    OnPropertyChanged(nameof(CanSaveSelectedShift));
+    OnPropertyChanged(nameof(CanUpdateSelectedShift));
+    SaveShiftCommand.NotifyCanExecuteChanged();
+    UpdateShiftCommand.NotifyCanExecuteChanged();
+  }
 }

--- a/src/Bluewater.App/Views/ShiftsPage.xaml
+++ b/src/Bluewater.App/Views/ShiftsPage.xaml
@@ -1,12 +1,102 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:models="clr-namespace:Bluewater.App.Models"
              x:Class="Bluewater.App.Views.ShiftsPage"
-             Title="ShiftsPage">
-    <VerticalStackLayout>
-        <Label 
-            Text="Welcome to .NET MAUI!"
-            VerticalOptions="Center" 
-            HorizontalOptions="Center" />
-    </VerticalStackLayout>
+             Title="Shifts">
+  <Grid Padding="16" RowDefinitions="Auto,Auto,*" RowSpacing="16">
+    <Label Text="Shifts"
+           FontAttributes="Bold"
+           FontSize="24" />
+
+    <HorizontalStackLayout Grid.Row="1" Spacing="12">
+      <Button Text="Add"
+              Command="{Binding AddShiftCommand}" />
+      <Button Text="Save"
+              Command="{Binding SaveShiftCommand}"
+              IsEnabled="{Binding CanSaveSelectedShift}" />
+      <Button Text="Update"
+              Command="{Binding UpdateShiftCommand}"
+              IsEnabled="{Binding CanUpdateSelectedShift}" />
+    </HorizontalStackLayout>
+
+    <Grid Grid.Row="2">
+      <CollectionView ItemsSource="{Binding Shifts}"
+                      SelectedItem="{Binding SelectedShift}"
+                      SelectionMode="Single"
+                      VerticalOptions="FillAndExpand">
+        <CollectionView.EmptyView>
+          <VerticalStackLayout HorizontalOptions="Center"
+                               VerticalOptions="Center"
+                               Spacing="8">
+            <Label Text="No shifts found" />
+            <Label Text="Shifts will appear here once they are available."
+                   FontSize="12" />
+          </VerticalStackLayout>
+        </CollectionView.EmptyView>
+        <CollectionView.ItemTemplate>
+          <DataTemplate x:DataType="models:ShiftSummary">
+            <Border StrokeThickness="1"
+                    Padding="12"
+                    Margin="0,0,0,12">
+              <Border.StrokeShape>
+                <RoundRectangle CornerRadius="12" />
+              </Border.StrokeShape>
+              <Grid ColumnDefinitions="*,Auto"
+                    RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto"
+                    RowSpacing="8">
+                <Entry Grid.ColumnSpan="2"
+                       Placeholder="Shift name"
+                       Text="{Binding Name}" />
+
+                <Label Grid.Row="1"
+                       Text="Start"
+                       VerticalOptions="Center" />
+                <Entry Grid.Row="1"
+                       Grid.Column="1"
+                       Placeholder="HH:mm"
+                       Text="{Binding ShiftStartTime}" />
+
+                <Label Grid.Row="2"
+                       Text="Break Start"
+                       VerticalOptions="Center" />
+                <Entry Grid.Row="2"
+                       Grid.Column="1"
+                       Placeholder="HH:mm"
+                       Text="{Binding ShiftBreakTime}" />
+
+                <Label Grid.Row="3"
+                       Text="Break End"
+                       VerticalOptions="Center" />
+                <Entry Grid.Row="3"
+                       Grid.Column="1"
+                       Placeholder="HH:mm"
+                       Text="{Binding ShiftBreakEndTime}" />
+
+                <Label Grid.Row="4"
+                       Text="End"
+                       VerticalOptions="Center" />
+                <Entry Grid.Row="4"
+                       Grid.Column="1"
+                       Placeholder="HH:mm"
+                       Text="{Binding ShiftEndTime}" />
+
+                <Label Grid.Row="5"
+                       Text="Break Hours"
+                       VerticalOptions="Center" />
+                <Label Grid.Row="5"
+                       Grid.Column="1"
+                       Text="{Binding BreakHoursDisplay}" />
+              </Grid>
+            </Border>
+          </DataTemplate>
+        </CollectionView.ItemTemplate>
+      </CollectionView>
+
+      <ActivityIndicator IsRunning="{Binding IsBusy}"
+                         IsVisible="{Binding IsBusy}"
+                         HorizontalOptions="Center"
+                         VerticalOptions="Center" />
+    </Grid>
+  </Grid>
 </ContentPage>

--- a/src/Bluewater.App/Views/ShiftsPage.xaml.cs
+++ b/src/Bluewater.App/Views/ShiftsPage.xaml.cs
@@ -9,4 +9,14 @@ public partial class ShiftsPage : ContentPage
     InitializeComponent();
     BindingContext = vm;
   }
+
+  protected override async void OnAppearing()
+  {
+    base.OnAppearing();
+
+    if (BindingContext is ShiftsViewModel viewModel)
+    {
+      await viewModel.InitializeAsync();
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add DTOs and a shift API service to communicate with the Bluewater.Web shift endpoints
- update the shifts view model to load data, manage selection, and expose add/save/update commands
- redesign the shifts page to show editable shift times along with add/save/update controls

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dae65f41988329962812d3c8ad323d