### PR TITLE
Add CRUD services for leaves, attendances, payrolls, and schedules

### DIFF
--- a/src/Bluewater.App/Interfaces/IAttendanceApiService.cs
+++ b/src/Bluewater.App/Interfaces/IAttendanceApiService.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using Bluewater.App.Models;
+
+namespace Bluewater.App.Interfaces;
+
+public interface IAttendanceApiService
+{
+  Task<IReadOnlyList<AttendanceSummary>> GetAttendancesAsync(
+    Guid employeeId,
+    DateOnly startDate,
+    DateOnly endDate,
+    int? skip = null,
+    int? take = null,
+    CancellationToken cancellationToken = default);
+
+  Task<IReadOnlyList<EmployeeAttendanceSummary>> GetAttendanceSummariesAsync(
+    string charging,
+    DateOnly startDate,
+    DateOnly endDate,
+    int? skip = null,
+    int? take = null,
+    TenantDto tenant = TenantDto.Maribago,
+    CancellationToken cancellationToken = default);
+
+  Task<AttendanceSummary?> GetAttendanceByIdAsync(Guid attendanceId, CancellationToken cancellationToken = default);
+
+  Task<AttendanceSummary?> CreateAttendanceAsync(AttendanceSummary attendance, CancellationToken cancellationToken = default);
+
+  Task<AttendanceSummary?> UpdateAttendanceAsync(AttendanceSummary attendance, CancellationToken cancellationToken = default);
+
+  Task<bool> DeleteAttendanceAsync(Guid attendanceId, CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.App/Interfaces/ILeaveApiService.cs
+++ b/src/Bluewater.App/Interfaces/ILeaveApiService.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using Bluewater.App.Models;
+
+namespace Bluewater.App.Interfaces;
+
+public interface ILeaveApiService
+{
+  Task<IReadOnlyList<LeaveSummary>> GetLeavesAsync(
+    int? skip = null,
+    int? take = null,
+    TenantDto tenant = TenantDto.Maribago,
+    CancellationToken cancellationToken = default);
+
+  Task<LeaveSummary?> GetLeaveByIdAsync(Guid leaveId, CancellationToken cancellationToken = default);
+
+  Task<LeaveSummary?> CreateLeaveAsync(LeaveSummary leave, CancellationToken cancellationToken = default);
+
+  Task<LeaveSummary?> UpdateLeaveAsync(LeaveSummary leave, CancellationToken cancellationToken = default);
+
+  Task<bool> DeleteLeaveAsync(Guid leaveId, CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.App/Interfaces/IPayrollApiService.cs
+++ b/src/Bluewater.App/Interfaces/IPayrollApiService.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using Bluewater.App.Models;
+
+namespace Bluewater.App.Interfaces;
+
+public interface IPayrollApiService
+{
+  Task<IReadOnlyList<PayrollSummary>> GetPayrollsAsync(
+    DateOnly startDate,
+    DateOnly endDate,
+    string? chargingName = null,
+    int? skip = null,
+    int? take = null,
+    TenantDto tenant = TenantDto.Maribago,
+    CancellationToken cancellationToken = default);
+
+  Task<IReadOnlyList<PayrollGroupedSummary>> GetGroupedPayrollsAsync(
+    int? skip = null,
+    int? take = null,
+    CancellationToken cancellationToken = default);
+
+  Task<PayrollSummary?> GetPayrollByIdAsync(Guid payrollId, CancellationToken cancellationToken = default);
+
+  Task<Guid?> CreatePayrollAsync(PayrollSummary payroll, CancellationToken cancellationToken = default);
+
+  Task<PayrollSummary?> UpdatePayrollAsync(PayrollSummary payroll, CancellationToken cancellationToken = default);
+
+  Task<bool> DeletePayrollAsync(Guid payrollId, CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.App/Interfaces/IScheduleApiService.cs
+++ b/src/Bluewater.App/Interfaces/IScheduleApiService.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using Bluewater.App.Models;
+
+namespace Bluewater.App.Interfaces;
+
+public interface IScheduleApiService
+{
+  Task<IReadOnlyList<EmployeeScheduleSummary>> GetSchedulesAsync(
+    string chargingName,
+    DateOnly startDate,
+    DateOnly endDate,
+    int? skip = null,
+    int? take = null,
+    TenantDto tenant = TenantDto.Maribago,
+    CancellationToken cancellationToken = default);
+
+  Task<ScheduleSummary?> GetScheduleByIdAsync(Guid scheduleId, CancellationToken cancellationToken = default);
+
+  Task<Guid?> CreateScheduleAsync(ScheduleSummary schedule, CancellationToken cancellationToken = default);
+
+  Task<ScheduleSummary?> UpdateScheduleAsync(ScheduleSummary schedule, CancellationToken cancellationToken = default);
+
+  Task<bool> DeleteScheduleAsync(Guid scheduleId, CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.App/MauiProgram.cs
+++ b/src/Bluewater.App/MauiProgram.cs
@@ -61,6 +61,10 @@ public static class MauiProgram
     builder.Services.AddSingleton<IPositionApiService, PositionApiService>();
     builder.Services.AddSingleton<ISectionApiService, SectionApiService>();
     builder.Services.AddSingleton<IChargingApiService, ChargingApiService>();
+    builder.Services.AddSingleton<ILeaveApiService, LeaveApiService>();
+    builder.Services.AddSingleton<IAttendanceApiService, AttendanceApiService>();
+    builder.Services.AddSingleton<IPayrollApiService, PayrollApiService>();
+    builder.Services.AddSingleton<IScheduleApiService, ScheduleApiService>();
 
     // pages
     builder.Services.AddSingleton<AttendancePage>();

--- a/src/Bluewater.App/Models/ApplicationStatusDto.cs
+++ b/src/Bluewater.App/Models/ApplicationStatusDto.cs
@@ -1,0 +1,9 @@
+namespace Bluewater.App.Models;
+
+public enum ApplicationStatusDto
+{
+  NotSet = 0,
+  Pending,
+  Approved,
+  Rejected
+}

--- a/src/Bluewater.App/Models/AttendanceDtos.cs
+++ b/src/Bluewater.App/Models/AttendanceDtos.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+
+namespace Bluewater.App.Models;
+
+public class AttendanceListResponseDto
+{
+  public List<AttendanceDto?> Attendances { get; set; } = new();
+}
+
+public class AttendanceListAllResponseDto
+{
+  public List<EmployeeAttendanceDto?> Employees { get; set; } = new();
+}
+
+public class AttendanceDto
+{
+  public Guid Id { get; set; }
+  public Guid EmployeeId { get; set; }
+  public Guid? ShiftId { get; set; }
+  public Guid? TimesheetId { get; set; }
+  public Guid? LeaveId { get; set; }
+  public DateOnly? EntryDate { get; set; }
+  public decimal? WorkHrs { get; set; }
+  public decimal? LateHrs { get; set; }
+  public decimal? UnderHrs { get; set; }
+  public decimal? OverbreakHrs { get; set; }
+  public decimal? NightShiftHours { get; set; }
+  public bool IsLocked { get; set; }
+  public AttendanceShiftDto? Shift { get; set; }
+  public AttendanceTimesheetDto? Timesheet { get; set; }
+}
+
+public class AttendanceShiftDto
+{
+  public Guid Id { get; set; }
+  public string Name { get; set; } = string.Empty;
+  public TimeOnly? ShiftStartTime { get; set; }
+  public TimeOnly? ShiftBreakTime { get; set; }
+  public TimeOnly? ShiftBreakEndTime { get; set; }
+  public TimeOnly? ShiftEndTime { get; set; }
+  public decimal BreakHours { get; set; }
+}
+
+public class AttendanceTimesheetDto
+{
+  public Guid Id { get; set; }
+  public Guid EmployeeId { get; set; }
+  public DateTime? TimeIn1 { get; set; }
+  public DateTime? TimeOut1 { get; set; }
+  public DateTime? TimeIn2 { get; set; }
+  public DateTime? TimeOut2 { get; set; }
+  public DateOnly? EntryDate { get; set; }
+  public bool IsEdited { get; set; }
+}
+
+public class EmployeeAttendanceDto
+{
+  public Guid EmployeeId { get; set; }
+  public string Barcode { get; set; } = string.Empty;
+  public string Name { get; set; } = string.Empty;
+  public string? Department { get; set; }
+  public string? Section { get; set; }
+  public string? Charging { get; set; }
+  public List<AttendanceDto?> Attendances { get; set; } = new();
+  public decimal TotalWorkHrs { get; set; }
+  public int TotalAbsences { get; set; }
+  public decimal TotalLateHrs { get; set; }
+  public decimal TotalUnderHrs { get; set; }
+  public decimal TotalOverbreakHrs { get; set; }
+  public decimal TotalNightShiftHrs { get; set; }
+  public decimal TotalLeaves { get; set; }
+}
+
+public class AttendanceCreateRequestDto
+{
+  public const string Route = "Attendances";
+
+  public Guid EmployeeId { get; set; }
+  public Guid? ShiftId { get; set; }
+  public Guid? TimesheetId { get; set; }
+  public Guid? LeaveId { get; set; }
+  public DateOnly? EntryDate { get; set; }
+  public decimal? WorkHrs { get; set; }
+  public decimal? LateHrs { get; set; }
+  public decimal? UnderHrs { get; set; }
+  public decimal? OverbreakHrs { get; set; }
+  public decimal? NightShiftHrs { get; set; }
+  public bool IsLocked { get; set; }
+}
+
+public class AttendanceCreateResponseDto
+{
+  public AttendanceDto? Attendance { get; set; }
+}
+
+public class AttendanceUpdateRequestDto
+{
+  public const string Route = "Attendances";
+
+  public Guid EmployeeId { get; set; }
+  public DateOnly? EntryDate { get; set; }
+  public Guid? ShiftId { get; set; }
+  public Guid? TimesheetId { get; set; }
+  public Guid? LeaveId { get; set; }
+  public bool IsLocked { get; set; }
+}
+
+public class AttendanceUpdateResponseDto
+{
+  public AttendanceDto? Attendance { get; set; }
+}
+
+public static class AttendanceRequestRoutes
+{
+  public static string BuildGetRoute(Guid attendanceId) => $"Attendances/{attendanceId}";
+  public static string BuildDeleteRoute(Guid attendanceId) => $"Attendances/{attendanceId}";
+}
+
+public class AttendanceSummary
+{
+  public Guid Id { get; set; }
+  public Guid EmployeeId { get; set; }
+  public Guid? ShiftId { get; set; }
+  public Guid? TimesheetId { get; set; }
+  public Guid? LeaveId { get; set; }
+  public DateOnly? EntryDate { get; set; }
+  public decimal? WorkHours { get; set; }
+  public decimal? LateHours { get; set; }
+  public decimal? UnderHours { get; set; }
+  public decimal? OverbreakHours { get; set; }
+  public decimal? NightShiftHours { get; set; }
+  public bool IsLocked { get; set; }
+  public AttendanceShiftSummary? Shift { get; set; }
+  public AttendanceTimesheetSummary? Timesheet { get; set; }
+}
+
+public class AttendanceShiftSummary
+{
+  public Guid Id { get; set; }
+  public string Name { get; set; } = string.Empty;
+  public TimeOnly? ShiftStartTime { get; set; }
+  public TimeOnly? ShiftBreakTime { get; set; }
+  public TimeOnly? ShiftBreakEndTime { get; set; }
+  public TimeOnly? ShiftEndTime { get; set; }
+  public decimal BreakHours { get; set; }
+}
+
+public class AttendanceTimesheetSummary
+{
+  public Guid Id { get; set; }
+  public Guid EmployeeId { get; set; }
+  public DateTime? TimeIn1 { get; set; }
+  public DateTime? TimeOut1 { get; set; }
+  public DateTime? TimeIn2 { get; set; }
+  public DateTime? TimeOut2 { get; set; }
+  public DateOnly? EntryDate { get; set; }
+  public bool IsEdited { get; set; }
+}
+
+public class EmployeeAttendanceSummary
+{
+  public Guid EmployeeId { get; set; }
+  public string Barcode { get; set; } = string.Empty;
+  public string Name { get; set; } = string.Empty;
+  public string? Department { get; set; }
+  public string? Section { get; set; }
+  public string? Charging { get; set; }
+  public List<AttendanceSummary> Attendances { get; set; } = new();
+  public decimal TotalWorkHours { get; set; }
+  public int TotalAbsences { get; set; }
+  public decimal TotalLateHours { get; set; }
+  public decimal TotalUnderHours { get; set; }
+  public decimal TotalOverbreakHours { get; set; }
+  public decimal TotalNightShiftHours { get; set; }
+  public decimal TotalLeaves { get; set; }
+}

--- a/src/Bluewater.App/Models/LeaveDtos.cs
+++ b/src/Bluewater.App/Models/LeaveDtos.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+
+namespace Bluewater.App.Models;
+
+public class LeaveListResponseDto
+{
+  public List<LeaveDto?> Leaves { get; set; } = new();
+}
+
+public class LeaveDto
+{
+  public Guid Id { get; set; }
+  public DateTime? StartDate { get; set; }
+  public DateTime? EndDate { get; set; }
+  public bool IsHalfDay { get; set; }
+  public ApplicationStatusDto Status { get; set; } = ApplicationStatusDto.NotSet;
+  public Guid? EmployeeId { get; set; }
+  public Guid LeaveCreditId { get; set; }
+  public string EmployeeName { get; set; } = string.Empty;
+  public string LeaveCreditName { get; set; } = string.Empty;
+}
+
+public class CreateLeaveRequestDto
+{
+  public const string Route = "Leaves";
+
+  public DateTime? StartDate { get; set; }
+  public DateTime? EndDate { get; set; }
+  public bool IsHalfDay { get; set; }
+  public Guid EmployeeId { get; set; }
+  public Guid LeaveCreditId { get; set; }
+}
+
+public class CreateLeaveResponseDto
+{
+  public LeaveDto? Leave { get; set; }
+}
+
+public class UpdateLeaveRequestDto
+{
+  public Guid LeaveId { get; set; }
+  public Guid Id { get; set; }
+  public DateTime StartDate { get; set; }
+  public DateTime EndDate { get; set; }
+  public bool IsHalfDay { get; set; }
+  public ApplicationStatusDto Status { get; set; } = ApplicationStatusDto.NotSet;
+  public Guid EmployeeId { get; set; }
+  public Guid LeaveCreditId { get; set; }
+
+  public static string BuildRoute(Guid leaveId) => $"Leaves/{leaveId}";
+}
+
+public class UpdateLeaveResponseDto
+{
+  public LeaveDto? Leave { get; set; }
+}
+
+public class LeaveSummary
+{
+  public Guid Id { get; set; }
+  public DateTime? StartDate { get; set; }
+  public DateTime? EndDate { get; set; }
+  public bool IsHalfDay { get; set; }
+  public ApplicationStatusDto Status { get; set; } = ApplicationStatusDto.NotSet;
+  public Guid? EmployeeId { get; set; }
+  public Guid LeaveCreditId { get; set; }
+  public string EmployeeName { get; set; } = string.Empty;
+  public string LeaveCreditName { get; set; } = string.Empty;
+}

--- a/src/Bluewater.App/Models/PayrollDtos.cs
+++ b/src/Bluewater.App/Models/PayrollDtos.cs
@@ -1,0 +1,320 @@
+using System;
+using System.Collections.Generic;
+
+namespace Bluewater.App.Models;
+
+public class PayrollListResponseDto
+{
+  public List<PayrollDto?> Payrolls { get; set; } = new();
+}
+
+public class PayrollGroupedListResponseDto
+{
+  public List<PayrollSummaryDto?> Payrolls { get; set; } = new();
+}
+
+public class PayrollDto
+{
+  public Guid Id { get; set; }
+  public Guid? EmployeeId { get; set; }
+  public string? Name { get; set; }
+  public string? Barcode { get; set; }
+  public string? BankAccount { get; set; }
+  public DateOnly Date { get; set; }
+  public string? Division { get; set; }
+  public string? Department { get; set; }
+  public string? Section { get; set; }
+  public string? Position { get; set; }
+  public string? Charging { get; set; }
+  public decimal GrossPayAmount { get; set; }
+  public decimal NetAmount { get; set; }
+  public decimal BasicPayAmount { get; set; }
+  public decimal SssAmount { get; set; }
+  public decimal SssERAmount { get; set; }
+  public decimal PagibigAmount { get; set; }
+  public decimal PagibigERAmount { get; set; }
+  public decimal PhilhealthAmount { get; set; }
+  public decimal PhilhealthERAmount { get; set; }
+  public decimal RestDayAmount { get; set; }
+  public decimal RestDayHrs { get; set; }
+  public decimal RegularHolidayAmount { get; set; }
+  public decimal RegularHolidayHrs { get; set; }
+  public decimal SpecialHolidayAmount { get; set; }
+  public decimal SpecialHolidayHrs { get; set; }
+  public decimal OvertimeAmount { get; set; }
+  public decimal OvertimeHrs { get; set; }
+  public decimal NightDiffAmount { get; set; }
+  public decimal NightDiffHrs { get; set; }
+  public decimal NightDiffOvertimeAmount { get; set; }
+  public decimal NightDiffOvertimeHrs { get; set; }
+  public decimal NightDiffRegularHolidayAmount { get; set; }
+  public decimal NightDiffRegularHolidayHrs { get; set; }
+  public decimal NightDiffSpecialHolidayAmount { get; set; }
+  public decimal NightDiffSpecialHolidayHrs { get; set; }
+  public decimal OvertimeRestDayAmount { get; set; }
+  public decimal OvertimeRestDayHrs { get; set; }
+  public decimal OvertimeRegularHolidayAmount { get; set; }
+  public decimal OvertimeRegularHolidayHrs { get; set; }
+  public decimal OvertimeSpecialHolidayAmount { get; set; }
+  public decimal OvertimeSpecialHolidayHrs { get; set; }
+  public decimal UnionDues { get; set; }
+  public int Absences { get; set; }
+  public decimal AbsencesAmount { get; set; }
+  public decimal Leaves { get; set; }
+  public decimal LeavesAmount { get; set; }
+  public decimal Lates { get; set; }
+  public decimal LatesAmount { get; set; }
+  public decimal Undertime { get; set; }
+  public decimal UndertimeAmount { get; set; }
+  public decimal Overbreak { get; set; }
+  public decimal OverbreakAmount { get; set; }
+  public decimal SvcCharge { get; set; }
+  public decimal CostOfLivingAllowanceAmount { get; set; }
+  public decimal MonthlyAllowanceAmount { get; set; }
+  public decimal SalaryUnderpaymentAmount { get; set; }
+  public decimal RefundAbsencesAmount { get; set; }
+  public decimal RefundUndertimeAmount { get; set; }
+  public decimal RefundOvertimeAmount { get; set; }
+  public decimal LaborHoursIncome { get; set; }
+  public decimal LaborHrs { get; set; }
+  public decimal TaxDeductions { get; set; }
+  public decimal TotalConstantDeductions { get; set; }
+  public decimal TotalLoanDeductions { get; set; }
+  public decimal TotalDeductions { get; set; }
+}
+
+public class PayrollSummaryDto
+{
+  public DateOnly Date { get; set; }
+  public int Count { get; set; }
+  public decimal TotalServiceCharge { get; set; }
+  public int TotalAbsences { get; set; }
+  public decimal TotalLeaves { get; set; }
+  public decimal TotalLates { get; set; }
+  public decimal TotalUndertimes { get; set; }
+  public decimal TotalOverbreak { get; set; }
+  public decimal TotalTaxDeductions { get; set; }
+  public decimal TotalNetAmount { get; set; }
+}
+
+public class CreatePayrollRequestDto
+{
+  public const string Route = "Payrolls";
+
+  public Guid EmployeeId { get; set; }
+  public DateOnly Date { get; set; }
+  public decimal GrossPayAmount { get; set; }
+  public decimal NetAmount { get; set; }
+  public decimal BasicPayAmount { get; set; }
+  public decimal SssAmount { get; set; }
+  public decimal SssERAmount { get; set; }
+  public decimal PagibigAmount { get; set; }
+  public decimal PagibigERAmount { get; set; }
+  public decimal PhilhealthAmount { get; set; }
+  public decimal PhilhealthERAmount { get; set; }
+  public decimal RestDayAmount { get; set; }
+  public decimal RestDayHrs { get; set; }
+  public decimal RegularHolidayAmount { get; set; }
+  public decimal RegularHolidayHrs { get; set; }
+  public decimal SpecialHolidayAmount { get; set; }
+  public decimal SpecialHolidayHrs { get; set; }
+  public decimal OvertimeAmount { get; set; }
+  public decimal OvertimeHrs { get; set; }
+  public decimal NightDiffAmount { get; set; }
+  public decimal NightDiffHrs { get; set; }
+  public decimal NightDiffOvertimeAmount { get; set; }
+  public decimal NightDiffOvertimeHrs { get; set; }
+  public decimal NightDiffRegularHolidayAmount { get; set; }
+  public decimal NightDiffRegularHolidayHrs { get; set; }
+  public decimal NightDiffSpecialHolidayAmount { get; set; }
+  public decimal NightDiffSpecialHolidayHrs { get; set; }
+  public decimal OvertimeRestDayAmount { get; set; }
+  public decimal OvertimeRestDayHrs { get; set; }
+  public decimal OvertimeRegularHolidayAmount { get; set; }
+  public decimal OvertimeRegularHolidayHrs { get; set; }
+  public decimal OvertimeSpecialHolidayAmount { get; set; }
+  public decimal OvertimeSpecialHolidayHrs { get; set; }
+  public decimal UnionDues { get; set; }
+  public int Absences { get; set; }
+  public decimal AbsencesAmount { get; set; }
+  public decimal Leaves { get; set; }
+  public decimal LeavesAmount { get; set; }
+  public decimal Lates { get; set; }
+  public decimal LatesAmount { get; set; }
+  public decimal Undertime { get; set; }
+  public decimal UndertimeAmount { get; set; }
+  public decimal Overbreak { get; set; }
+  public decimal OverbreakAmount { get; set; }
+  public decimal SvcCharge { get; set; }
+  public decimal CostOfLivingAllowanceAmount { get; set; }
+  public decimal MonthlyAllowanceAmount { get; set; }
+  public decimal SalaryUnderpaymentAmount { get; set; }
+  public decimal RefundAbsencesAmount { get; set; }
+  public decimal RefundUndertimeAmount { get; set; }
+  public decimal RefundOvertimeAmount { get; set; }
+  public decimal LaborHoursIncome { get; set; }
+  public decimal LaborHrs { get; set; }
+  public decimal TaxDeductions { get; set; }
+  public decimal TotalConstantDeductions { get; set; }
+  public decimal TotalLoanDeductions { get; set; }
+  public decimal TotalDeductions { get; set; }
+}
+
+public class CreatePayrollResponseDto
+{
+  public Guid PayrollId { get; set; }
+}
+
+public class UpdatePayrollRequestDto
+{
+  public Guid PayrollId { get; set; }
+  public Guid Id { get; set; }
+  public Guid EmployeeId { get; set; }
+  public DateOnly Date { get; set; }
+  public decimal GrossPayAmount { get; set; }
+  public decimal NetAmount { get; set; }
+  public decimal BasicPayAmount { get; set; }
+  public decimal SssAmount { get; set; }
+  public decimal SssERAmount { get; set; }
+  public decimal PagibigAmount { get; set; }
+  public decimal PagibigERAmount { get; set; }
+  public decimal PhilhealthAmount { get; set; }
+  public decimal PhilhealthERAmount { get; set; }
+  public decimal RestDayAmount { get; set; }
+  public decimal RestDayHrs { get; set; }
+  public decimal RegularHolidayAmount { get; set; }
+  public decimal RegularHolidayHrs { get; set; }
+  public decimal SpecialHolidayAmount { get; set; }
+  public decimal SpecialHolidayHrs { get; set; }
+  public decimal OvertimeAmount { get; set; }
+  public decimal OvertimeHrs { get; set; }
+  public decimal NightDiffAmount { get; set; }
+  public decimal NightDiffHrs { get; set; }
+  public decimal NightDiffOvertimeAmount { get; set; }
+  public decimal NightDiffOvertimeHrs { get; set; }
+  public decimal NightDiffRegularHolidayAmount { get; set; }
+  public decimal NightDiffRegularHolidayHrs { get; set; }
+  public decimal NightDiffSpecialHolidayAmount { get; set; }
+  public decimal NightDiffSpecialHolidayHrs { get; set; }
+  public decimal OvertimeRestDayAmount { get; set; }
+  public decimal OvertimeRestDayHrs { get; set; }
+  public decimal OvertimeRegularHolidayAmount { get; set; }
+  public decimal OvertimeRegularHolidayHrs { get; set; }
+  public decimal OvertimeSpecialHolidayAmount { get; set; }
+  public decimal OvertimeSpecialHolidayHrs { get; set; }
+  public decimal UnionDues { get; set; }
+  public int Absences { get; set; }
+  public decimal AbsencesAmount { get; set; }
+  public decimal Leaves { get; set; }
+  public decimal LeavesAmount { get; set; }
+  public decimal Lates { get; set; }
+  public decimal LatesAmount { get; set; }
+  public decimal Undertime { get; set; }
+  public decimal UndertimeAmount { get; set; }
+  public decimal Overbreak { get; set; }
+  public decimal OverbreakAmount { get; set; }
+  public decimal SvcCharge { get; set; }
+  public decimal CostOfLivingAllowanceAmount { get; set; }
+  public decimal MonthlyAllowanceAmount { get; set; }
+  public decimal SalaryUnderpaymentAmount { get; set; }
+  public decimal RefundAbsencesAmount { get; set; }
+  public decimal RefundUndertimeAmount { get; set; }
+  public decimal RefundOvertimeAmount { get; set; }
+  public decimal LaborHoursIncome { get; set; }
+  public decimal LaborHrs { get; set; }
+  public decimal TaxDeductions { get; set; }
+  public decimal TotalConstantDeductions { get; set; }
+  public decimal TotalLoanDeductions { get; set; }
+  public decimal TotalDeductions { get; set; }
+
+  public static string BuildRoute(Guid payrollId) => $"Payrolls/{payrollId}";
+}
+
+public class UpdatePayrollResponseDto
+{
+  public PayrollDto? Payroll { get; set; }
+}
+
+public class PayrollSummary
+{
+  public Guid Id { get; set; }
+  public Guid? EmployeeId { get; set; }
+  public string? Name { get; set; }
+  public string? Barcode { get; set; }
+  public string? BankAccount { get; set; }
+  public DateOnly Date { get; set; }
+  public string? Division { get; set; }
+  public string? Department { get; set; }
+  public string? Section { get; set; }
+  public string? Position { get; set; }
+  public string? Charging { get; set; }
+  public decimal GrossPayAmount { get; set; }
+  public decimal NetAmount { get; set; }
+  public decimal BasicPayAmount { get; set; }
+  public decimal SssAmount { get; set; }
+  public decimal SssERAmount { get; set; }
+  public decimal PagibigAmount { get; set; }
+  public decimal PagibigERAmount { get; set; }
+  public decimal PhilhealthAmount { get; set; }
+  public decimal PhilhealthERAmount { get; set; }
+  public decimal RestDayAmount { get; set; }
+  public decimal RestDayHrs { get; set; }
+  public decimal RegularHolidayAmount { get; set; }
+  public decimal RegularHolidayHrs { get; set; }
+  public decimal SpecialHolidayAmount { get; set; }
+  public decimal SpecialHolidayHrs { get; set; }
+  public decimal OvertimeAmount { get; set; }
+  public decimal OvertimeHrs { get; set; }
+  public decimal NightDiffAmount { get; set; }
+  public decimal NightDiffHrs { get; set; }
+  public decimal NightDiffOvertimeAmount { get; set; }
+  public decimal NightDiffOvertimeHrs { get; set; }
+  public decimal NightDiffRegularHolidayAmount { get; set; }
+  public decimal NightDiffRegularHolidayHrs { get; set; }
+  public decimal NightDiffSpecialHolidayAmount { get; set; }
+  public decimal NightDiffSpecialHolidayHrs { get; set; }
+  public decimal OvertimeRestDayAmount { get; set; }
+  public decimal OvertimeRestDayHrs { get; set; }
+  public decimal OvertimeRegularHolidayAmount { get; set; }
+  public decimal OvertimeRegularHolidayHrs { get; set; }
+  public decimal OvertimeSpecialHolidayAmount { get; set; }
+  public decimal OvertimeSpecialHolidayHrs { get; set; }
+  public decimal UnionDues { get; set; }
+  public int Absences { get; set; }
+  public decimal AbsencesAmount { get; set; }
+  public decimal Leaves { get; set; }
+  public decimal LeavesAmount { get; set; }
+  public decimal Lates { get; set; }
+  public decimal LatesAmount { get; set; }
+  public decimal Undertime { get; set; }
+  public decimal UndertimeAmount { get; set; }
+  public decimal Overbreak { get; set; }
+  public decimal OverbreakAmount { get; set; }
+  public decimal SvcCharge { get; set; }
+  public decimal CostOfLivingAllowanceAmount { get; set; }
+  public decimal MonthlyAllowanceAmount { get; set; }
+  public decimal SalaryUnderpaymentAmount { get; set; }
+  public decimal RefundAbsencesAmount { get; set; }
+  public decimal RefundUndertimeAmount { get; set; }
+  public decimal RefundOvertimeAmount { get; set; }
+  public decimal LaborHoursIncome { get; set; }
+  public decimal LaborHrs { get; set; }
+  public decimal TaxDeductions { get; set; }
+  public decimal TotalConstantDeductions { get; set; }
+  public decimal TotalLoanDeductions { get; set; }
+  public decimal TotalDeductions { get; set; }
+}
+
+public class PayrollGroupedSummary
+{
+  public DateOnly Date { get; set; }
+  public int Count { get; set; }
+  public decimal TotalServiceCharge { get; set; }
+  public int TotalAbsences { get; set; }
+  public decimal TotalLeaves { get; set; }
+  public decimal TotalLates { get; set; }
+  public decimal TotalUndertimes { get; set; }
+  public decimal TotalOverbreak { get; set; }
+  public decimal TotalTaxDeductions { get; set; }
+  public decimal TotalNetAmount { get; set; }
+}

--- a/src/Bluewater.App/Models/ScheduleDtos.cs
+++ b/src/Bluewater.App/Models/ScheduleDtos.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+
+namespace Bluewater.App.Models;
+
+public class ScheduleListResponseDto
+{
+  public List<EmployeeScheduleDto?> Employees { get; set; } = new();
+}
+
+public class ScheduleDto
+{
+  public Guid Id { get; set; }
+  public Guid EmployeeId { get; set; }
+  public string Name { get; set; } = string.Empty;
+  public Guid ShiftId { get; set; }
+  public DateOnly ScheduleDate { get; set; }
+  public bool IsDefault { get; set; }
+  public ScheduleShiftDetailsDto? Shift { get; set; }
+}
+
+public class ScheduleShiftDetailsDto
+{
+  public Guid Id { get; set; }
+  public string Name { get; set; } = string.Empty;
+  public TimeOnly? ShiftStartTime { get; set; }
+  public TimeOnly? ShiftBreakTime { get; set; }
+  public TimeOnly? ShiftBreakEndTime { get; set; }
+  public TimeOnly? ShiftEndTime { get; set; }
+  public decimal BreakHours { get; set; }
+}
+
+public class EmployeeScheduleDto
+{
+  public Guid EmployeeId { get; set; }
+  public string Barcode { get; set; } = string.Empty;
+  public string Name { get; set; } = string.Empty;
+  public string Section { get; set; } = string.Empty;
+  public string Charging { get; set; } = string.Empty;
+  public List<ScheduleShiftInfoDto?> Shifts { get; set; } = new();
+}
+
+public class ScheduleShiftInfoDto
+{
+  public Guid ScheduleId { get; set; }
+  public ScheduleShiftDetailsDto? Shift { get; set; }
+  public DateOnly ScheduleDate { get; set; }
+  public bool IsDefault { get; set; }
+  public bool IsUpdated { get; set; }
+}
+
+public class CreateScheduleRequestDto
+{
+  public const string Route = "Schedules";
+
+  public Guid EmployeeId { get; set; }
+  public Guid ShiftId { get; set; }
+  public DateOnly ScheduleDate { get; set; }
+  public bool IsDefault { get; set; }
+}
+
+public class CreateScheduleResponseDto
+{
+  public Guid ScheduleId { get; set; }
+}
+
+public class UpdateScheduleRequestDto
+{
+  public Guid ScheduleId { get; set; }
+  public Guid EmployeeId { get; set; }
+  public Guid ShiftId { get; set; }
+  public DateOnly ScheduleDate { get; set; }
+  public bool IsDefault { get; set; }
+
+  public static string BuildRoute(Guid scheduleId) => $"Schedules/{scheduleId}";
+}
+
+public class UpdateScheduleResponseDto
+{
+  public ScheduleDto? Schedule { get; set; }
+}
+
+public static class ScheduleRequestRoutes
+{
+  public static string BuildGetRoute(Guid scheduleId) => $"Schedules/{scheduleId}";
+  public static string BuildDeleteRoute(Guid scheduleId) => $"Schedules/{scheduleId}";
+}
+
+public class ScheduleSummary
+{
+  public Guid Id { get; set; }
+  public Guid EmployeeId { get; set; }
+  public string Name { get; set; } = string.Empty;
+  public Guid ShiftId { get; set; }
+  public DateOnly ScheduleDate { get; set; }
+  public bool IsDefault { get; set; }
+  public ScheduleShiftDetailsSummary? Shift { get; set; }
+}
+
+public class ScheduleShiftDetailsSummary
+{
+  public Guid Id { get; set; }
+  public string Name { get; set; } = string.Empty;
+  public TimeOnly? ShiftStartTime { get; set; }
+  public TimeOnly? ShiftBreakTime { get; set; }
+  public TimeOnly? ShiftBreakEndTime { get; set; }
+  public TimeOnly? ShiftEndTime { get; set; }
+  public decimal BreakHours { get; set; }
+}
+
+public class EmployeeScheduleSummary
+{
+  public Guid EmployeeId { get; set; }
+  public string Barcode { get; set; } = string.Empty;
+  public string Name { get; set; } = string.Empty;
+  public string Section { get; set; } = string.Empty;
+  public string Charging { get; set; } = string.Empty;
+  public List<ScheduleShiftInfoSummary> Shifts { get; set; } = new();
+}
+
+public class ScheduleShiftInfoSummary
+{
+  public Guid ScheduleId { get; set; }
+  public ScheduleShiftDetailsSummary? Shift { get; set; }
+  public DateOnly ScheduleDate { get; set; }
+  public bool IsDefault { get; set; }
+  public bool IsUpdated { get; set; }
+}

--- a/src/Bluewater.App/Models/TenantDto.cs
+++ b/src/Bluewater.App/Models/TenantDto.cs
@@ -1,0 +1,11 @@
+namespace Bluewater.App.Models;
+
+public enum TenantDto
+{
+  Maribago = 0,
+  Panglao,
+  Sumilon,
+  AlmontInland,
+  AlmontCity,
+  AlmontBeach
+}

--- a/src/Bluewater.App/Services/AttendanceApiService.cs
+++ b/src/Bluewater.App/Services/AttendanceApiService.cs
@@ -1,0 +1,299 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Bluewater.App.Interfaces;
+using Bluewater.App.Models;
+
+namespace Bluewater.App.Services;
+
+public class AttendanceApiService(IApiClient apiClient) : IAttendanceApiService
+{
+  public async Task<IReadOnlyList<AttendanceSummary>> GetAttendancesAsync(
+    Guid employeeId,
+    DateOnly startDate,
+    DateOnly endDate,
+    int? skip = null,
+    int? take = null,
+    CancellationToken cancellationToken = default)
+  {
+    if (employeeId == Guid.Empty)
+    {
+      throw new ArgumentException("Employee ID must be provided", nameof(employeeId));
+    }
+
+    string requestUri = BuildListRequestUri(employeeId, startDate, endDate, skip, take);
+
+    AttendanceListResponseDto? response = await apiClient.GetAsync<AttendanceListResponseDto>(requestUri, cancellationToken);
+
+    if (response?.Attendances is not { Count: > 0 })
+    {
+      return Array.Empty<AttendanceSummary>();
+    }
+
+    return response.Attendances
+      .Where(dto => dto is not null)
+      .Select(MapToSummary)
+      .ToList();
+  }
+
+  public async Task<IReadOnlyList<EmployeeAttendanceSummary>> GetAttendanceSummariesAsync(
+    string charging,
+    DateOnly startDate,
+    DateOnly endDate,
+    int? skip = null,
+    int? take = null,
+    TenantDto tenant = TenantDto.Maribago,
+    CancellationToken cancellationToken = default)
+  {
+    if (string.IsNullOrWhiteSpace(charging))
+    {
+      throw new ArgumentException("Charging must be provided", nameof(charging));
+    }
+
+    string requestUri = BuildListAllRequestUri(charging, startDate, endDate, tenant, skip, take);
+
+    AttendanceListAllResponseDto? response = await apiClient.GetAsync<AttendanceListAllResponseDto>(requestUri, cancellationToken);
+
+    if (response?.Employees is not { Count: > 0 })
+    {
+      return Array.Empty<EmployeeAttendanceSummary>();
+    }
+
+    return response.Employees
+      .Where(dto => dto is not null)
+      .Select(MapToEmployeeSummary)
+      .ToList();
+  }
+
+  public async Task<AttendanceSummary?> GetAttendanceByIdAsync(Guid attendanceId, CancellationToken cancellationToken = default)
+  {
+    if (attendanceId == Guid.Empty)
+    {
+      throw new ArgumentException("Attendance ID must be provided", nameof(attendanceId));
+    }
+
+    AttendanceDto? dto = await apiClient.GetAsync<AttendanceDto>(
+      AttendanceRequestRoutes.BuildGetRoute(attendanceId),
+      cancellationToken);
+
+    return dto is null ? null : MapToSummary(dto);
+  }
+
+  public async Task<AttendanceSummary?> CreateAttendanceAsync(AttendanceSummary attendance, CancellationToken cancellationToken = default)
+  {
+    if (attendance is null)
+    {
+      throw new ArgumentNullException(nameof(attendance));
+    }
+
+    if (attendance.EmployeeId == Guid.Empty)
+    {
+      throw new ArgumentException("Employee ID must be provided", nameof(attendance));
+    }
+
+    AttendanceCreateRequestDto request = new()
+    {
+      EmployeeId = attendance.EmployeeId,
+      ShiftId = attendance.ShiftId,
+      TimesheetId = attendance.TimesheetId,
+      LeaveId = attendance.LeaveId,
+      EntryDate = attendance.EntryDate,
+      WorkHrs = attendance.WorkHours,
+      LateHrs = attendance.LateHours,
+      UnderHrs = attendance.UnderHours,
+      OverbreakHrs = attendance.OverbreakHours,
+      NightShiftHrs = attendance.NightShiftHours,
+      IsLocked = attendance.IsLocked
+    };
+
+    AttendanceCreateResponseDto? response = await apiClient.PostAsync<AttendanceCreateRequestDto, AttendanceCreateResponseDto>(
+      AttendanceCreateRequestDto.Route,
+      request,
+      cancellationToken);
+
+    return response?.Attendance is null ? null : MapToSummary(response.Attendance);
+  }
+
+  public async Task<AttendanceSummary?> UpdateAttendanceAsync(AttendanceSummary attendance, CancellationToken cancellationToken = default)
+  {
+    if (attendance is null)
+    {
+      throw new ArgumentNullException(nameof(attendance));
+    }
+
+    if (attendance.EmployeeId == Guid.Empty)
+    {
+      throw new ArgumentException("Employee ID must be provided", nameof(attendance));
+    }
+
+    if (attendance.EntryDate is null)
+    {
+      throw new ArgumentException("Entry date must be provided", nameof(attendance));
+    }
+
+    AttendanceUpdateRequestDto request = new()
+    {
+      EmployeeId = attendance.EmployeeId,
+      EntryDate = attendance.EntryDate,
+      ShiftId = attendance.ShiftId,
+      TimesheetId = attendance.TimesheetId,
+      LeaveId = attendance.LeaveId,
+      IsLocked = attendance.IsLocked
+    };
+
+    AttendanceUpdateResponseDto? response = await apiClient.PutAsync<AttendanceUpdateRequestDto, AttendanceUpdateResponseDto>(
+      AttendanceUpdateRequestDto.Route,
+      request,
+      cancellationToken);
+
+    return response?.Attendance is null ? null : MapToSummary(response.Attendance);
+  }
+
+  public Task<bool> DeleteAttendanceAsync(Guid attendanceId, CancellationToken cancellationToken = default)
+  {
+    if (attendanceId == Guid.Empty)
+    {
+      throw new ArgumentException("Attendance ID must be provided", nameof(attendanceId));
+    }
+
+    return apiClient.DeleteAsync(AttendanceRequestRoutes.BuildDeleteRoute(attendanceId), cancellationToken);
+  }
+
+  private static string BuildListRequestUri(Guid employeeId, DateOnly startDate, DateOnly endDate, int? skip, int? take)
+  {
+    List<string> parameters =
+    [
+      $"employeeId={employeeId}",
+      $"startDate={startDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}",
+      $"endDate={endDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}"
+    ];
+
+    if (skip.HasValue)
+    {
+      parameters.Add($"skip={skip.Value}");
+    }
+
+    if (take.HasValue)
+    {
+      parameters.Add($"take={take.Value}");
+    }
+
+    string query = string.Join('&', parameters);
+    return $"Attendances?{query}";
+  }
+
+  private static string BuildListAllRequestUri(
+    string charging,
+    DateOnly startDate,
+    DateOnly endDate,
+    TenantDto tenant,
+    int? skip,
+    int? take)
+  {
+    List<string> parameters =
+    [
+      $"charging={Uri.EscapeDataString(charging)}",
+      $"startDate={startDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}",
+      $"endDate={endDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}",
+      $"tenant={tenant}"
+    ];
+
+    if (skip.HasValue)
+    {
+      parameters.Add($"skip={skip.Value}");
+    }
+
+    if (take.HasValue)
+    {
+      parameters.Add($"take={take.Value}");
+    }
+
+    string query = string.Join('&', parameters);
+    return $"Attendances/All?{query}";
+  }
+
+  private static AttendanceSummary MapToSummary(AttendanceDto dto)
+  {
+    return new AttendanceSummary
+    {
+      Id = dto.Id,
+      EmployeeId = dto.EmployeeId,
+      ShiftId = dto.ShiftId,
+      TimesheetId = dto.TimesheetId,
+      LeaveId = dto.LeaveId,
+      EntryDate = dto.EntryDate,
+      WorkHours = dto.WorkHrs,
+      LateHours = dto.LateHrs,
+      UnderHours = dto.UnderHrs,
+      OverbreakHours = dto.OverbreakHrs,
+      NightShiftHours = dto.NightShiftHours,
+      IsLocked = dto.IsLocked,
+      Shift = MapShift(dto.Shift),
+      Timesheet = MapTimesheet(dto.Timesheet)
+    };
+  }
+
+  private static AttendanceShiftSummary? MapShift(AttendanceShiftDto? shift)
+  {
+    if (shift is null)
+    {
+      return null;
+    }
+
+    return new AttendanceShiftSummary
+    {
+      Id = shift.Id,
+      Name = shift.Name,
+      ShiftStartTime = shift.ShiftStartTime,
+      ShiftBreakTime = shift.ShiftBreakTime,
+      ShiftBreakEndTime = shift.ShiftBreakEndTime,
+      ShiftEndTime = shift.ShiftEndTime,
+      BreakHours = shift.BreakHours
+    };
+  }
+
+  private static AttendanceTimesheetSummary? MapTimesheet(AttendanceTimesheetDto? timesheet)
+  {
+    if (timesheet is null)
+    {
+      return null;
+    }
+
+    return new AttendanceTimesheetSummary
+    {
+      Id = timesheet.Id,
+      EmployeeId = timesheet.EmployeeId,
+      TimeIn1 = timesheet.TimeIn1,
+      TimeOut1 = timesheet.TimeOut1,
+      TimeIn2 = timesheet.TimeIn2,
+      TimeOut2 = timesheet.TimeOut2,
+      EntryDate = timesheet.EntryDate,
+      IsEdited = timesheet.IsEdited
+    };
+  }
+
+  private static EmployeeAttendanceSummary MapToEmployeeSummary(EmployeeAttendanceDto dto)
+  {
+    return new EmployeeAttendanceSummary
+    {
+      EmployeeId = dto.EmployeeId,
+      Barcode = dto.Barcode,
+      Name = dto.Name,
+      Department = dto.Department,
+      Section = dto.Section,
+      Charging = dto.Charging,
+      Attendances = dto.Attendances?
+        .Where(attendance => attendance is not null)
+        .Select(MapToSummary)
+        .ToList() ?? new List<AttendanceSummary>(),
+      TotalWorkHours = dto.TotalWorkHrs,
+      TotalAbsences = dto.TotalAbsences,
+      TotalLateHours = dto.TotalLateHrs,
+      TotalUnderHours = dto.TotalUnderHrs,
+      TotalOverbreakHours = dto.TotalOverbreakHrs,
+      TotalNightShiftHours = dto.TotalNightShiftHrs,
+      TotalLeaves = dto.TotalLeaves
+    };
+  }
+}

--- a/src/Bluewater.App/Services/LeaveApiService.cs
+++ b/src/Bluewater.App/Services/LeaveApiService.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Bluewater.App.Interfaces;
+using Bluewater.App.Models;
+
+namespace Bluewater.App.Services;
+
+public class LeaveApiService(IApiClient apiClient) : ILeaveApiService
+{
+  public async Task<IReadOnlyList<LeaveSummary>> GetLeavesAsync(
+    int? skip = null,
+    int? take = null,
+    TenantDto tenant = TenantDto.Maribago,
+    CancellationToken cancellationToken = default)
+  {
+    string requestUri = BuildRequestUri(skip, take, tenant);
+
+    LeaveListResponseDto? response = await apiClient.GetAsync<LeaveListResponseDto>(requestUri, cancellationToken);
+
+    if (response?.Leaves is not { Count: > 0 })
+    {
+      return Array.Empty<LeaveSummary>();
+    }
+
+    return response.Leaves
+      .Where(dto => dto is not null)
+      .Select(MapToSummary)
+      .ToList();
+  }
+
+  public async Task<LeaveSummary?> GetLeaveByIdAsync(Guid leaveId, CancellationToken cancellationToken = default)
+  {
+    if (leaveId == Guid.Empty)
+    {
+      throw new ArgumentException("Leave ID must be provided", nameof(leaveId));
+    }
+
+    LeaveDto? dto = await apiClient.GetAsync<LeaveDto>($"Leaves/{leaveId}", cancellationToken);
+    return dto is null ? null : MapToSummary(dto);
+  }
+
+  public async Task<LeaveSummary?> CreateLeaveAsync(LeaveSummary leave, CancellationToken cancellationToken = default)
+  {
+    if (leave is null)
+    {
+      throw new ArgumentNullException(nameof(leave));
+    }
+
+    if (!leave.EmployeeId.HasValue || leave.EmployeeId.Value == Guid.Empty)
+    {
+      throw new ArgumentException("Employee ID must be provided", nameof(leave));
+    }
+
+    if (leave.LeaveCreditId == Guid.Empty)
+    {
+      throw new ArgumentException("Leave credit ID must be provided", nameof(leave));
+    }
+
+    CreateLeaveRequestDto request = new()
+    {
+      StartDate = leave.StartDate,
+      EndDate = leave.EndDate,
+      IsHalfDay = leave.IsHalfDay,
+      EmployeeId = leave.EmployeeId.Value,
+      LeaveCreditId = leave.LeaveCreditId
+    };
+
+    CreateLeaveResponseDto? response = await apiClient.PostAsync<CreateLeaveRequestDto, CreateLeaveResponseDto>(
+      CreateLeaveRequestDto.Route,
+      request,
+      cancellationToken);
+
+    return response?.Leave is null ? null : MapToSummary(response.Leave);
+  }
+
+  public async Task<LeaveSummary?> UpdateLeaveAsync(LeaveSummary leave, CancellationToken cancellationToken = default)
+  {
+    if (leave is null)
+    {
+      throw new ArgumentNullException(nameof(leave));
+    }
+
+    if (leave.Id == Guid.Empty)
+    {
+      throw new ArgumentException("Leave ID must be provided", nameof(leave));
+    }
+
+    if (!leave.EmployeeId.HasValue || leave.EmployeeId.Value == Guid.Empty)
+    {
+      throw new ArgumentException("Employee ID must be provided", nameof(leave));
+    }
+
+    if (leave.StartDate is null)
+    {
+      throw new ArgumentException("Start date must be provided", nameof(leave));
+    }
+
+    if (leave.EndDate is null)
+    {
+      throw new ArgumentException("End date must be provided", nameof(leave));
+    }
+
+    UpdateLeaveRequestDto request = new()
+    {
+      LeaveId = leave.Id,
+      Id = leave.Id,
+      StartDate = leave.StartDate.Value,
+      EndDate = leave.EndDate.Value,
+      IsHalfDay = leave.IsHalfDay,
+      Status = leave.Status,
+      EmployeeId = leave.EmployeeId.Value,
+      LeaveCreditId = leave.LeaveCreditId
+    };
+
+    UpdateLeaveResponseDto? response = await apiClient.PutAsync<UpdateLeaveRequestDto, UpdateLeaveResponseDto>(
+      UpdateLeaveRequestDto.BuildRoute(leave.Id),
+      request,
+      cancellationToken);
+
+    return response?.Leave is null ? null : MapToSummary(response.Leave);
+  }
+
+  public Task<bool> DeleteLeaveAsync(Guid leaveId, CancellationToken cancellationToken = default)
+  {
+    if (leaveId == Guid.Empty)
+    {
+      throw new ArgumentException("Leave ID must be provided", nameof(leaveId));
+    }
+
+    return apiClient.DeleteAsync($"Leaves/{leaveId}", cancellationToken);
+  }
+
+  private static string BuildRequestUri(int? skip, int? take, TenantDto tenant)
+  {
+    List<string> parameters = [];
+
+    if (skip.HasValue)
+    {
+      parameters.Add($"skip={skip.Value}");
+    }
+
+    if (take.HasValue)
+    {
+      parameters.Add($"take={take.Value}");
+    }
+
+    parameters.Add($"tenant={tenant}");
+
+    if (parameters.Count == 0)
+    {
+      return "Leaves";
+    }
+
+    string query = string.Join('&', parameters);
+    return $"Leaves?{query}";
+  }
+
+  private static LeaveSummary MapToSummary(LeaveDto dto)
+  {
+    return new LeaveSummary
+    {
+      Id = dto.Id,
+      StartDate = dto.StartDate,
+      EndDate = dto.EndDate,
+      IsHalfDay = dto.IsHalfDay,
+      Status = dto.Status,
+      EmployeeId = dto.EmployeeId,
+      LeaveCreditId = dto.LeaveCreditId,
+      EmployeeName = dto.EmployeeName,
+      LeaveCreditName = dto.LeaveCreditName
+    };
+  }
+}

--- a/src/Bluewater.App/Services/PayrollApiService.cs
+++ b/src/Bluewater.App/Services/PayrollApiService.cs
@@ -1,0 +1,402 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Bluewater.App.Interfaces;
+using Bluewater.App.Models;
+
+namespace Bluewater.App.Services;
+
+public class PayrollApiService(IApiClient apiClient) : IPayrollApiService
+{
+  public async Task<IReadOnlyList<PayrollSummary>> GetPayrollsAsync(
+    DateOnly startDate,
+    DateOnly endDate,
+    string? chargingName = null,
+    int? skip = null,
+    int? take = null,
+    TenantDto tenant = TenantDto.Maribago,
+    CancellationToken cancellationToken = default)
+  {
+    string requestUri = BuildListRequestUri(startDate, endDate, chargingName, tenant, skip, take);
+
+    PayrollListResponseDto? response = await apiClient.GetAsync<PayrollListResponseDto>(requestUri, cancellationToken);
+
+    if (response?.Payrolls is not { Count: > 0 })
+    {
+      return Array.Empty<PayrollSummary>();
+    }
+
+    return response.Payrolls
+      .Where(dto => dto is not null)
+      .Select(MapToSummary)
+      .ToList();
+  }
+
+  public async Task<IReadOnlyList<PayrollGroupedSummary>> GetGroupedPayrollsAsync(
+    int? skip = null,
+    int? take = null,
+    CancellationToken cancellationToken = default)
+  {
+    string requestUri = BuildGroupedRequestUri(skip, take);
+
+    PayrollGroupedListResponseDto? response = await apiClient.GetAsync<PayrollGroupedListResponseDto>(requestUri, cancellationToken);
+
+    if (response?.Payrolls is not { Count: > 0 })
+    {
+      return Array.Empty<PayrollGroupedSummary>();
+    }
+
+    return response.Payrolls
+      .Where(dto => dto is not null)
+      .Select(MapToGroupedSummary)
+      .ToList();
+  }
+
+  public async Task<PayrollSummary?> GetPayrollByIdAsync(Guid payrollId, CancellationToken cancellationToken = default)
+  {
+    if (payrollId == Guid.Empty)
+    {
+      throw new ArgumentException("Payroll ID must be provided", nameof(payrollId));
+    }
+
+    PayrollDto? dto = await apiClient.GetAsync<PayrollDto>($"Payrolls/{payrollId}", cancellationToken);
+    return dto is null ? null : MapToSummary(dto);
+  }
+
+  public async Task<Guid?> CreatePayrollAsync(PayrollSummary payroll, CancellationToken cancellationToken = default)
+  {
+    if (payroll is null)
+    {
+      throw new ArgumentNullException(nameof(payroll));
+    }
+
+    if (!payroll.EmployeeId.HasValue || payroll.EmployeeId.Value == Guid.Empty)
+    {
+      throw new ArgumentException("Employee ID must be provided", nameof(payroll));
+    }
+
+    CreatePayrollRequestDto request = BuildCreateRequest(payroll);
+
+    CreatePayrollResponseDto? response = await apiClient.PostAsync<CreatePayrollRequestDto, CreatePayrollResponseDto>(
+      CreatePayrollRequestDto.Route,
+      request,
+      cancellationToken);
+
+    return response?.PayrollId;
+  }
+
+  public async Task<PayrollSummary?> UpdatePayrollAsync(PayrollSummary payroll, CancellationToken cancellationToken = default)
+  {
+    if (payroll is null)
+    {
+      throw new ArgumentNullException(nameof(payroll));
+    }
+
+    if (payroll.Id == Guid.Empty)
+    {
+      throw new ArgumentException("Payroll ID must be provided", nameof(payroll));
+    }
+
+    if (!payroll.EmployeeId.HasValue || payroll.EmployeeId.Value == Guid.Empty)
+    {
+      throw new ArgumentException("Employee ID must be provided", nameof(payroll));
+    }
+
+    UpdatePayrollRequestDto request = BuildUpdateRequest(payroll);
+
+    UpdatePayrollResponseDto? response = await apiClient.PutAsync<UpdatePayrollRequestDto, UpdatePayrollResponseDto>(
+      UpdatePayrollRequestDto.BuildRoute(payroll.Id),
+      request,
+      cancellationToken);
+
+    return response?.Payroll is null ? null : MapToSummary(response.Payroll);
+  }
+
+  public Task<bool> DeletePayrollAsync(Guid payrollId, CancellationToken cancellationToken = default)
+  {
+    if (payrollId == Guid.Empty)
+    {
+      throw new ArgumentException("Payroll ID must be provided", nameof(payrollId));
+    }
+
+    return apiClient.DeleteAsync($"Payrolls/{payrollId}", cancellationToken);
+  }
+
+  private static string BuildListRequestUri(
+    DateOnly startDate,
+    DateOnly endDate,
+    string? chargingName,
+    TenantDto tenant,
+    int? skip,
+    int? take)
+  {
+    List<string> parameters =
+    [
+      $"startDate={startDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}",
+      $"endDate={endDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}",
+      $"tenant={tenant}"
+    ];
+
+    if (!string.IsNullOrWhiteSpace(chargingName))
+    {
+      parameters.Add($"chargingName={Uri.EscapeDataString(chargingName)}");
+    }
+
+    if (skip.HasValue)
+    {
+      parameters.Add($"skip={skip.Value}");
+    }
+
+    if (take.HasValue)
+    {
+      parameters.Add($"take={take.Value}");
+    }
+
+    string query = string.Join('&', parameters);
+    return $"Payrolls?{query}";
+  }
+
+  private static string BuildGroupedRequestUri(int? skip, int? take)
+  {
+    List<string> parameters = [];
+
+    if (skip.HasValue)
+    {
+      parameters.Add($"skip={skip.Value}");
+    }
+
+    if (take.HasValue)
+    {
+      parameters.Add($"take={take.Value}");
+    }
+
+    if (parameters.Count == 0)
+    {
+      return "Payrolls/Grouped";
+    }
+
+    string query = string.Join('&', parameters);
+    return $"Payrolls/Grouped?{query}";
+  }
+
+  private static CreatePayrollRequestDto BuildCreateRequest(PayrollSummary payroll)
+  {
+    return new CreatePayrollRequestDto
+    {
+      EmployeeId = payroll.EmployeeId!.Value,
+      Date = payroll.Date,
+      GrossPayAmount = payroll.GrossPayAmount,
+      NetAmount = payroll.NetAmount,
+      BasicPayAmount = payroll.BasicPayAmount,
+      SssAmount = payroll.SssAmount,
+      SssERAmount = payroll.SssERAmount,
+      PagibigAmount = payroll.PagibigAmount,
+      PagibigERAmount = payroll.PagibigERAmount,
+      PhilhealthAmount = payroll.PhilhealthAmount,
+      PhilhealthERAmount = payroll.PhilhealthERAmount,
+      RestDayAmount = payroll.RestDayAmount,
+      RestDayHrs = payroll.RestDayHrs,
+      RegularHolidayAmount = payroll.RegularHolidayAmount,
+      RegularHolidayHrs = payroll.RegularHolidayHrs,
+      SpecialHolidayAmount = payroll.SpecialHolidayAmount,
+      SpecialHolidayHrs = payroll.SpecialHolidayHrs,
+      OvertimeAmount = payroll.OvertimeAmount,
+      OvertimeHrs = payroll.OvertimeHrs,
+      NightDiffAmount = payroll.NightDiffAmount,
+      NightDiffHrs = payroll.NightDiffHrs,
+      NightDiffOvertimeAmount = payroll.NightDiffOvertimeAmount,
+      NightDiffOvertimeHrs = payroll.NightDiffOvertimeHrs,
+      NightDiffRegularHolidayAmount = payroll.NightDiffRegularHolidayAmount,
+      NightDiffRegularHolidayHrs = payroll.NightDiffRegularHolidayHrs,
+      NightDiffSpecialHolidayAmount = payroll.NightDiffSpecialHolidayAmount,
+      NightDiffSpecialHolidayHrs = payroll.NightDiffSpecialHolidayHrs,
+      OvertimeRestDayAmount = payroll.OvertimeRestDayAmount,
+      OvertimeRestDayHrs = payroll.OvertimeRestDayHrs,
+      OvertimeRegularHolidayAmount = payroll.OvertimeRegularHolidayAmount,
+      OvertimeRegularHolidayHrs = payroll.OvertimeRegularHolidayHrs,
+      OvertimeSpecialHolidayAmount = payroll.OvertimeSpecialHolidayAmount,
+      OvertimeSpecialHolidayHrs = payroll.OvertimeSpecialHolidayHrs,
+      UnionDues = payroll.UnionDues,
+      Absences = payroll.Absences,
+      AbsencesAmount = payroll.AbsencesAmount,
+      Leaves = payroll.Leaves,
+      LeavesAmount = payroll.LeavesAmount,
+      Lates = payroll.Lates,
+      LatesAmount = payroll.LatesAmount,
+      Undertime = payroll.Undertime,
+      UndertimeAmount = payroll.UndertimeAmount,
+      Overbreak = payroll.Overbreak,
+      OverbreakAmount = payroll.OverbreakAmount,
+      SvcCharge = payroll.SvcCharge,
+      CostOfLivingAllowanceAmount = payroll.CostOfLivingAllowanceAmount,
+      MonthlyAllowanceAmount = payroll.MonthlyAllowanceAmount,
+      SalaryUnderpaymentAmount = payroll.SalaryUnderpaymentAmount,
+      RefundAbsencesAmount = payroll.RefundAbsencesAmount,
+      RefundUndertimeAmount = payroll.RefundUndertimeAmount,
+      RefundOvertimeAmount = payroll.RefundOvertimeAmount,
+      LaborHoursIncome = payroll.LaborHoursIncome,
+      LaborHrs = payroll.LaborHrs,
+      TaxDeductions = payroll.TaxDeductions,
+      TotalConstantDeductions = payroll.TotalConstantDeductions,
+      TotalLoanDeductions = payroll.TotalLoanDeductions,
+      TotalDeductions = payroll.TotalDeductions
+    };
+  }
+
+  private static UpdatePayrollRequestDto BuildUpdateRequest(PayrollSummary payroll)
+  {
+    return new UpdatePayrollRequestDto
+    {
+      PayrollId = payroll.Id,
+      Id = payroll.Id,
+      EmployeeId = payroll.EmployeeId!.Value,
+      Date = payroll.Date,
+      GrossPayAmount = payroll.GrossPayAmount,
+      NetAmount = payroll.NetAmount,
+      BasicPayAmount = payroll.BasicPayAmount,
+      SssAmount = payroll.SssAmount,
+      SssERAmount = payroll.SssERAmount,
+      PagibigAmount = payroll.PagibigAmount,
+      PagibigERAmount = payroll.PagibigERAmount,
+      PhilhealthAmount = payroll.PhilhealthAmount,
+      PhilhealthERAmount = payroll.PhilhealthERAmount,
+      RestDayAmount = payroll.RestDayAmount,
+      RestDayHrs = payroll.RestDayHrs,
+      RegularHolidayAmount = payroll.RegularHolidayAmount,
+      RegularHolidayHrs = payroll.RegularHolidayHrs,
+      SpecialHolidayAmount = payroll.SpecialHolidayAmount,
+      SpecialHolidayHrs = payroll.SpecialHolidayHrs,
+      OvertimeAmount = payroll.OvertimeAmount,
+      OvertimeHrs = payroll.OvertimeHrs,
+      NightDiffAmount = payroll.NightDiffAmount,
+      NightDiffHrs = payroll.NightDiffHrs,
+      NightDiffOvertimeAmount = payroll.NightDiffOvertimeAmount,
+      NightDiffOvertimeHrs = payroll.NightDiffOvertimeHrs,
+      NightDiffRegularHolidayAmount = payroll.NightDiffRegularHolidayAmount,
+      NightDiffRegularHolidayHrs = payroll.NightDiffRegularHolidayHrs,
+      NightDiffSpecialHolidayAmount = payroll.NightDiffSpecialHolidayAmount,
+      NightDiffSpecialHolidayHrs = payroll.NightDiffSpecialHolidayHrs,
+      OvertimeRestDayAmount = payroll.OvertimeRestDayAmount,
+      OvertimeRestDayHrs = payroll.OvertimeRestDayHrs,
+      OvertimeRegularHolidayAmount = payroll.OvertimeRegularHolidayAmount,
+      OvertimeRegularHolidayHrs = payroll.OvertimeRegularHolidayHrs,
+      OvertimeSpecialHolidayAmount = payroll.OvertimeSpecialHolidayAmount,
+      OvertimeSpecialHolidayHrs = payroll.OvertimeSpecialHolidayHrs,
+      UnionDues = payroll.UnionDues,
+      Absences = payroll.Absences,
+      AbsencesAmount = payroll.AbsencesAmount,
+      Leaves = payroll.Leaves,
+      LeavesAmount = payroll.LeavesAmount,
+      Lates = payroll.Lates,
+      LatesAmount = payroll.LatesAmount,
+      Undertime = payroll.Undertime,
+      UndertimeAmount = payroll.UndertimeAmount,
+      Overbreak = payroll.Overbreak,
+      OverbreakAmount = payroll.OverbreakAmount,
+      SvcCharge = payroll.SvcCharge,
+      CostOfLivingAllowanceAmount = payroll.CostOfLivingAllowanceAmount,
+      MonthlyAllowanceAmount = payroll.MonthlyAllowanceAmount,
+      SalaryUnderpaymentAmount = payroll.SalaryUnderpaymentAmount,
+      RefundAbsencesAmount = payroll.RefundAbsencesAmount,
+      RefundUndertimeAmount = payroll.RefundUndertimeAmount,
+      RefundOvertimeAmount = payroll.RefundOvertimeAmount,
+      LaborHoursIncome = payroll.LaborHoursIncome,
+      LaborHrs = payroll.LaborHrs,
+      TaxDeductions = payroll.TaxDeductions,
+      TotalConstantDeductions = payroll.TotalConstantDeductions,
+      TotalLoanDeductions = payroll.TotalLoanDeductions,
+      TotalDeductions = payroll.TotalDeductions
+    };
+  }
+
+  private static PayrollSummary MapToSummary(PayrollDto dto)
+  {
+    return new PayrollSummary
+    {
+      Id = dto.Id,
+      EmployeeId = dto.EmployeeId,
+      Name = dto.Name,
+      Barcode = dto.Barcode,
+      BankAccount = dto.BankAccount,
+      Date = dto.Date,
+      Division = dto.Division,
+      Department = dto.Department,
+      Section = dto.Section,
+      Position = dto.Position,
+      Charging = dto.Charging,
+      GrossPayAmount = dto.GrossPayAmount,
+      NetAmount = dto.NetAmount,
+      BasicPayAmount = dto.BasicPayAmount,
+      SssAmount = dto.SssAmount,
+      SssERAmount = dto.SssERAmount,
+      PagibigAmount = dto.PagibigAmount,
+      PagibigERAmount = dto.PagibigERAmount,
+      PhilhealthAmount = dto.PhilhealthAmount,
+      PhilhealthERAmount = dto.PhilhealthERAmount,
+      RestDayAmount = dto.RestDayAmount,
+      RestDayHrs = dto.RestDayHrs,
+      RegularHolidayAmount = dto.RegularHolidayAmount,
+      RegularHolidayHrs = dto.RegularHolidayHrs,
+      SpecialHolidayAmount = dto.SpecialHolidayAmount,
+      SpecialHolidayHrs = dto.SpecialHolidayHrs,
+      OvertimeAmount = dto.OvertimeAmount,
+      OvertimeHrs = dto.OvertimeHrs,
+      NightDiffAmount = dto.NightDiffAmount,
+      NightDiffHrs = dto.NightDiffHrs,
+      NightDiffOvertimeAmount = dto.NightDiffOvertimeAmount,
+      NightDiffOvertimeHrs = dto.NightDiffOvertimeHrs,
+      NightDiffRegularHolidayAmount = dto.NightDiffRegularHolidayAmount,
+      NightDiffRegularHolidayHrs = dto.NightDiffRegularHolidayHrs,
+      NightDiffSpecialHolidayAmount = dto.NightDiffSpecialHolidayAmount,
+      NightDiffSpecialHolidayHrs = dto.NightDiffSpecialHolidayHrs,
+      OvertimeRestDayAmount = dto.OvertimeRestDayAmount,
+      OvertimeRestDayHrs = dto.OvertimeRestDayHrs,
+      OvertimeRegularHolidayAmount = dto.OvertimeRegularHolidayAmount,
+      OvertimeRegularHolidayHrs = dto.OvertimeRegularHolidayHrs,
+      OvertimeSpecialHolidayAmount = dto.OvertimeSpecialHolidayAmount,
+      OvertimeSpecialHolidayHrs = dto.OvertimeSpecialHolidayHrs,
+      UnionDues = dto.UnionDues,
+      Absences = dto.Absences,
+      AbsencesAmount = dto.AbsencesAmount,
+      Leaves = dto.Leaves,
+      LeavesAmount = dto.LeavesAmount,
+      Lates = dto.Lates,
+      LatesAmount = dto.LatesAmount,
+      Undertime = dto.Undertime,
+      UndertimeAmount = dto.UndertimeAmount,
+      Overbreak = dto.Overbreak,
+      OverbreakAmount = dto.OverbreakAmount,
+      SvcCharge = dto.SvcCharge,
+      CostOfLivingAllowanceAmount = dto.CostOfLivingAllowanceAmount,
+      MonthlyAllowanceAmount = dto.MonthlyAllowanceAmount,
+      SalaryUnderpaymentAmount = dto.SalaryUnderpaymentAmount,
+      RefundAbsencesAmount = dto.RefundAbsencesAmount,
+      RefundUndertimeAmount = dto.RefundUndertimeAmount,
+      RefundOvertimeAmount = dto.RefundOvertimeAmount,
+      LaborHoursIncome = dto.LaborHoursIncome,
+      LaborHrs = dto.LaborHrs,
+      TaxDeductions = dto.TaxDeductions,
+      TotalConstantDeductions = dto.TotalConstantDeductions,
+      TotalLoanDeductions = dto.TotalLoanDeductions,
+      TotalDeductions = dto.TotalDeductions
+    };
+  }
+
+  private static PayrollGroupedSummary MapToGroupedSummary(PayrollSummaryDto dto)
+  {
+    return new PayrollGroupedSummary
+    {
+      Date = dto.Date,
+      Count = dto.Count,
+      TotalServiceCharge = dto.TotalServiceCharge,
+      TotalAbsences = dto.TotalAbsences,
+      TotalLeaves = dto.TotalLeaves,
+      TotalLates = dto.TotalLates,
+      TotalUndertimes = dto.TotalUndertimes,
+      TotalOverbreak = dto.TotalOverbreak,
+      TotalTaxDeductions = dto.TotalTaxDeductions,
+      TotalNetAmount = dto.TotalNetAmount
+    };
+  }
+}

--- a/src/Bluewater.App/Services/ScheduleApiService.cs
+++ b/src/Bluewater.App/Services/ScheduleApiService.cs
@@ -1,0 +1,224 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Bluewater.App.Interfaces;
+using Bluewater.App.Models;
+
+namespace Bluewater.App.Services;
+
+public class ScheduleApiService(IApiClient apiClient) : IScheduleApiService
+{
+  public async Task<IReadOnlyList<EmployeeScheduleSummary>> GetSchedulesAsync(
+    string chargingName,
+    DateOnly startDate,
+    DateOnly endDate,
+    int? skip = null,
+    int? take = null,
+    TenantDto tenant = TenantDto.Maribago,
+    CancellationToken cancellationToken = default)
+  {
+    if (string.IsNullOrWhiteSpace(chargingName))
+    {
+      throw new ArgumentException("Charging name must be provided", nameof(chargingName));
+    }
+
+    string requestUri = BuildListRequestUri(chargingName, startDate, endDate, tenant, skip, take);
+
+    ScheduleListResponseDto? response = await apiClient.GetAsync<ScheduleListResponseDto>(requestUri, cancellationToken);
+
+    if (response?.Employees is not { Count: > 0 })
+    {
+      return Array.Empty<EmployeeScheduleSummary>();
+    }
+
+    return response.Employees
+      .Where(dto => dto is not null)
+      .Select(MapToEmployeeSummary)
+      .ToList();
+  }
+
+  public async Task<ScheduleSummary?> GetScheduleByIdAsync(Guid scheduleId, CancellationToken cancellationToken = default)
+  {
+    if (scheduleId == Guid.Empty)
+    {
+      throw new ArgumentException("Schedule ID must be provided", nameof(scheduleId));
+    }
+
+    ScheduleDto? dto = await apiClient.GetAsync<ScheduleDto>(ScheduleRequestRoutes.BuildGetRoute(scheduleId), cancellationToken);
+    return dto is null ? null : MapToSummary(dto);
+  }
+
+  public async Task<Guid?> CreateScheduleAsync(ScheduleSummary schedule, CancellationToken cancellationToken = default)
+  {
+    if (schedule is null)
+    {
+      throw new ArgumentNullException(nameof(schedule));
+    }
+
+    if (schedule.EmployeeId == Guid.Empty)
+    {
+      throw new ArgumentException("Employee ID must be provided", nameof(schedule));
+    }
+
+    if (schedule.ShiftId == Guid.Empty)
+    {
+      throw new ArgumentException("Shift ID must be provided", nameof(schedule));
+    }
+
+    CreateScheduleRequestDto request = new()
+    {
+      EmployeeId = schedule.EmployeeId,
+      ShiftId = schedule.ShiftId,
+      ScheduleDate = schedule.ScheduleDate,
+      IsDefault = schedule.IsDefault
+    };
+
+    CreateScheduleResponseDto? response = await apiClient.PostAsync<CreateScheduleRequestDto, CreateScheduleResponseDto>(
+      CreateScheduleRequestDto.Route,
+      request,
+      cancellationToken);
+
+    return response?.ScheduleId;
+  }
+
+  public async Task<ScheduleSummary?> UpdateScheduleAsync(ScheduleSummary schedule, CancellationToken cancellationToken = default)
+  {
+    if (schedule is null)
+    {
+      throw new ArgumentNullException(nameof(schedule));
+    }
+
+    if (schedule.Id == Guid.Empty)
+    {
+      throw new ArgumentException("Schedule ID must be provided", nameof(schedule));
+    }
+
+    if (schedule.EmployeeId == Guid.Empty)
+    {
+      throw new ArgumentException("Employee ID must be provided", nameof(schedule));
+    }
+
+    if (schedule.ShiftId == Guid.Empty)
+    {
+      throw new ArgumentException("Shift ID must be provided", nameof(schedule));
+    }
+
+    UpdateScheduleRequestDto request = new()
+    {
+      ScheduleId = schedule.Id,
+      EmployeeId = schedule.EmployeeId,
+      ShiftId = schedule.ShiftId,
+      ScheduleDate = schedule.ScheduleDate,
+      IsDefault = schedule.IsDefault
+    };
+
+    UpdateScheduleResponseDto? response = await apiClient.PutAsync<UpdateScheduleRequestDto, UpdateScheduleResponseDto>(
+      UpdateScheduleRequestDto.BuildRoute(schedule.Id),
+      request,
+      cancellationToken);
+
+    return response?.Schedule is null ? null : MapToSummary(response.Schedule);
+  }
+
+  public Task<bool> DeleteScheduleAsync(Guid scheduleId, CancellationToken cancellationToken = default)
+  {
+    if (scheduleId == Guid.Empty)
+    {
+      throw new ArgumentException("Schedule ID must be provided", nameof(scheduleId));
+    }
+
+    return apiClient.DeleteAsync(ScheduleRequestRoutes.BuildDeleteRoute(scheduleId), cancellationToken);
+  }
+
+  private static string BuildListRequestUri(
+    string chargingName,
+    DateOnly startDate,
+    DateOnly endDate,
+    TenantDto tenant,
+    int? skip,
+    int? take)
+  {
+    List<string> parameters =
+    [
+      $"chargingName={Uri.EscapeDataString(chargingName)}",
+      $"startDate={startDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}",
+      $"endDate={endDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}",
+      $"tenant={tenant}"
+    ];
+
+    if (skip.HasValue)
+    {
+      parameters.Add($"skip={skip.Value}");
+    }
+
+    if (take.HasValue)
+    {
+      parameters.Add($"take={take.Value}");
+    }
+
+    string query = string.Join('&', parameters);
+    return $"Schedules?{query}";
+  }
+
+  private static ScheduleSummary MapToSummary(ScheduleDto dto)
+  {
+    return new ScheduleSummary
+    {
+      Id = dto.Id,
+      EmployeeId = dto.EmployeeId,
+      Name = dto.Name,
+      ShiftId = dto.ShiftId,
+      ScheduleDate = dto.ScheduleDate,
+      IsDefault = dto.IsDefault,
+      Shift = MapShift(dto.Shift)
+    };
+  }
+
+  private static EmployeeScheduleSummary MapToEmployeeSummary(EmployeeScheduleDto dto)
+  {
+    return new EmployeeScheduleSummary
+    {
+      EmployeeId = dto.EmployeeId,
+      Barcode = dto.Barcode,
+      Name = dto.Name,
+      Section = dto.Section,
+      Charging = dto.Charging,
+      Shifts = dto.Shifts?
+        .Where(shift => shift is not null)
+        .Select(MapShiftInfo)
+        .ToList() ?? new List<ScheduleShiftInfoSummary>()
+    };
+  }
+
+  private static ScheduleShiftDetailsSummary? MapShift(ScheduleShiftDetailsDto? dto)
+  {
+    if (dto is null)
+    {
+      return null;
+    }
+
+    return new ScheduleShiftDetailsSummary
+    {
+      Id = dto.Id,
+      Name = dto.Name,
+      ShiftStartTime = dto.ShiftStartTime,
+      ShiftBreakTime = dto.ShiftBreakTime,
+      ShiftBreakEndTime = dto.ShiftBreakEndTime,
+      ShiftEndTime = dto.ShiftEndTime,
+      BreakHours = dto.BreakHours
+    };
+  }
+
+  private static ScheduleShiftInfoSummary MapShiftInfo(ScheduleShiftInfoDto dto)
+  {
+    return new ScheduleShiftInfoSummary
+    {
+      ScheduleId = dto.ScheduleId,
+      Shift = MapShift(dto.Shift),
+      ScheduleDate = dto.ScheduleDate,
+      IsDefault = dto.IsDefault,
+      IsUpdated = dto.IsUpdated
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add DTO models and enums to represent leave, attendance, payroll, and schedule API payloads
- introduce API service interfaces and implementations that provide CRUD operations for the new modules
- register the new API services with the MAUI dependency injection container

## Testing
- Not run (dotnet CLI not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68dbd1099f148329ab04e3b9ef726159