### PR TITLE
Add CRUD services for leave credits, employee types, and levels

### DIFF
--- a/src/Bluewater.Core/Interfaces/ICreateEmployeeTypeService.cs
+++ b/src/Bluewater.Core/Interfaces/ICreateEmployeeTypeService.cs
@@ -1,0 +1,8 @@
+using Ardalis.Result;
+
+namespace Bluewater.Core.Interfaces;
+
+public interface ICreateEmployeeTypeService
+{
+  Task<Result<Guid>> CreateEmployeeTypeAsync(string name, string value, bool isActive, CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.Core/Interfaces/ICreateLeaveCreditService.cs
+++ b/src/Bluewater.Core/Interfaces/ICreateLeaveCreditService.cs
@@ -1,0 +1,16 @@
+using Ardalis.Result;
+using Bluewater.Core.LeaveCreditAggregate;
+
+namespace Bluewater.Core.Interfaces;
+
+public interface ICreateLeaveCreditService
+{
+  Task<Result<Guid>> CreateLeaveCredit(
+    string code,
+    string? description,
+    decimal? credit,
+    int? sortOrder,
+    bool isLeaveWithPay,
+    bool isCanCarryOver,
+    CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.Core/Interfaces/ICreateLevelService.cs
+++ b/src/Bluewater.Core/Interfaces/ICreateLevelService.cs
@@ -1,0 +1,8 @@
+using Ardalis.Result;
+
+namespace Bluewater.Core.Interfaces;
+
+public interface ICreateLevelService
+{
+  Task<Result<Guid>> CreateLevelAsync(string name, string value, bool isActive, CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.Core/Interfaces/IGetEmployeeTypeService.cs
+++ b/src/Bluewater.Core/Interfaces/IGetEmployeeTypeService.cs
@@ -1,0 +1,8 @@
+using Bluewater.Core.EmployeeTypeAggregate;
+
+namespace Bluewater.Core.Interfaces;
+
+public interface IGetEmployeeTypeService
+{
+  Task<EmployeeType?> GetEmployeeTypeAsync(Guid employeeTypeId, CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.Core/Interfaces/IGetLeaveCreditService.cs
+++ b/src/Bluewater.Core/Interfaces/IGetLeaveCreditService.cs
@@ -1,0 +1,8 @@
+using Bluewater.Core.LeaveCreditAggregate;
+
+namespace Bluewater.Core.Interfaces;
+
+public interface IGetLeaveCreditService
+{
+  Task<LeaveCredit?> GetLeaveCreditAsync(Guid leaveCreditId, CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.Core/Interfaces/IGetLevelService.cs
+++ b/src/Bluewater.Core/Interfaces/IGetLevelService.cs
@@ -1,0 +1,8 @@
+using Bluewater.Core.LevelAggregate;
+
+namespace Bluewater.Core.Interfaces;
+
+public interface IGetLevelService
+{
+  Task<Level?> GetLevelAsync(Guid levelId, CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.Core/Interfaces/IListEmployeeTypeService.cs
+++ b/src/Bluewater.Core/Interfaces/IListEmployeeTypeService.cs
@@ -1,0 +1,8 @@
+using Bluewater.Core.EmployeeTypeAggregate;
+
+namespace Bluewater.Core.Interfaces;
+
+public interface IListEmployeeTypeService
+{
+  Task<IEnumerable<EmployeeType>> ListEmployeeTypesAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.Core/Interfaces/IListLeaveCreditService.cs
+++ b/src/Bluewater.Core/Interfaces/IListLeaveCreditService.cs
@@ -1,0 +1,8 @@
+using Bluewater.Core.LeaveCreditAggregate;
+
+namespace Bluewater.Core.Interfaces;
+
+public interface IListLeaveCreditService
+{
+  Task<IEnumerable<LeaveCredit>> ListLeaveCreditsAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.Core/Interfaces/IListLevelService.cs
+++ b/src/Bluewater.Core/Interfaces/IListLevelService.cs
@@ -1,0 +1,8 @@
+using Bluewater.Core.LevelAggregate;
+
+namespace Bluewater.Core.Interfaces;
+
+public interface IListLevelService
+{
+  Task<IEnumerable<Level>> ListLevelsAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.Core/Interfaces/IUpdateEmployeeTypeService.cs
+++ b/src/Bluewater.Core/Interfaces/IUpdateEmployeeTypeService.cs
@@ -1,0 +1,9 @@
+using Ardalis.Result;
+using Bluewater.Core.EmployeeTypeAggregate;
+
+namespace Bluewater.Core.Interfaces;
+
+public interface IUpdateEmployeeTypeService
+{
+  Task<Result<EmployeeType>> UpdateEmployeeTypeAsync(Guid employeeTypeId, string name, string value, bool isActive, CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.Core/Interfaces/IUpdateLeaveCreditService.cs
+++ b/src/Bluewater.Core/Interfaces/IUpdateLeaveCreditService.cs
@@ -1,0 +1,17 @@
+using Ardalis.Result;
+using Bluewater.Core.LeaveCreditAggregate;
+
+namespace Bluewater.Core.Interfaces;
+
+public interface IUpdateLeaveCreditService
+{
+  Task<Result<LeaveCredit>> UpdateLeaveCreditAsync(
+    Guid leaveCreditId,
+    string code,
+    string? description,
+    decimal? credit,
+    int? sortOrder,
+    bool isLeaveWithPay,
+    bool isCanCarryOver,
+    CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.Core/Interfaces/IUpdateLevelService.cs
+++ b/src/Bluewater.Core/Interfaces/IUpdateLevelService.cs
@@ -1,0 +1,9 @@
+using Ardalis.Result;
+using Bluewater.Core.LevelAggregate;
+
+namespace Bluewater.Core.Interfaces;
+
+public interface IUpdateLevelService
+{
+  Task<Result<Level>> UpdateLevelAsync(Guid levelId, string name, string value, bool isActive, CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.Core/LeaveCreditAggregate/LeaveCredit.cs
+++ b/src/Bluewater.Core/LeaveCreditAggregate/LeaveCredit.cs
@@ -16,4 +16,15 @@ public class LeaveCredit(string leaveCode, string leaveDescription, decimal defa
   public Guid UpdateBy { get; private set; } = Guid.Empty;
 
   public LeaveCredit() : this(string.Empty, string.Empty, 0, false, false, 0) { }
+
+  public void UpdateLeaveCredit(string leaveCode, string leaveDescription, decimal defaultCredits, bool isLeaveWithPay, bool isCanCarryOver, int sortOrder)
+  {
+    LeaveCode = leaveCode;
+    LeaveDescription = leaveDescription;
+    DefaultCredits = defaultCredits;
+    IsLeaveWithPay = isLeaveWithPay;
+    IsCanCarryOver = isCanCarryOver;
+    SortOrder = sortOrder;
+    UpdatedDate = DateTime.Now;
+  }
 }

--- a/src/Bluewater.Core/Services/CreateEmployeeTypeService.cs
+++ b/src/Bluewater.Core/Services/CreateEmployeeTypeService.cs
@@ -1,0 +1,30 @@
+using Ardalis.Result;
+using Ardalis.SharedKernel;
+using Bluewater.Core.EmployeeTypeAggregate;
+using Bluewater.Core.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace Bluewater.Core.Services;
+
+public class CreateEmployeeTypeService(IRepository<EmployeeType> _repository, ILogger<CreateEmployeeTypeService> _logger) : ICreateEmployeeTypeService
+{
+  public async Task<Result<Guid>> CreateEmployeeTypeAsync(string name, string value, bool isActive, CancellationToken cancellationToken = default)
+  {
+    if (string.IsNullOrWhiteSpace(name))
+    {
+      return Result<Guid>.Invalid(new[] { new ValidationError(nameof(name), "Employee type name is required.") });
+    }
+
+    if (string.IsNullOrWhiteSpace(value))
+    {
+      return Result<Guid>.Invalid(new[] { new ValidationError(nameof(value), "Employee type value is required.") });
+    }
+
+    var employeeType = new EmployeeType(name, value, isActive);
+    var created = await _repository.AddAsync(employeeType, cancellationToken);
+
+    _logger.LogInformation("Created Employee Type {EmployeeTypeId}", created.Id);
+
+    return Result.Success(created.Id);
+  }
+}

--- a/src/Bluewater.Core/Services/CreateLeaveCreditService.cs
+++ b/src/Bluewater.Core/Services/CreateLeaveCreditService.cs
@@ -1,0 +1,52 @@
+using Ardalis.Result;
+using Ardalis.SharedKernel;
+using Bluewater.Core.Interfaces;
+using Bluewater.Core.LeaveCreditAggregate;
+using Microsoft.Extensions.Logging;
+
+namespace Bluewater.Core.Services;
+
+public class CreateLeaveCreditService(IRepository<LeaveCredit> _repository, ILogger<CreateLeaveCreditService> _logger) : ICreateLeaveCreditService
+{
+  public async Task<Result<Guid>> CreateLeaveCredit(
+    string code,
+    string? description,
+    decimal? credit,
+    int? sortOrder,
+    bool isLeaveWithPay,
+    bool isCanCarryOver,
+    CancellationToken cancellationToken = default)
+  {
+    if (string.IsNullOrWhiteSpace(code))
+    {
+      return Result<Guid>.CriticalError(code ?? string.Empty, "Leave code is required.");
+    }
+
+    if (string.IsNullOrWhiteSpace(description))
+    {
+      return Result<Guid>.CriticalError(description ?? string.Empty, "Leave description is required.");
+    }
+
+    if (credit <= 0)
+    {
+      return Result<Guid>.CriticalError((credit ?? 0).ToString(), "Leave credit must be greater than 0.");
+    }
+
+    if (sortOrder < 0)
+    {
+      return Result<Guid>.CriticalError((sortOrder ?? 0).ToString(), "Sort order must be greater than or equal to 0.");
+    }
+
+    if (sortOrder > 100)
+    {
+      return Result<Guid>.CriticalError((sortOrder ?? 0).ToString(), "Sort order must be less than or equal to 100.");
+    }
+
+    var leaveCredit = new LeaveCredit(code, description!, credit ?? 0.00m, isLeaveWithPay, isCanCarryOver, sortOrder ?? 0);
+    var created = await _repository.AddAsync(leaveCredit, cancellationToken);
+
+    _logger.LogInformation("Created Leave Credit {LeaveCreditId}", created.Id);
+
+    return created.Id;
+  }
+}

--- a/src/Bluewater.Core/Services/CreateLevelService.cs
+++ b/src/Bluewater.Core/Services/CreateLevelService.cs
@@ -1,0 +1,30 @@
+using Ardalis.Result;
+using Ardalis.SharedKernel;
+using Bluewater.Core.Interfaces;
+using Bluewater.Core.LevelAggregate;
+using Microsoft.Extensions.Logging;
+
+namespace Bluewater.Core.Services;
+
+public class CreateLevelService(IRepository<Level> _repository, ILogger<CreateLevelService> _logger) : ICreateLevelService
+{
+  public async Task<Result<Guid>> CreateLevelAsync(string name, string value, bool isActive, CancellationToken cancellationToken = default)
+  {
+    if (string.IsNullOrWhiteSpace(name))
+    {
+      return Result<Guid>.Invalid(new[] { new ValidationError(nameof(name), "Level name is required.") });
+    }
+
+    if (string.IsNullOrWhiteSpace(value))
+    {
+      return Result<Guid>.Invalid(new[] { new ValidationError(nameof(value), "Level value is required.") });
+    }
+
+    var level = new Level(name, value, isActive);
+    var created = await _repository.AddAsync(level, cancellationToken);
+
+    _logger.LogInformation("Created Level {LevelId}", created.Id);
+
+    return Result.Success(created.Id);
+  }
+}

--- a/src/Bluewater.Core/Services/GetEmployeeTypeService.cs
+++ b/src/Bluewater.Core/Services/GetEmployeeTypeService.cs
@@ -1,0 +1,15 @@
+using Ardalis.SharedKernel;
+using Bluewater.Core.EmployeeTypeAggregate;
+using Bluewater.Core.EmployeeTypeAggregate.Specifications;
+using Bluewater.Core.Interfaces;
+
+namespace Bluewater.Core.Services;
+
+public class GetEmployeeTypeService(IReadRepository<EmployeeType> _repository) : IGetEmployeeTypeService
+{
+  public async Task<EmployeeType?> GetEmployeeTypeAsync(Guid employeeTypeId, CancellationToken cancellationToken = default)
+  {
+    var spec = new EmployeeTypeByIdSpec(employeeTypeId);
+    return await _repository.FirstOrDefaultAsync(spec, cancellationToken);
+  }
+}

--- a/src/Bluewater.Core/Services/GetLeaveCreditService.cs
+++ b/src/Bluewater.Core/Services/GetLeaveCreditService.cs
@@ -1,0 +1,13 @@
+using Ardalis.SharedKernel;
+using Bluewater.Core.Interfaces;
+using Bluewater.Core.LeaveCreditAggregate;
+
+namespace Bluewater.Core.Services;
+
+public class GetLeaveCreditService(IReadRepository<LeaveCredit> _repository) : IGetLeaveCreditService
+{
+  public async Task<LeaveCredit?> GetLeaveCreditAsync(Guid leaveCreditId, CancellationToken cancellationToken = default)
+  {
+    return await _repository.GetByIdAsync(leaveCreditId, cancellationToken);
+  }
+}

--- a/src/Bluewater.Core/Services/GetLevelService.cs
+++ b/src/Bluewater.Core/Services/GetLevelService.cs
@@ -1,0 +1,15 @@
+using Ardalis.SharedKernel;
+using Bluewater.Core.Interfaces;
+using Bluewater.Core.LevelAggregate;
+using Bluewater.Core.LevelAggregate.Specifications;
+
+namespace Bluewater.Core.Services;
+
+public class GetLevelService(IReadRepository<Level> _repository) : IGetLevelService
+{
+  public async Task<Level?> GetLevelAsync(Guid levelId, CancellationToken cancellationToken = default)
+  {
+    var spec = new LevelByIdSpec(levelId);
+    return await _repository.FirstOrDefaultAsync(spec, cancellationToken);
+  }
+}

--- a/src/Bluewater.Core/Services/ListEmployeeTypeService.cs
+++ b/src/Bluewater.Core/Services/ListEmployeeTypeService.cs
@@ -1,0 +1,15 @@
+using System.Linq;
+using Ardalis.SharedKernel;
+using Bluewater.Core.EmployeeTypeAggregate;
+using Bluewater.Core.Interfaces;
+
+namespace Bluewater.Core.Services;
+
+public class ListEmployeeTypeService(IReadRepository<EmployeeType> _repository) : IListEmployeeTypeService
+{
+  public async Task<IEnumerable<EmployeeType>> ListEmployeeTypesAsync(CancellationToken cancellationToken = default)
+  {
+    var employeeTypes = await _repository.ListAsync(cancellationToken);
+    return employeeTypes.AsEnumerable();
+  }
+}

--- a/src/Bluewater.Core/Services/ListLeaveCreditService.cs
+++ b/src/Bluewater.Core/Services/ListLeaveCreditService.cs
@@ -1,0 +1,15 @@
+using System.Linq;
+using Ardalis.SharedKernel;
+using Bluewater.Core.Interfaces;
+using Bluewater.Core.LeaveCreditAggregate;
+
+namespace Bluewater.Core.Services;
+
+public class ListLeaveCreditService(IReadRepository<LeaveCredit> _repository) : IListLeaveCreditService
+{
+  public async Task<IEnumerable<LeaveCredit>> ListLeaveCreditsAsync(CancellationToken cancellationToken = default)
+  {
+    var leaveCredits = await _repository.ListAsync(cancellationToken);
+    return leaveCredits.AsEnumerable();
+  }
+}

--- a/src/Bluewater.Core/Services/ListLevelService.cs
+++ b/src/Bluewater.Core/Services/ListLevelService.cs
@@ -1,0 +1,15 @@
+using System.Linq;
+using Ardalis.SharedKernel;
+using Bluewater.Core.Interfaces;
+using Bluewater.Core.LevelAggregate;
+
+namespace Bluewater.Core.Services;
+
+public class ListLevelService(IReadRepository<Level> _repository) : IListLevelService
+{
+  public async Task<IEnumerable<Level>> ListLevelsAsync(CancellationToken cancellationToken = default)
+  {
+    var levels = await _repository.ListAsync(cancellationToken);
+    return levels.AsEnumerable();
+  }
+}

--- a/src/Bluewater.Core/Services/UpdateEmployeeTypeService.cs
+++ b/src/Bluewater.Core/Services/UpdateEmployeeTypeService.cs
@@ -1,0 +1,36 @@
+using Ardalis.Result;
+using Ardalis.SharedKernel;
+using Bluewater.Core.EmployeeTypeAggregate;
+using Bluewater.Core.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace Bluewater.Core.Services;
+
+public class UpdateEmployeeTypeService(IRepository<EmployeeType> _repository, ILogger<UpdateEmployeeTypeService> _logger) : IUpdateEmployeeTypeService
+{
+  public async Task<Result<EmployeeType>> UpdateEmployeeTypeAsync(Guid employeeTypeId, string name, string value, bool isActive, CancellationToken cancellationToken = default)
+  {
+    var existing = await _repository.GetByIdAsync(employeeTypeId, cancellationToken);
+    if (existing == null)
+    {
+      return Result.NotFound();
+    }
+
+    if (string.IsNullOrWhiteSpace(name))
+    {
+      return Result<EmployeeType>.Invalid(new[] { new ValidationError(nameof(name), "Employee type name is required.") });
+    }
+
+    if (string.IsNullOrWhiteSpace(value))
+    {
+      return Result<EmployeeType>.Invalid(new[] { new ValidationError(nameof(value), "Employee type value is required.") });
+    }
+
+    existing.UpdateEmployeeType(name, value, isActive);
+    await _repository.UpdateAsync(existing, cancellationToken);
+
+    _logger.LogInformation("Updated Employee Type {EmployeeTypeId}", employeeTypeId);
+
+    return Result.Success(existing);
+  }
+}

--- a/src/Bluewater.Core/Services/UpdateLeaveCreditService.cs
+++ b/src/Bluewater.Core/Services/UpdateLeaveCreditService.cs
@@ -1,0 +1,59 @@
+using Ardalis.Result;
+using Ardalis.SharedKernel;
+using Bluewater.Core.Interfaces;
+using Bluewater.Core.LeaveCreditAggregate;
+using Microsoft.Extensions.Logging;
+
+namespace Bluewater.Core.Services;
+
+public class UpdateLeaveCreditService(IRepository<LeaveCredit> _repository, ILogger<UpdateLeaveCreditService> _logger) : IUpdateLeaveCreditService
+{
+  public async Task<Result<LeaveCredit>> UpdateLeaveCreditAsync(
+    Guid leaveCreditId,
+    string code,
+    string? description,
+    decimal? credit,
+    int? sortOrder,
+    bool isLeaveWithPay,
+    bool isCanCarryOver,
+    CancellationToken cancellationToken = default)
+  {
+    var existing = await _repository.GetByIdAsync(leaveCreditId, cancellationToken);
+    if (existing == null)
+    {
+      return Result.NotFound();
+    }
+
+    if (string.IsNullOrWhiteSpace(code))
+    {
+      return Result<LeaveCredit>.CriticalError(code ?? string.Empty, "Leave code is required.");
+    }
+
+    if (string.IsNullOrWhiteSpace(description))
+    {
+      return Result<LeaveCredit>.CriticalError(description ?? string.Empty, "Leave description is required.");
+    }
+
+    if (credit <= 0)
+    {
+      return Result<LeaveCredit>.CriticalError((credit ?? 0).ToString(), "Leave credit must be greater than 0.");
+    }
+
+    if (sortOrder < 0)
+    {
+      return Result<LeaveCredit>.CriticalError((sortOrder ?? 0).ToString(), "Sort order must be greater than or equal to 0.");
+    }
+
+    if (sortOrder > 100)
+    {
+      return Result<LeaveCredit>.CriticalError((sortOrder ?? 0).ToString(), "Sort order must be less than or equal to 100.");
+    }
+
+    existing.UpdateLeaveCredit(code, description!, credit ?? existing.DefaultCredits, isLeaveWithPay, isCanCarryOver, sortOrder ?? existing.SortOrder);
+    await _repository.UpdateAsync(existing, cancellationToken);
+
+    _logger.LogInformation("Updated Leave Credit {LeaveCreditId}", leaveCreditId);
+
+    return Result.Success(existing);
+  }
+}

--- a/src/Bluewater.Core/Services/UpdateLevelService.cs
+++ b/src/Bluewater.Core/Services/UpdateLevelService.cs
@@ -1,0 +1,36 @@
+using Ardalis.Result;
+using Ardalis.SharedKernel;
+using Bluewater.Core.Interfaces;
+using Bluewater.Core.LevelAggregate;
+using Microsoft.Extensions.Logging;
+
+namespace Bluewater.Core.Services;
+
+public class UpdateLevelService(IRepository<Level> _repository, ILogger<UpdateLevelService> _logger) : IUpdateLevelService
+{
+  public async Task<Result<Level>> UpdateLevelAsync(Guid levelId, string name, string value, bool isActive, CancellationToken cancellationToken = default)
+  {
+    var existing = await _repository.GetByIdAsync(levelId, cancellationToken);
+    if (existing == null)
+    {
+      return Result.NotFound();
+    }
+
+    if (string.IsNullOrWhiteSpace(name))
+    {
+      return Result<Level>.Invalid(new[] { new ValidationError(nameof(name), "Level name is required.") });
+    }
+
+    if (string.IsNullOrWhiteSpace(value))
+    {
+      return Result<Level>.Invalid(new[] { new ValidationError(nameof(value), "Level value is required.") });
+    }
+
+    existing.UpdateLevel(name, value, isActive);
+    await _repository.UpdateAsync(existing, cancellationToken);
+
+    _logger.LogInformation("Updated Level {LevelId}", levelId);
+
+    return Result.Success(existing);
+  }
+}

--- a/src/Bluewater.Infrastructure/InfrastructureServiceExtensions.cs
+++ b/src/Bluewater.Infrastructure/InfrastructureServiceExtensions.cs
@@ -74,14 +74,26 @@ public static class InfrastructureServiceExtensions
     // Holidays
     services.AddScoped<IDeleteHolidayService, DeleteHolidayService>();
     // Employee Types
+    services.AddScoped<ICreateEmployeeTypeService, CreateEmployeeTypeService>();
+    services.AddScoped<IListEmployeeTypeService, ListEmployeeTypeService>();
+    services.AddScoped<IGetEmployeeTypeService, GetEmployeeTypeService>();
+    services.AddScoped<IUpdateEmployeeTypeService, UpdateEmployeeTypeService>();
     services.AddScoped<IDeleteEmployeeTypeService, DeleteEmployeeTypeService>();
     // Employee Levels
+    services.AddScoped<ICreateLevelService, CreateLevelService>();
+    services.AddScoped<IListLevelService, ListLevelService>();
+    services.AddScoped<IGetLevelService, GetLevelService>();
+    services.AddScoped<IUpdateLevelService, UpdateLevelService>();
     services.AddScoped<IDeleteLevelService, DeleteLevelService>();
     // Shifts
     services.AddScoped<IListShiftQueryService, ListShiftsQueryService>();
     // Employee
     services.AddScoped<IDeleteEmployeeService, DeleteEmployeeService>();
     // LeaveCredits
+    services.AddScoped<ICreateLeaveCreditService, CreateLeaveCreditService>();
+    services.AddScoped<IListLeaveCreditService, ListLeaveCreditService>();
+    services.AddScoped<IGetLeaveCreditService, GetLeaveCreditService>();
+    services.AddScoped<IUpdateLeaveCreditService, UpdateLeaveCreditService>();
     services.AddScoped<IDeleteLeaveCreditService, DeleteLeaveCreditService>();
     // Leave
     services.AddScoped<IDeleteLeaveService, DeleteLeaveService>();

--- a/src/Bluewater.UseCases/EmployeeTypes/Create/CreateEmployeeTypeHandler.cs
+++ b/src/Bluewater.UseCases/EmployeeTypes/Create/CreateEmployeeTypeHandler.cs
@@ -1,15 +1,13 @@
 using Ardalis.Result;
 using Ardalis.SharedKernel;
-using Bluewater.Core.EmployeeTypeAggregate;
+using Bluewater.Core.Interfaces;
 using Bluewater.UseCases.EmployeeTypes.Create;
 
 namespace Bluewater.UseCases.Contributors.Create;
-public class CreateEmployeeTypeHandler(IRepository<EmployeeType> _repository) : ICommandHandler<CreateEmployeeTypeCommand, Result<Guid>>
+public class CreateEmployeeTypeHandler(ICreateEmployeeTypeService _createEmployeeTypeService) : ICommandHandler<CreateEmployeeTypeCommand, Result<Guid>>
 {
   public async Task<Result<Guid>> Handle(CreateEmployeeTypeCommand request, CancellationToken cancellationToken)
   {
-    var newEmployeeType = new EmployeeType(request.Name, request.Value, request.IsActive);
-    var createdItem = await _repository.AddAsync(newEmployeeType, cancellationToken);
-    return createdItem.Id;
+    return await _createEmployeeTypeService.CreateEmployeeTypeAsync(request.Name, request.Value, request.IsActive, cancellationToken);
   }
 }

--- a/src/Bluewater.UseCases/EmployeeTypes/Get/GetEmployeeTypeHandler.cs
+++ b/src/Bluewater.UseCases/EmployeeTypes/Get/GetEmployeeTypeHandler.cs
@@ -1,15 +1,13 @@
 using Ardalis.Result;
 using Ardalis.SharedKernel;
-using Bluewater.Core.EmployeeTypeAggregate;
-using Bluewater.Core.EmployeeTypeAggregate.Specifications;
+using Bluewater.Core.Interfaces;
 
 namespace Bluewater.UseCases.EmployeeTypes.Get;
-public class GetEmployeeTypeHandler(IRepository<EmployeeType> _repository) : IQueryHandler<GetEmployeeTypeQuery, Result<EmployeeTypeDTO>>
+public class GetEmployeeTypeHandler(IGetEmployeeTypeService _employeeTypeService) : IQueryHandler<GetEmployeeTypeQuery, Result<EmployeeTypeDTO>>
 {
   public async Task<Result<EmployeeTypeDTO>> Handle(GetEmployeeTypeQuery request, CancellationToken cancellationToken)
   {
-    var spec = new EmployeeTypeByIdSpec(request.EmployeeTypeId ?? Guid.Empty);
-    var entity = await _repository.FirstOrDefaultAsync(spec, cancellationToken);
+    var entity = await _employeeTypeService.GetEmployeeTypeAsync(request.EmployeeTypeId ?? Guid.Empty, cancellationToken);
     if (entity == null) return Result.NotFound();
 
     return new EmployeeTypeDTO(entity.Id, entity.Name, entity.Value, entity.IsActive);

--- a/src/Bluewater.UseCases/EmployeeTypes/List/ListEmployeeTypeHandler.cs
+++ b/src/Bluewater.UseCases/EmployeeTypes/List/ListEmployeeTypeHandler.cs
@@ -1,14 +1,16 @@
+using System.Linq;
 using Ardalis.Result;
 using Ardalis.SharedKernel;
-using Bluewater.Core.EmployeeTypeAggregate;
+using Bluewater.Core.Interfaces;
 
 namespace Bluewater.UseCases.EmployeeTypes.List;
 // NOTE: CHANGED FROM ORIGINAL IMPLEMENTATION
-internal class ListEmployeeTypeHandler(IRepository<EmployeeType> _repository) : IQueryHandler<ListEmployeeTypeQuery, Result<IEnumerable<EmployeeTypeDTO>>>
+internal class ListEmployeeTypeHandler(IListEmployeeTypeService _employeeTypeService) : IQueryHandler<ListEmployeeTypeQuery, Result<IEnumerable<EmployeeTypeDTO>>>
 {
   public async Task<Result<IEnumerable<EmployeeTypeDTO>>> Handle(ListEmployeeTypeQuery request, CancellationToken cancellationToken)
   {
-    var result = (await _repository.ListAsync(cancellationToken)).Select(s => new EmployeeTypeDTO(s.Id, s.Name, s.Value, s.IsActive));
+    var employeeTypes = await _employeeTypeService.ListEmployeeTypesAsync(cancellationToken);
+    var result = employeeTypes.Select(s => new EmployeeTypeDTO(s.Id, s.Name, s.Value, s.IsActive));
     return Result.Success(result);
   }
 }

--- a/src/Bluewater.UseCases/LeaveCredits/Create/CreateLeaveCreditHandler.cs
+++ b/src/Bluewater.UseCases/LeaveCredits/Create/CreateLeaveCreditHandler.cs
@@ -1,27 +1,20 @@
 ﻿using Ardalis.Result;
 using Ardalis.SharedKernel;
-using Bluewater.Core.LeaveCreditAggregate;
+using Bluewater.Core.Interfaces;
 
 namespace Bluewater.UseCases.LeaveCredits.Create;
 
-public class CreateLeaveCreditHandler(IRepository<LeaveCredit> _repository) : ICommandHandler<CreateLeaveCreditCommand, Result<Guid>>
+public class CreateLeaveCreditHandler(ICreateLeaveCreditService _createLeaveCreditService) : ICommandHandler<CreateLeaveCreditCommand, Result<Guid>>
 {
   public async Task<Result<Guid>> Handle(CreateLeaveCreditCommand request, CancellationToken cancellationToken)
   {
-    // assertions
-    if(string.IsNullOrWhiteSpace(request.Code))
-      return Result<Guid>.CriticalError(request.Code, "Leave code is required.");
-    if (string.IsNullOrWhiteSpace(request.Description))
-      return Result<Guid>.CriticalError(request.Description, "Leave description is required.");
-    if (request.Credit <= 0)
-      return Result<Guid>.CriticalError(request.Credit.ToString(), "Leave credit must be greater than 0.");
-    if (request.SortOrder < 0)
-      return Result<Guid>.CriticalError(request.SortOrder.ToString(), "Sort order must be greater than or equal to 0.");
-    if (request.SortOrder > 100)
-      return Result<Guid>.CriticalError(request.SortOrder.ToString(), "Sort order must be less than or equal to 100.");
-
-    var newLeaveCredit = new LeaveCredit(request.Code, request.Description, request.Credit ?? 0.00m, request.IsLeaveWithPay, request.IsCanCarryOver, request.SortOrder ?? 0);
-    var createdItem = await _repository.AddAsync(newLeaveCredit, cancellationToken);
-    return createdItem.Id;
+    return await _createLeaveCreditService.CreateLeaveCredit(
+      request.Code,
+      request.Description,
+      request.Credit,
+      request.SortOrder,
+      request.IsLeaveWithPay,
+      request.IsCanCarryOver,
+      cancellationToken);
   }
 }

--- a/src/Bluewater.UseCases/LeaveCredits/Get/GetLeaveCreditHandler.cs
+++ b/src/Bluewater.UseCases/LeaveCredits/Get/GetLeaveCreditHandler.cs
@@ -1,0 +1,17 @@
+using Ardalis.Result;
+using Ardalis.SharedKernel;
+using Bluewater.Core.Interfaces;
+using Bluewater.UseCases.LeaveCredits;
+
+namespace Bluewater.UseCases.LeaveCredits.Get;
+
+public class GetLeaveCreditHandler(IGetLeaveCreditService _leaveCreditService) : IQueryHandler<GetLeaveCreditQuery, Result<LeaveCreditDTO>>
+{
+  public async Task<Result<LeaveCreditDTO>> Handle(GetLeaveCreditQuery request, CancellationToken cancellationToken)
+  {
+    var entity = await _leaveCreditService.GetLeaveCreditAsync(request.LeaveCreditId ?? Guid.Empty, cancellationToken);
+    if (entity == null) return Result.NotFound();
+
+    return new LeaveCreditDTO(entity.Id, entity.LeaveCode, entity.LeaveDescription, entity.DefaultCredits, entity.SortOrder, entity.IsLeaveWithPay, entity.IsCanCarryOver);
+  }
+}

--- a/src/Bluewater.UseCases/LeaveCredits/Get/GetLeaveCreditQuery.cs
+++ b/src/Bluewater.UseCases/LeaveCredits/Get/GetLeaveCreditQuery.cs
@@ -1,0 +1,7 @@
+using Ardalis.Result;
+using Ardalis.SharedKernel;
+using Bluewater.UseCases.LeaveCredits;
+
+namespace Bluewater.UseCases.LeaveCredits.Get;
+
+public record GetLeaveCreditQuery(Guid? LeaveCreditId) : IQuery<Result<LeaveCreditDTO>>;

--- a/src/Bluewater.UseCases/LeaveCredits/List/ListLeaveCreditHandler.cs
+++ b/src/Bluewater.UseCases/LeaveCredits/List/ListLeaveCreditHandler.cs
@@ -1,15 +1,17 @@
 ﻿
+using System.Linq;
 using Ardalis.Result;
 using Ardalis.SharedKernel;
-using Bluewater.Core.LeaveCreditAggregate;
+using Bluewater.Core.Interfaces;
 
 namespace Bluewater.UseCases.LeaveCredits.List;
 
-public class ListLeaveCreditHandler(IRepository<LeaveCredit> _repository) : IQueryHandler<ListLeaveCreditQuery, Result<IEnumerable<LeaveCreditDTO>>>
+public class ListLeaveCreditHandler(IListLeaveCreditService _leaveCreditService) : IQueryHandler<ListLeaveCreditQuery, Result<IEnumerable<LeaveCreditDTO>>>
 {
   public async Task<Result<IEnumerable<LeaveCreditDTO>>> Handle(ListLeaveCreditQuery request, CancellationToken cancellationToken)
   {
-    var result = (await _repository.ListAsync(cancellationToken)).Select(s => new LeaveCreditDTO(s.Id, s.LeaveCode, s.LeaveDescription, s.DefaultCredits, s.SortOrder, s.IsLeaveWithPay, s.IsCanCarryOver));
+    var leaveCredits = await _leaveCreditService.ListLeaveCreditsAsync(cancellationToken);
+    var result = leaveCredits.Select(s => new LeaveCreditDTO(s.Id, s.LeaveCode, s.LeaveDescription, s.DefaultCredits, s.SortOrder, s.IsLeaveWithPay, s.IsCanCarryOver));
     return Result.Success(result);
   }
 }

--- a/src/Bluewater.UseCases/LeaveCredits/Update/UpdateLeaveCreditCommand.cs
+++ b/src/Bluewater.UseCases/LeaveCredits/Update/UpdateLeaveCreditCommand.cs
@@ -1,0 +1,14 @@
+using Ardalis.Result;
+using Ardalis.SharedKernel;
+using Bluewater.UseCases.LeaveCredits;
+
+namespace Bluewater.UseCases.LeaveCredits.Update;
+
+public record UpdateLeaveCreditCommand(
+  Guid LeaveCreditId,
+  string Code,
+  string? Description,
+  decimal? Credit,
+  int? SortOrder,
+  bool IsLeaveWithPay,
+  bool IsCanCarryOver) : ICommand<Result<LeaveCreditDTO>>;

--- a/src/Bluewater.UseCases/LeaveCredits/Update/UpdateLeaveCreditHandler.cs
+++ b/src/Bluewater.UseCases/LeaveCredits/Update/UpdateLeaveCreditHandler.cs
@@ -1,0 +1,40 @@
+using System.Linq;
+using Ardalis.Result;
+using Ardalis.SharedKernel;
+using Bluewater.Core.Interfaces;
+using Bluewater.UseCases.LeaveCredits;
+
+namespace Bluewater.UseCases.LeaveCredits.Update;
+
+public class UpdateLeaveCreditHandler(IUpdateLeaveCreditService _updateLeaveCreditService) : ICommandHandler<UpdateLeaveCreditCommand, Result<LeaveCreditDTO>>
+{
+  public async Task<Result<LeaveCreditDTO>> Handle(UpdateLeaveCreditCommand request, CancellationToken cancellationToken)
+  {
+    var updateResult = await _updateLeaveCreditService.UpdateLeaveCreditAsync(
+      request.LeaveCreditId,
+      request.Code,
+      request.Description,
+      request.Credit,
+      request.SortOrder,
+      request.IsLeaveWithPay,
+      request.IsCanCarryOver,
+      cancellationToken);
+
+    if (!updateResult.IsSuccess)
+    {
+      return updateResult.Status switch
+      {
+        ResultStatus.NotFound => Result<LeaveCreditDTO>.NotFound(),
+        ResultStatus.Invalid => Result<LeaveCreditDTO>.Invalid(updateResult.ValidationErrors),
+        ResultStatus.Unauthorized => Result<LeaveCreditDTO>.Unauthorized(),
+        ResultStatus.Forbidden => Result<LeaveCreditDTO>.Forbidden(),
+        ResultStatus.CriticalError => Result<LeaveCreditDTO>.CriticalError(updateResult.Errors.ToArray()),
+        ResultStatus.Error => Result<LeaveCreditDTO>.Error(updateResult.Errors.ToArray()),
+        _ => Result<LeaveCreditDTO>.Error(new[] { "Unable to update leave credit." })
+      };
+    }
+
+    var leaveCredit = updateResult.Value;
+    return Result.Success(new LeaveCreditDTO(leaveCredit.Id, leaveCredit.LeaveCode, leaveCredit.LeaveDescription, leaveCredit.DefaultCredits, leaveCredit.SortOrder, leaveCredit.IsLeaveWithPay, leaveCredit.IsCanCarryOver));
+  }
+}

--- a/src/Bluewater.UseCases/Levels/Create/CreateLevelHandler.cs
+++ b/src/Bluewater.UseCases/Levels/Create/CreateLevelHandler.cs
@@ -1,15 +1,13 @@
 using Ardalis.Result;
 using Ardalis.SharedKernel;
-using Bluewater.Core.LevelAggregate;
+using Bluewater.Core.Interfaces;
 using Bluewater.UseCases.Levels.Create;
 
 namespace Bluewater.UseCases.Contributors.Create;
-public class CreateLevelHandler(IRepository<Level> _repository) : ICommandHandler<CreateLevelCommand, Result<Guid>>
+public class CreateLevelHandler(ICreateLevelService _createLevelService) : ICommandHandler<CreateLevelCommand, Result<Guid>>
 {
   public async Task<Result<Guid>> Handle(CreateLevelCommand request, CancellationToken cancellationToken)
   {
-    var newLevel = new Level(request.Name, request.Value, request.IsActive);
-    var createdItem = await _repository.AddAsync(newLevel, cancellationToken);
-    return createdItem.Id;
+    return await _createLevelService.CreateLevelAsync(request.Name, request.Value, request.IsActive, cancellationToken);
   }
 }

--- a/src/Bluewater.UseCases/Levels/Get/GetLevelHandler.cs
+++ b/src/Bluewater.UseCases/Levels/Get/GetLevelHandler.cs
@@ -1,15 +1,13 @@
 using Ardalis.Result;
 using Ardalis.SharedKernel;
-using Bluewater.Core.LevelAggregate;
-using Bluewater.Core.LevelAggregate.Specifications;
+using Bluewater.Core.Interfaces;
 
 namespace Bluewater.UseCases.Levels.Get;
-public class GetLevelHandler(IRepository<Level> _repository) : IQueryHandler<GetLevelQuery, Result<LevelDTO>>
+public class GetLevelHandler(IGetLevelService _levelService) : IQueryHandler<GetLevelQuery, Result<LevelDTO>>
 {
   public async Task<Result<LevelDTO>> Handle(GetLevelQuery request, CancellationToken cancellationToken)
   {
-    var spec = new LevelByIdSpec(request.LevelId ?? Guid.Empty);
-    var entity = await _repository.FirstOrDefaultAsync(spec, cancellationToken);
+    var entity = await _levelService.GetLevelAsync(request.LevelId ?? Guid.Empty, cancellationToken);
     if (entity == null) return Result.NotFound();
 
     return new LevelDTO(entity.Id, entity.Name, entity.Value, entity.IsActive);

--- a/src/Bluewater.UseCases/Levels/List/ListLevelHandler.cs
+++ b/src/Bluewater.UseCases/Levels/List/ListLevelHandler.cs
@@ -1,14 +1,16 @@
 using Ardalis.Result;
+using System.Linq;
 using Ardalis.SharedKernel;
-using Bluewater.Core.LevelAggregate;
+using Bluewater.Core.Interfaces;
 
 namespace Bluewater.UseCases.Levels.List;
 
-internal class ListLevelHandler(IRepository<Level> _repository) : IQueryHandler<ListLevelQuery, Result<IEnumerable<LevelDTO>>>
+internal class ListLevelHandler(IListLevelService _levelService) : IQueryHandler<ListLevelQuery, Result<IEnumerable<LevelDTO>>>
 {
   public async Task<Result<IEnumerable<LevelDTO>>> Handle(ListLevelQuery request, CancellationToken cancellationToken)
   {
-    var result = (await _repository.ListAsync(cancellationToken)).Select(s => new LevelDTO(s.Id, s.Name, s.Value, s.IsActive));
+    var levels = await _levelService.ListLevelsAsync(cancellationToken);
+    var result = levels.Select(s => new LevelDTO(s.Id, s.Name, s.Value, s.IsActive));
     return Result.Success(result);
   }
 }

--- a/src/Bluewater.UseCases/Levels/Update/UpdateLevelHandler.cs
+++ b/src/Bluewater.UseCases/Levels/Update/UpdateLevelHandler.cs
@@ -1,22 +1,30 @@
+using System.Linq;
 using Ardalis.Result;
 using Ardalis.SharedKernel;
-using Bluewater.Core.LevelAggregate;
+using Bluewater.Core.Interfaces;
 
 namespace Bluewater.UseCases.Levels.Update;
-public class UpdateLevelHandler(IRepository<Level> _repository) : ICommandHandler<UpdateLevelCommand, Result<LevelDTO>>
+public class UpdateLevelHandler(IUpdateLevelService _updateLevelService) : ICommandHandler<UpdateLevelCommand, Result<LevelDTO>>
 {
   public async Task<Result<LevelDTO>> Handle(UpdateLevelCommand request, CancellationToken cancellationToken)
   {
-    var existingLevel = await _repository.GetByIdAsync(request.LevelId, cancellationToken);
-    if (existingLevel == null)
+    var updateResult = await _updateLevelService.UpdateLevelAsync(request.LevelId, request.NewName, request.Value, request.IsActive, cancellationToken);
+
+    if (!updateResult.IsSuccess)
     {
-      return Result.NotFound();
+      return updateResult.Status switch
+      {
+        ResultStatus.NotFound => Result<LevelDTO>.NotFound(),
+        ResultStatus.Invalid => Result<LevelDTO>.Invalid(updateResult.ValidationErrors),
+        ResultStatus.Unauthorized => Result<LevelDTO>.Unauthorized(),
+        ResultStatus.Forbidden => Result<LevelDTO>.Forbidden(),
+        ResultStatus.CriticalError => Result<LevelDTO>.CriticalError(updateResult.Errors.ToArray()),
+        ResultStatus.Error => Result<LevelDTO>.Error(updateResult.Errors.ToArray()),
+        _ => Result<LevelDTO>.Error(new[] { "Unable to update level." })
+      };
     }
 
-    existingLevel.UpdateLevel(request.NewName!, request.Value, request.IsActive);
-
-    await _repository.UpdateAsync(existingLevel, cancellationToken);
-
-    return Result.Success(new LevelDTO(existingLevel.Id, existingLevel.Name, existingLevel.Value, existingLevel.IsActive));
+    var level = updateResult.Value;
+    return Result.Success(new LevelDTO(level.Id, level.Name, level.Value, level.IsActive));
   }
 }


### PR DESCRIPTION
## Summary
- add dedicated create, list, get, and update service interfaces plus implementations for leave credits, employee types, and levels, including an entity update helper for leave credits
- refactor the corresponding use case handlers to consume the new services and introduce missing get/update handlers for leave credits
- register the new services in the infrastructure dependency injection container

## Testing
- dotnet build *(fails: `dotnet`: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd5775e9c832997702120ae8dbd24