### PR TITLE
Add CRUD services for organizational entities

### DIFF
--- a/src/Bluewater.App/Interfaces/IApiClient.cs
+++ b/src/Bluewater.App/Interfaces/IApiClient.cs
@@ -11,4 +11,5 @@ public interface IApiClient
     string requestUri,
     TRequest request,
     CancellationToken cancellationToken = default);
+  Task<bool> DeleteAsync(string requestUri, CancellationToken cancellationToken = default);
 }

--- a/src/Bluewater.App/Interfaces/IChargingApiService.cs
+++ b/src/Bluewater.App/Interfaces/IChargingApiService.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using Bluewater.App.Models;
+
+namespace Bluewater.App.Interfaces;
+
+public interface IChargingApiService
+{
+  Task<IReadOnlyList<ChargingSummary>> GetChargingsAsync(
+    int? skip = null,
+    int? take = null,
+    CancellationToken cancellationToken = default);
+
+  Task<ChargingSummary?> GetChargingByIdAsync(Guid chargingId, CancellationToken cancellationToken = default);
+
+  Task<ChargingSummary?> CreateChargingAsync(ChargingSummary charging, CancellationToken cancellationToken = default);
+
+  Task<ChargingSummary?> UpdateChargingAsync(ChargingSummary charging, CancellationToken cancellationToken = default);
+
+  Task<bool> DeleteChargingAsync(Guid chargingId, CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.App/Interfaces/IDepartmentApiService.cs
+++ b/src/Bluewater.App/Interfaces/IDepartmentApiService.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using Bluewater.App.Models;
+
+namespace Bluewater.App.Interfaces;
+
+public interface IDepartmentApiService
+{
+  Task<IReadOnlyList<DepartmentSummary>> GetDepartmentsAsync(
+    int? skip = null,
+    int? take = null,
+    CancellationToken cancellationToken = default);
+
+  Task<DepartmentSummary?> GetDepartmentByIdAsync(Guid departmentId, CancellationToken cancellationToken = default);
+
+  Task<DepartmentSummary?> CreateDepartmentAsync(DepartmentSummary department, CancellationToken cancellationToken = default);
+
+  Task<DepartmentSummary?> UpdateDepartmentAsync(DepartmentSummary department, CancellationToken cancellationToken = default);
+
+  Task<bool> DeleteDepartmentAsync(Guid departmentId, CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.App/Interfaces/IDivisionApiService.cs
+++ b/src/Bluewater.App/Interfaces/IDivisionApiService.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using Bluewater.App.Models;
+
+namespace Bluewater.App.Interfaces;
+
+public interface IDivisionApiService
+{
+  Task<IReadOnlyList<DivisionSummary>> GetDivisionsAsync(
+    int? skip = null,
+    int? take = null,
+    CancellationToken cancellationToken = default);
+
+  Task<DivisionSummary?> GetDivisionByIdAsync(Guid divisionId, CancellationToken cancellationToken = default);
+
+  Task<DivisionSummary?> CreateDivisionAsync(DivisionSummary division, CancellationToken cancellationToken = default);
+
+  Task<DivisionSummary?> UpdateDivisionAsync(DivisionSummary division, CancellationToken cancellationToken = default);
+
+  Task<bool> DeleteDivisionAsync(Guid divisionId, CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.App/Interfaces/IPositionApiService.cs
+++ b/src/Bluewater.App/Interfaces/IPositionApiService.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using Bluewater.App.Models;
+
+namespace Bluewater.App.Interfaces;
+
+public interface IPositionApiService
+{
+  Task<IReadOnlyList<PositionSummary>> GetPositionsAsync(
+    int? skip = null,
+    int? take = null,
+    CancellationToken cancellationToken = default);
+
+  Task<PositionSummary?> GetPositionByIdAsync(Guid positionId, CancellationToken cancellationToken = default);
+
+  Task<PositionSummary?> CreatePositionAsync(PositionSummary position, CancellationToken cancellationToken = default);
+
+  Task<PositionSummary?> UpdatePositionAsync(PositionSummary position, CancellationToken cancellationToken = default);
+
+  Task<bool> DeletePositionAsync(Guid positionId, CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.App/Interfaces/ISectionApiService.cs
+++ b/src/Bluewater.App/Interfaces/ISectionApiService.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using Bluewater.App.Models;
+
+namespace Bluewater.App.Interfaces;
+
+public interface ISectionApiService
+{
+  Task<IReadOnlyList<SectionSummary>> GetSectionsAsync(
+    int? skip = null,
+    int? take = null,
+    CancellationToken cancellationToken = default);
+
+  Task<SectionSummary?> GetSectionByIdAsync(Guid sectionId, CancellationToken cancellationToken = default);
+
+  Task<SectionSummary?> CreateSectionAsync(SectionSummary section, CancellationToken cancellationToken = default);
+
+  Task<SectionSummary?> UpdateSectionAsync(SectionSummary section, CancellationToken cancellationToken = default);
+
+  Task<bool> DeleteSectionAsync(Guid sectionId, CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.App/MauiProgram.cs
+++ b/src/Bluewater.App/MauiProgram.cs
@@ -56,6 +56,11 @@ public static class MauiProgram
     builder.Services.AddSingleton<IApiClient, ApiClient>();
     builder.Services.AddSingleton<IEmployeeApiService, EmployeeApiService>();
     builder.Services.AddSingleton<IShiftApiService, ShiftApiService>();
+    builder.Services.AddSingleton<IDepartmentApiService, DepartmentApiService>();
+    builder.Services.AddSingleton<IDivisionApiService, DivisionApiService>();
+    builder.Services.AddSingleton<IPositionApiService, PositionApiService>();
+    builder.Services.AddSingleton<ISectionApiService, SectionApiService>();
+    builder.Services.AddSingleton<IChargingApiService, ChargingApiService>();
 
     // pages
     builder.Services.AddSingleton<AttendancePage>();

--- a/src/Bluewater.App/Models/ChargingDtos.cs
+++ b/src/Bluewater.App/Models/ChargingDtos.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+
+namespace Bluewater.App.Models;
+
+public class ChargingListResponseDto
+{
+  public List<ChargingDto?> Chargings { get; set; } = new();
+}
+
+public class ChargingDto
+{
+  public Guid Id { get; set; }
+  public string Name { get; set; } = string.Empty;
+  public string? Description { get; set; }
+  public Guid? DepartmentId { get; set; }
+}
+
+public class CreateChargingRequestDto
+{
+  public const string Route = "Chargings";
+
+  public string? Name { get; set; }
+  public string? Description { get; set; }
+  public Guid? DepartmentId { get; set; }
+}
+
+public class UpdateChargingRequestDto
+{
+  public const string Route = "Chargings";
+
+  public Guid Id { get; set; }
+  public string? Name { get; set; }
+  public string? Description { get; set; }
+  public Guid? DepartmentId { get; set; }
+}
+
+public class UpdateChargingResponseDto
+{
+  public ChargingDto? Charging { get; set; }
+}

--- a/src/Bluewater.App/Models/ChargingSummary.cs
+++ b/src/Bluewater.App/Models/ChargingSummary.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Bluewater.App.Models;
+
+public class ChargingSummary
+{
+  public Guid Id { get; set; }
+  public string Name { get; set; } = string.Empty;
+  public string? Description { get; set; }
+  public Guid? DepartmentId { get; set; }
+}

--- a/src/Bluewater.App/Models/DepartmentDtos.cs
+++ b/src/Bluewater.App/Models/DepartmentDtos.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+
+namespace Bluewater.App.Models;
+
+public class DepartmentListResponseDto
+{
+  public List<DepartmentDto?> Departments { get; set; } = new();
+}
+
+public class DepartmentDto
+{
+  public Guid Id { get; set; }
+  public string Name { get; set; } = string.Empty;
+  public string? Description { get; set; }
+  public Guid DivisionId { get; set; }
+}
+
+public class CreateDepartmentRequestDto
+{
+  public string? Name { get; set; }
+  public string? Description { get; set; }
+  public Guid DivisionId { get; set; }
+}
+
+public class UpdateDepartmentRequestDto
+{
+  public Guid DepartmentId { get; set; }
+  public Guid Id { get; set; }
+  public string? Name { get; set; }
+  public string? Description { get; set; }
+  public Guid DivisionId { get; set; }
+
+  public static string BuildRoute(Guid departmentId) => $"Departments/{departmentId}";
+}
+
+public class UpdateDepartmentResponseDto
+{
+  public DepartmentDto? Department { get; set; }
+}

--- a/src/Bluewater.App/Models/DepartmentSummary.cs
+++ b/src/Bluewater.App/Models/DepartmentSummary.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Bluewater.App.Models;
+
+public class DepartmentSummary
+{
+  public Guid Id { get; set; }
+  public string Name { get; set; } = string.Empty;
+  public string? Description { get; set; }
+  public Guid DivisionId { get; set; }
+}

--- a/src/Bluewater.App/Models/DivisionDtos.cs
+++ b/src/Bluewater.App/Models/DivisionDtos.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+
+namespace Bluewater.App.Models;
+
+public class DivisionListResponseDto
+{
+  public List<DivisionDto?> Divisions { get; set; } = new();
+}
+
+public class DivisionDto
+{
+  public Guid Id { get; set; }
+  public string Name { get; set; } = string.Empty;
+  public string? Description { get; set; }
+}
+
+public class CreateDivisionRequestDto
+{
+  public string? Name { get; set; }
+  public string? Description { get; set; }
+}
+
+public class UpdateDivisionRequestDto
+{
+  public Guid DivisionId { get; set; }
+  public Guid Id { get; set; }
+  public string? Name { get; set; }
+  public string? Description { get; set; }
+
+  public static string BuildRoute(Guid divisionId) => $"Divisions/{divisionId}";
+}
+
+public class UpdateDivisionResponseDto
+{
+  public DivisionDto? Division { get; set; }
+}

--- a/src/Bluewater.App/Models/DivisionSummary.cs
+++ b/src/Bluewater.App/Models/DivisionSummary.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Bluewater.App.Models;
+
+public class DivisionSummary
+{
+  public Guid Id { get; set; }
+  public string Name { get; set; } = string.Empty;
+  public string? Description { get; set; }
+}

--- a/src/Bluewater.App/Models/PositionDtos.cs
+++ b/src/Bluewater.App/Models/PositionDtos.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+
+namespace Bluewater.App.Models;
+
+public class PositionListResponseDto
+{
+  public List<PositionDto?> Positions { get; set; } = new();
+}
+
+public class PositionDto
+{
+  public Guid Id { get; set; }
+  public string Name { get; set; } = string.Empty;
+  public string? Description { get; set; }
+  public Guid SectionId { get; set; }
+}
+
+public class CreatePositionRequestDto
+{
+  public string? Name { get; set; }
+  public string? Description { get; set; }
+  public Guid SectionId { get; set; }
+}
+
+public class UpdatePositionRequestDto
+{
+  public Guid PositionId { get; set; }
+  public Guid Id { get; set; }
+  public string? Name { get; set; }
+  public string? Description { get; set; }
+  public Guid SectionId { get; set; }
+
+  public static string BuildRoute(Guid positionId) => $"Positions/{positionId}";
+}
+
+public class UpdatePositionResponseDto
+{
+  public PositionDto? Position { get; set; }
+}

--- a/src/Bluewater.App/Models/PositionSummary.cs
+++ b/src/Bluewater.App/Models/PositionSummary.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Bluewater.App.Models;
+
+public class PositionSummary
+{
+  public Guid Id { get; set; }
+  public string Name { get; set; } = string.Empty;
+  public string? Description { get; set; }
+  public Guid SectionId { get; set; }
+}

--- a/src/Bluewater.App/Models/SectionDtos.cs
+++ b/src/Bluewater.App/Models/SectionDtos.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+
+namespace Bluewater.App.Models;
+
+public class SectionListResponseDto
+{
+  public List<SectionDto?> Sections { get; set; } = new();
+}
+
+public class SectionDto
+{
+  public Guid Id { get; set; }
+  public string Name { get; set; } = string.Empty;
+  public string? Description { get; set; }
+  public string? Approved1Id { get; set; }
+  public string? Approved2Id { get; set; }
+  public string? Approved3Id { get; set; }
+  public Guid DepartmentId { get; set; }
+}
+
+public class CreateSectionRequestDto
+{
+  public string? Name { get; set; }
+  public string? Description { get; set; }
+  public string? Approved1Id { get; set; }
+  public string? Approved2Id { get; set; }
+  public string? Approved3Id { get; set; }
+  public Guid DepartmentId { get; set; }
+}
+
+public class UpdateSectionRequestDto
+{
+  public Guid SectionId { get; set; }
+  public Guid Id { get; set; }
+  public string? Name { get; set; }
+  public string? Description { get; set; }
+  public string? Approved1Id { get; set; }
+  public string? Approved2Id { get; set; }
+  public string? Approved3Id { get; set; }
+  public Guid DepartmentId { get; set; }
+
+  public static string BuildRoute(Guid sectionId) => $"Sections/{sectionId}";
+}
+
+public class UpdateSectionResponseDto
+{
+  public SectionDto? Section { get; set; }
+}

--- a/src/Bluewater.App/Models/SectionSummary.cs
+++ b/src/Bluewater.App/Models/SectionSummary.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Bluewater.App.Models;
+
+public class SectionSummary
+{
+  public Guid Id { get; set; }
+  public string Name { get; set; } = string.Empty;
+  public string? Description { get; set; }
+  public string? Approved1Id { get; set; }
+  public string? Approved2Id { get; set; }
+  public string? Approved3Id { get; set; }
+  public Guid DepartmentId { get; set; }
+}

--- a/src/Bluewater.App/Services/ApiClient.cs
+++ b/src/Bluewater.App/Services/ApiClient.cs
@@ -55,6 +55,20 @@ public class ApiClient(HttpClient httpClient) : IApiClient
     return await SendAsync<TResponse>(message, cancellationToken);
   }
 
+  public async Task<bool> DeleteAsync(string requestUri, CancellationToken cancellationToken = default)
+  {
+    using var message = new HttpRequestMessage(HttpMethod.Delete, requestUri);
+    using HttpResponseMessage response = await httpClient.SendAsync(message, cancellationToken);
+
+    if (response.StatusCode == HttpStatusCode.NotFound)
+    {
+      return false;
+    }
+
+    response.EnsureSuccessStatusCode();
+    return true;
+  }
+
   private async Task<T?> SendAsync<T>(HttpRequestMessage message, CancellationToken cancellationToken)
   {
     using HttpResponseMessage response = await httpClient.SendAsync(message, cancellationToken);

--- a/src/Bluewater.App/Services/ChargingApiService.cs
+++ b/src/Bluewater.App/Services/ChargingApiService.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Bluewater.App.Interfaces;
+using Bluewater.App.Models;
+
+namespace Bluewater.App.Services;
+
+public class ChargingApiService(IApiClient apiClient) : IChargingApiService
+{
+  public async Task<IReadOnlyList<ChargingSummary>> GetChargingsAsync(
+    int? skip = null,
+    int? take = null,
+    CancellationToken cancellationToken = default)
+  {
+    string requestUri = BuildRequestUri(skip, take);
+
+    ChargingListResponseDto? response = await apiClient.GetAsync<ChargingListResponseDto>(requestUri, cancellationToken);
+
+    if (response?.Chargings is not { Count: > 0 })
+    {
+      return Array.Empty<ChargingSummary>();
+    }
+
+    return response.Chargings
+      .Where(dto => dto is not null)
+      .Select(MapToSummary)
+      .ToList();
+  }
+
+  public async Task<ChargingSummary?> GetChargingByIdAsync(Guid chargingId, CancellationToken cancellationToken = default)
+  {
+    if (chargingId == Guid.Empty)
+    {
+      throw new ArgumentException("Charging ID must be provided", nameof(chargingId));
+    }
+
+    ChargingDto? dto = await apiClient.GetAsync<ChargingDto>($"Chargings/{chargingId}", cancellationToken);
+    return dto is null ? null : MapToSummary(dto);
+  }
+
+  public async Task<ChargingSummary?> CreateChargingAsync(ChargingSummary charging, CancellationToken cancellationToken = default)
+  {
+    if (charging is null)
+    {
+      throw new ArgumentNullException(nameof(charging));
+    }
+
+    CreateChargingRequestDto request = new()
+    {
+      Name = charging.Name,
+      Description = charging.Description,
+      DepartmentId = charging.DepartmentId
+    };
+
+    ChargingDto? response = await apiClient.PostAsync<CreateChargingRequestDto, ChargingDto>(CreateChargingRequestDto.Route, request, cancellationToken);
+    return response is null ? null : MapToSummary(response);
+  }
+
+  public async Task<ChargingSummary?> UpdateChargingAsync(ChargingSummary charging, CancellationToken cancellationToken = default)
+  {
+    if (charging is null)
+    {
+      throw new ArgumentNullException(nameof(charging));
+    }
+
+    if (charging.Id == Guid.Empty)
+    {
+      throw new ArgumentException("Charging ID must be provided", nameof(charging));
+    }
+
+    UpdateChargingRequestDto request = new()
+    {
+      Id = charging.Id,
+      Name = charging.Name,
+      Description = charging.Description,
+      DepartmentId = charging.DepartmentId
+    };
+
+    UpdateChargingResponseDto? response = await apiClient.PutAsync<UpdateChargingRequestDto, UpdateChargingResponseDto>(
+      UpdateChargingRequestDto.Route,
+      request,
+      cancellationToken);
+
+    return response?.Charging is null ? null : MapToSummary(response.Charging);
+  }
+
+  public Task<bool> DeleteChargingAsync(Guid chargingId, CancellationToken cancellationToken = default)
+  {
+    if (chargingId == Guid.Empty)
+    {
+      throw new ArgumentException("Charging ID must be provided", nameof(chargingId));
+    }
+
+    return apiClient.DeleteAsync($"Chargings/{chargingId}", cancellationToken);
+  }
+
+  private static string BuildRequestUri(int? skip, int? take)
+  {
+    List<string> parameters = [];
+
+    if (skip.HasValue)
+    {
+      parameters.Add($"skip={skip.Value}");
+    }
+
+    if (take.HasValue)
+    {
+      parameters.Add($"take={take.Value}");
+    }
+
+    if (parameters.Count == 0)
+    {
+      return "Chargings";
+    }
+
+    string query = string.Join('&', parameters);
+    return $"Chargings?{query}";
+  }
+
+  private static ChargingSummary MapToSummary(ChargingDto dto)
+  {
+    return new ChargingSummary
+    {
+      Id = dto.Id,
+      Name = dto.Name,
+      Description = dto.Description,
+      DepartmentId = dto.DepartmentId
+    };
+  }
+}

--- a/src/Bluewater.App/Services/DepartmentApiService.cs
+++ b/src/Bluewater.App/Services/DepartmentApiService.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Bluewater.App.Interfaces;
+using Bluewater.App.Models;
+
+namespace Bluewater.App.Services;
+
+public class DepartmentApiService(IApiClient apiClient) : IDepartmentApiService
+{
+  public async Task<IReadOnlyList<DepartmentSummary>> GetDepartmentsAsync(
+    int? skip = null,
+    int? take = null,
+    CancellationToken cancellationToken = default)
+  {
+    string requestUri = BuildRequestUri(skip, take);
+
+    DepartmentListResponseDto? response = await apiClient.GetAsync<DepartmentListResponseDto>(requestUri, cancellationToken);
+
+    if (response?.Departments is not { Count: > 0 })
+    {
+      return Array.Empty<DepartmentSummary>();
+    }
+
+    return response.Departments
+      .Where(dto => dto is not null)
+      .Select(MapToSummary)
+      .ToList();
+  }
+
+  public async Task<DepartmentSummary?> GetDepartmentByIdAsync(Guid departmentId, CancellationToken cancellationToken = default)
+  {
+    if (departmentId == Guid.Empty)
+    {
+      throw new ArgumentException("Department ID must be provided", nameof(departmentId));
+    }
+
+    DepartmentDto? dto = await apiClient.GetAsync<DepartmentDto>($"Departments/{departmentId}", cancellationToken);
+    return dto is null ? null : MapToSummary(dto);
+  }
+
+  public async Task<DepartmentSummary?> CreateDepartmentAsync(DepartmentSummary department, CancellationToken cancellationToken = default)
+  {
+    if (department is null)
+    {
+      throw new ArgumentNullException(nameof(department));
+    }
+
+    CreateDepartmentRequestDto request = new()
+    {
+      Name = department.Name,
+      Description = department.Description,
+      DivisionId = department.DivisionId
+    };
+
+    DepartmentDto? response = await apiClient.PostAsync<CreateDepartmentRequestDto, DepartmentDto>("Departments", request, cancellationToken);
+
+    return response is null ? null : MapToSummary(response);
+  }
+
+  public async Task<DepartmentSummary?> UpdateDepartmentAsync(DepartmentSummary department, CancellationToken cancellationToken = default)
+  {
+    if (department is null)
+    {
+      throw new ArgumentNullException(nameof(department));
+    }
+
+    if (department.Id == Guid.Empty)
+    {
+      throw new ArgumentException("Department ID must be provided", nameof(department));
+    }
+
+    UpdateDepartmentRequestDto request = new()
+    {
+      DepartmentId = department.Id,
+      Id = department.Id,
+      Name = department.Name,
+      Description = department.Description,
+      DivisionId = department.DivisionId
+    };
+
+    UpdateDepartmentResponseDto? response = await apiClient.PutAsync<UpdateDepartmentRequestDto, UpdateDepartmentResponseDto>(
+      UpdateDepartmentRequestDto.BuildRoute(department.Id),
+      request,
+      cancellationToken);
+
+    return response?.Department is null ? null : MapToSummary(response.Department);
+  }
+
+  public Task<bool> DeleteDepartmentAsync(Guid departmentId, CancellationToken cancellationToken = default)
+  {
+    if (departmentId == Guid.Empty)
+    {
+      throw new ArgumentException("Department ID must be provided", nameof(departmentId));
+    }
+
+    return apiClient.DeleteAsync($"Departments/{departmentId}", cancellationToken);
+  }
+
+  private static string BuildRequestUri(int? skip, int? take)
+  {
+    List<string> parameters = [];
+
+    if (skip.HasValue)
+    {
+      parameters.Add($"skip={skip.Value}");
+    }
+
+    if (take.HasValue)
+    {
+      parameters.Add($"take={take.Value}");
+    }
+
+    if (parameters.Count == 0)
+    {
+      return "Departments";
+    }
+
+    string query = string.Join('&', parameters);
+    return $"Departments?{query}";
+  }
+
+  private static DepartmentSummary MapToSummary(DepartmentDto dto)
+  {
+    return new DepartmentSummary
+    {
+      Id = dto.Id,
+      Name = dto.Name,
+      Description = dto.Description,
+      DivisionId = dto.DivisionId
+    };
+  }
+}

--- a/src/Bluewater.App/Services/DivisionApiService.cs
+++ b/src/Bluewater.App/Services/DivisionApiService.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Bluewater.App.Interfaces;
+using Bluewater.App.Models;
+
+namespace Bluewater.App.Services;
+
+public class DivisionApiService(IApiClient apiClient) : IDivisionApiService
+{
+  public async Task<IReadOnlyList<DivisionSummary>> GetDivisionsAsync(
+    int? skip = null,
+    int? take = null,
+    CancellationToken cancellationToken = default)
+  {
+    string requestUri = BuildRequestUri(skip, take);
+
+    DivisionListResponseDto? response = await apiClient.GetAsync<DivisionListResponseDto>(requestUri, cancellationToken);
+
+    if (response?.Divisions is not { Count: > 0 })
+    {
+      return Array.Empty<DivisionSummary>();
+    }
+
+    return response.Divisions
+      .Where(dto => dto is not null)
+      .Select(MapToSummary)
+      .ToList();
+  }
+
+  public async Task<DivisionSummary?> GetDivisionByIdAsync(Guid divisionId, CancellationToken cancellationToken = default)
+  {
+    if (divisionId == Guid.Empty)
+    {
+      throw new ArgumentException("Division ID must be provided", nameof(divisionId));
+    }
+
+    DivisionDto? dto = await apiClient.GetAsync<DivisionDto>($"Divisions/{divisionId}", cancellationToken);
+    return dto is null ? null : MapToSummary(dto);
+  }
+
+  public async Task<DivisionSummary?> CreateDivisionAsync(DivisionSummary division, CancellationToken cancellationToken = default)
+  {
+    if (division is null)
+    {
+      throw new ArgumentNullException(nameof(division));
+    }
+
+    CreateDivisionRequestDto request = new()
+    {
+      Name = division.Name,
+      Description = division.Description
+    };
+
+    DivisionDto? response = await apiClient.PostAsync<CreateDivisionRequestDto, DivisionDto>("Divisions", request, cancellationToken);
+    return response is null ? null : MapToSummary(response);
+  }
+
+  public async Task<DivisionSummary?> UpdateDivisionAsync(DivisionSummary division, CancellationToken cancellationToken = default)
+  {
+    if (division is null)
+    {
+      throw new ArgumentNullException(nameof(division));
+    }
+
+    if (division.Id == Guid.Empty)
+    {
+      throw new ArgumentException("Division ID must be provided", nameof(division));
+    }
+
+    UpdateDivisionRequestDto request = new()
+    {
+      DivisionId = division.Id,
+      Id = division.Id,
+      Name = division.Name,
+      Description = division.Description
+    };
+
+    UpdateDivisionResponseDto? response = await apiClient.PutAsync<UpdateDivisionRequestDto, UpdateDivisionResponseDto>(
+      UpdateDivisionRequestDto.BuildRoute(division.Id),
+      request,
+      cancellationToken);
+
+    return response?.Division is null ? null : MapToSummary(response.Division);
+  }
+
+  public Task<bool> DeleteDivisionAsync(Guid divisionId, CancellationToken cancellationToken = default)
+  {
+    if (divisionId == Guid.Empty)
+    {
+      throw new ArgumentException("Division ID must be provided", nameof(divisionId));
+    }
+
+    return apiClient.DeleteAsync($"Divisions/{divisionId}", cancellationToken);
+  }
+
+  private static string BuildRequestUri(int? skip, int? take)
+  {
+    List<string> parameters = [];
+
+    if (skip.HasValue)
+    {
+      parameters.Add($"skip={skip.Value}");
+    }
+
+    if (take.HasValue)
+    {
+      parameters.Add($"take={take.Value}");
+    }
+
+    if (parameters.Count == 0)
+    {
+      return "Divisions";
+    }
+
+    string query = string.Join('&', parameters);
+    return $"Divisions?{query}";
+  }
+
+  private static DivisionSummary MapToSummary(DivisionDto dto)
+  {
+    return new DivisionSummary
+    {
+      Id = dto.Id,
+      Name = dto.Name,
+      Description = dto.Description
+    };
+  }
+}

--- a/src/Bluewater.App/Services/PositionApiService.cs
+++ b/src/Bluewater.App/Services/PositionApiService.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Bluewater.App.Interfaces;
+using Bluewater.App.Models;
+
+namespace Bluewater.App.Services;
+
+public class PositionApiService(IApiClient apiClient) : IPositionApiService
+{
+  public async Task<IReadOnlyList<PositionSummary>> GetPositionsAsync(
+    int? skip = null,
+    int? take = null,
+    CancellationToken cancellationToken = default)
+  {
+    string requestUri = BuildRequestUri(skip, take);
+
+    PositionListResponseDto? response = await apiClient.GetAsync<PositionListResponseDto>(requestUri, cancellationToken);
+
+    if (response?.Positions is not { Count: > 0 })
+    {
+      return Array.Empty<PositionSummary>();
+    }
+
+    return response.Positions
+      .Where(dto => dto is not null)
+      .Select(MapToSummary)
+      .ToList();
+  }
+
+  public async Task<PositionSummary?> GetPositionByIdAsync(Guid positionId, CancellationToken cancellationToken = default)
+  {
+    if (positionId == Guid.Empty)
+    {
+      throw new ArgumentException("Position ID must be provided", nameof(positionId));
+    }
+
+    PositionDto? dto = await apiClient.GetAsync<PositionDto>($"Positions/{positionId}", cancellationToken);
+    return dto is null ? null : MapToSummary(dto);
+  }
+
+  public async Task<PositionSummary?> CreatePositionAsync(PositionSummary position, CancellationToken cancellationToken = default)
+  {
+    if (position is null)
+    {
+      throw new ArgumentNullException(nameof(position));
+    }
+
+    CreatePositionRequestDto request = new()
+    {
+      Name = position.Name,
+      Description = position.Description,
+      SectionId = position.SectionId
+    };
+
+    PositionDto? response = await apiClient.PostAsync<CreatePositionRequestDto, PositionDto>("Positions", request, cancellationToken);
+    return response is null ? null : MapToSummary(response);
+  }
+
+  public async Task<PositionSummary?> UpdatePositionAsync(PositionSummary position, CancellationToken cancellationToken = default)
+  {
+    if (position is null)
+    {
+      throw new ArgumentNullException(nameof(position));
+    }
+
+    if (position.Id == Guid.Empty)
+    {
+      throw new ArgumentException("Position ID must be provided", nameof(position));
+    }
+
+    UpdatePositionRequestDto request = new()
+    {
+      PositionId = position.Id,
+      Id = position.Id,
+      Name = position.Name,
+      Description = position.Description,
+      SectionId = position.SectionId
+    };
+
+    UpdatePositionResponseDto? response = await apiClient.PutAsync<UpdatePositionRequestDto, UpdatePositionResponseDto>(
+      UpdatePositionRequestDto.BuildRoute(position.Id),
+      request,
+      cancellationToken);
+
+    return response?.Position is null ? null : MapToSummary(response.Position);
+  }
+
+  public Task<bool> DeletePositionAsync(Guid positionId, CancellationToken cancellationToken = default)
+  {
+    if (positionId == Guid.Empty)
+    {
+      throw new ArgumentException("Position ID must be provided", nameof(positionId));
+    }
+
+    return apiClient.DeleteAsync($"Positions/{positionId}", cancellationToken);
+  }
+
+  private static string BuildRequestUri(int? skip, int? take)
+  {
+    List<string> parameters = [];
+
+    if (skip.HasValue)
+    {
+      parameters.Add($"skip={skip.Value}");
+    }
+
+    if (take.HasValue)
+    {
+      parameters.Add($"take={take.Value}");
+    }
+
+    if (parameters.Count == 0)
+    {
+      return "Positions";
+    }
+
+    string query = string.Join('&', parameters);
+    return $"Positions?{query}";
+  }
+
+  private static PositionSummary MapToSummary(PositionDto dto)
+  {
+    return new PositionSummary
+    {
+      Id = dto.Id,
+      Name = dto.Name,
+      Description = dto.Description,
+      SectionId = dto.SectionId
+    };
+  }
+}

--- a/src/Bluewater.App/Services/SectionApiService.cs
+++ b/src/Bluewater.App/Services/SectionApiService.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Bluewater.App.Interfaces;
+using Bluewater.App.Models;
+
+namespace Bluewater.App.Services;
+
+public class SectionApiService(IApiClient apiClient) : ISectionApiService
+{
+  public async Task<IReadOnlyList<SectionSummary>> GetSectionsAsync(
+    int? skip = null,
+    int? take = null,
+    CancellationToken cancellationToken = default)
+  {
+    string requestUri = BuildRequestUri(skip, take);
+
+    SectionListResponseDto? response = await apiClient.GetAsync<SectionListResponseDto>(requestUri, cancellationToken);
+
+    if (response?.Sections is not { Count: > 0 })
+    {
+      return Array.Empty<SectionSummary>();
+    }
+
+    return response.Sections
+      .Where(dto => dto is not null)
+      .Select(MapToSummary)
+      .ToList();
+  }
+
+  public async Task<SectionSummary?> GetSectionByIdAsync(Guid sectionId, CancellationToken cancellationToken = default)
+  {
+    if (sectionId == Guid.Empty)
+    {
+      throw new ArgumentException("Section ID must be provided", nameof(sectionId));
+    }
+
+    SectionDto? dto = await apiClient.GetAsync<SectionDto>($"Sections/{sectionId}", cancellationToken);
+    return dto is null ? null : MapToSummary(dto);
+  }
+
+  public async Task<SectionSummary?> CreateSectionAsync(SectionSummary section, CancellationToken cancellationToken = default)
+  {
+    if (section is null)
+    {
+      throw new ArgumentNullException(nameof(section));
+    }
+
+    CreateSectionRequestDto request = new()
+    {
+      Name = section.Name,
+      Description = section.Description,
+      Approved1Id = section.Approved1Id,
+      Approved2Id = section.Approved2Id,
+      Approved3Id = section.Approved3Id,
+      DepartmentId = section.DepartmentId
+    };
+
+    SectionDto? response = await apiClient.PostAsync<CreateSectionRequestDto, SectionDto>("Sections", request, cancellationToken);
+    return response is null ? null : MapToSummary(response);
+  }
+
+  public async Task<SectionSummary?> UpdateSectionAsync(SectionSummary section, CancellationToken cancellationToken = default)
+  {
+    if (section is null)
+    {
+      throw new ArgumentNullException(nameof(section));
+    }
+
+    if (section.Id == Guid.Empty)
+    {
+      throw new ArgumentException("Section ID must be provided", nameof(section));
+    }
+
+    UpdateSectionRequestDto request = new()
+    {
+      SectionId = section.Id,
+      Id = section.Id,
+      Name = section.Name,
+      Description = section.Description,
+      Approved1Id = section.Approved1Id,
+      Approved2Id = section.Approved2Id,
+      Approved3Id = section.Approved3Id,
+      DepartmentId = section.DepartmentId
+    };
+
+    UpdateSectionResponseDto? response = await apiClient.PutAsync<UpdateSectionRequestDto, UpdateSectionResponseDto>(
+      UpdateSectionRequestDto.BuildRoute(section.Id),
+      request,
+      cancellationToken);
+
+    return response?.Section is null ? null : MapToSummary(response.Section);
+  }
+
+  public Task<bool> DeleteSectionAsync(Guid sectionId, CancellationToken cancellationToken = default)
+  {
+    if (sectionId == Guid.Empty)
+    {
+      throw new ArgumentException("Section ID must be provided", nameof(sectionId));
+    }
+
+    return apiClient.DeleteAsync($"Sections/{sectionId}", cancellationToken);
+  }
+
+  private static string BuildRequestUri(int? skip, int? take)
+  {
+    List<string> parameters = [];
+
+    if (skip.HasValue)
+    {
+      parameters.Add($"skip={skip.Value}");
+    }
+
+    if (take.HasValue)
+    {
+      parameters.Add($"take={take.Value}");
+    }
+
+    if (parameters.Count == 0)
+    {
+      return "Sections";
+    }
+
+    string query = string.Join('&', parameters);
+    return $"Sections?{query}";
+  }
+
+  private static SectionSummary MapToSummary(SectionDto dto)
+  {
+    return new SectionSummary
+    {
+      Id = dto.Id,
+      Name = dto.Name,
+      Description = dto.Description,
+      Approved1Id = dto.Approved1Id,
+      Approved2Id = dto.Approved2Id,
+      Approved3Id = dto.Approved3Id,
+      DepartmentId = dto.DepartmentId
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add DTOs and summaries for departments, divisions, positions, sections, and chargings in the MAUI app
- implement API services and interfaces that wrap the REST endpoints for full CRUD on the new organizational entities
- extend the shared API client with delete support and register the new services for dependency injection

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbccd53f988329a79310effee2bd67