### PR TITLE
Add activity tracing service and logging

### DIFF
--- a/src/Bluewater.App/App.xaml.cs
+++ b/src/Bluewater.App/App.xaml.cs
@@ -1,14 +1,17 @@
-﻿namespace Bluewater.App;
+namespace Bluewater.App;
 
 public partial class App : Application
 {
-  public App()
+  private readonly AppShell appShell;
+
+  public App(AppShell appShell)
   {
     InitializeComponent();
+    this.appShell = appShell;
   }
 
   protected override Window CreateWindow(IActivationState? activationState)
   {
-    return new Window(new AppShell());
+    return new Window(appShell);
   }
 }

--- a/src/Bluewater.App/AppShell.xaml.cs
+++ b/src/Bluewater.App/AppShell.xaml.cs
@@ -1,9 +1,44 @@
-﻿namespace Bluewater.App;
+using Bluewater.App.Interfaces;
+
+namespace Bluewater.App;
 
 public partial class AppShell : Shell
 {
-  public AppShell()
+  private readonly IActivityTraceService activityTraceService;
+
+  public AppShell(IActivityTraceService activityTraceService)
   {
     InitializeComponent();
+    this.activityTraceService = activityTraceService;
+
+    Navigated += OnShellNavigated;
+    Navigating += OnShellNavigating;
+  }
+
+  private async void OnShellNavigated(object? sender, ShellNavigatedEventArgs e)
+  {
+    await activityTraceService
+      .LogNavigationAsync(
+        e.Previous?.Location.OriginalString,
+        e.Current?.Location.OriginalString,
+        new
+        {
+          Phase = "Navigated"
+        })
+      .ConfigureAwait(false);
+  }
+
+  private async void OnShellNavigating(object? sender, ShellNavigatingEventArgs e)
+  {
+    await activityTraceService
+      .LogNavigationAsync(
+        e.Current?.Location.OriginalString,
+        e.Target?.Location.OriginalString,
+        new
+        {
+          Phase = "Navigating",
+          e.Source
+        })
+      .ConfigureAwait(false);
   }
 }

--- a/src/Bluewater.App/Interfaces/IActivityTraceService.cs
+++ b/src/Bluewater.App/Interfaces/IActivityTraceService.cs
@@ -1,0 +1,10 @@
+namespace Bluewater.App.Interfaces;
+
+public interface IActivityTraceService
+{
+  Task LogNavigationAsync(string? fromRoute, string? toRoute, object? metadata = null);
+
+  Task LogCommandAsync(string commandName, object? metadata = null);
+
+  Task<string> GetCurrentLogPathAsync();
+}

--- a/src/Bluewater.App/MauiProgram.cs
+++ b/src/Bluewater.App/MauiProgram.cs
@@ -65,6 +65,9 @@ public static class MauiProgram
     builder.Services.AddSingleton<IAttendanceApiService, AttendanceApiService>();
     builder.Services.AddSingleton<IPayrollApiService, PayrollApiService>();
     builder.Services.AddSingleton<IScheduleApiService, ScheduleApiService>();
+    builder.Services.AddSingleton<IActivityTraceService, ActivityTraceService>();
+
+    builder.Services.AddSingleton<AppShell>();
 
     // pages
     builder.Services.AddSingleton<AttendancePage>();

--- a/src/Bluewater.App/Models/ActivityTraceEntry.cs
+++ b/src/Bluewater.App/Models/ActivityTraceEntry.cs
@@ -1,0 +1,9 @@
+namespace Bluewater.App.Models;
+
+public record ActivityTraceEntry(
+  DateTimeOffset Timestamp,
+  string EventType,
+  string? FromRoute = null,
+  string? ToRoute = null,
+  string? CommandName = null,
+  object? Metadata = null);

--- a/src/Bluewater.App/Services/ActivityTraceService.cs
+++ b/src/Bluewater.App/Services/ActivityTraceService.cs
@@ -1,0 +1,93 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using Bluewater.App.Interfaces;
+using Bluewater.App.Models;
+using Microsoft.Maui.Storage;
+
+namespace Bluewater.App.Services;
+
+public sealed class ActivityTraceService : IActivityTraceService, IAsyncDisposable
+{
+  private const string LogFilePrefix = "activity-trace-";
+  private readonly SemaphoreSlim writeLock = new(1, 1);
+  private readonly JsonSerializerOptions serializerOptions = new()
+  {
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+  };
+
+  private readonly string appDataDirectory;
+
+  public ActivityTraceService(string? appDataDirectory = null)
+  {
+    this.appDataDirectory = appDataDirectory ?? FileSystem.AppDataDirectory;
+  }
+
+  public Task<string> GetCurrentLogPathAsync()
+  {
+    string logFilePath = GetLogFilePath(DateTimeOffset.UtcNow);
+    return Task.FromResult(logFilePath);
+  }
+
+  public Task LogCommandAsync(string commandName, object? metadata = null)
+  {
+    if (string.IsNullOrWhiteSpace(commandName))
+    {
+      throw new ArgumentException("Command name must be provided.", nameof(commandName));
+    }
+
+    var entry = new ActivityTraceEntry(
+      Timestamp: DateTimeOffset.UtcNow,
+      EventType: "Command",
+      CommandName: commandName,
+      Metadata: metadata);
+
+    return AppendEntryAsync(entry);
+  }
+
+  public Task LogNavigationAsync(string? fromRoute, string? toRoute, object? metadata = null)
+  {
+    var entry = new ActivityTraceEntry(
+      Timestamp: DateTimeOffset.UtcNow,
+      EventType: "Navigation",
+      FromRoute: fromRoute,
+      ToRoute: toRoute,
+      Metadata: metadata);
+
+    return AppendEntryAsync(entry);
+  }
+
+  private async Task AppendEntryAsync(ActivityTraceEntry entry)
+  {
+    string logFilePath = GetLogFilePath(entry.Timestamp);
+    Directory.CreateDirectory(Path.GetDirectoryName(logFilePath)!);
+
+    string serializedEntry = JsonSerializer.Serialize(entry, serializerOptions);
+
+    await writeLock.WaitAsync().ConfigureAwait(false);
+    try
+    {
+      await using var stream = new FileStream(logFilePath, FileMode.Append, FileAccess.Write, FileShare.Read);
+      await using var writer = new StreamWriter(stream, Encoding.UTF8);
+      await writer.WriteLineAsync(serializedEntry).ConfigureAwait(false);
+    }
+    finally
+    {
+      writeLock.Release();
+    }
+  }
+
+  private string GetLogFilePath(DateTimeOffset timestamp)
+  {
+    string fileName = $"{LogFilePrefix}{timestamp:yyyyMMdd}.log";
+    return Path.Combine(appDataDirectory, fileName);
+  }
+
+  public ValueTask DisposeAsync()
+  {
+    writeLock.Dispose();
+    return ValueTask.CompletedTask;
+  }
+}

--- a/src/Bluewater.App/ViewModels/AttendanceViewModel.cs
+++ b/src/Bluewater.App/ViewModels/AttendanceViewModel.cs
@@ -1,7 +1,12 @@
+using Bluewater.App.Interfaces;
 using Bluewater.App.ViewModels.Base;
 
 namespace Bluewater.App.ViewModels;
 
 public partial class AttendanceViewModel : BaseViewModel
 {
+  public AttendanceViewModel(IActivityTraceService activityTraceService)
+    : base(activityTraceService)
+  {
+  }
 }

--- a/src/Bluewater.App/ViewModels/Base/BaseViewModel.cs
+++ b/src/Bluewater.App/ViewModels/Base/BaseViewModel.cs
@@ -1,16 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Bluewater.App.Interfaces;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Bluewater.App.ViewModels.Base;
 
-public partial class BaseViewModel : ObservableObject
+public abstract partial class BaseViewModel : ObservableObject
 {
+  protected BaseViewModel(IActivityTraceService activityTraceService)
+  {
+    ActivityTraceService = activityTraceService;
+  }
+
+  protected IActivityTraceService ActivityTraceService { get; }
+
   [ObservableProperty]
   public partial bool IsBusy { get; set; }
+
+  protected Task TraceCommandAsync(string name, object? args = null)
+  {
+    return ActivityTraceService.LogCommandAsync(name, args);
+  }
 
   public virtual Task InitializeAsync() => Task.CompletedTask;
 }

--- a/src/Bluewater.App/ViewModels/EmployeeViewModel.cs
+++ b/src/Bluewater.App/ViewModels/EmployeeViewModel.cs
@@ -14,7 +14,8 @@ public partial class EmployeeViewModel : BaseViewModel
   private readonly IEmployeeApiService employeeApiService;
   private bool hasInitialized;
 
-  public EmployeeViewModel(IEmployeeApiService employeeApiService)
+  public EmployeeViewModel(IEmployeeApiService employeeApiService, IActivityTraceService activityTraceService)
+    : base(activityTraceService)
   {
     this.employeeApiService = employeeApiService;
   }

--- a/src/Bluewater.App/ViewModels/HomeViewModel.cs
+++ b/src/Bluewater.App/ViewModels/HomeViewModel.cs
@@ -1,7 +1,12 @@
+using Bluewater.App.Interfaces;
 using Bluewater.App.ViewModels.Base;
 
 namespace Bluewater.App.ViewModels;
 
 public partial class HomeViewModel : BaseViewModel
 {
+  public HomeViewModel(IActivityTraceService activityTraceService)
+    : base(activityTraceService)
+  {
+  }
 }

--- a/src/Bluewater.App/ViewModels/LeaveViewModel.cs
+++ b/src/Bluewater.App/ViewModels/LeaveViewModel.cs
@@ -1,7 +1,12 @@
+using Bluewater.App.Interfaces;
 using Bluewater.App.ViewModels.Base;
 
 namespace Bluewater.App.ViewModels;
 
 public partial class LeaveViewModel : BaseViewModel
 {
+  public LeaveViewModel(IActivityTraceService activityTraceService)
+    : base(activityTraceService)
+  {
+  }
 }

--- a/src/Bluewater.App/ViewModels/LoginViewModel.cs
+++ b/src/Bluewater.App/ViewModels/LoginViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Bluewater.App.ViewModels.Base;
+using Bluewater.App.Interfaces;
+using Bluewater.App.ViewModels.Base;
 using Bluewater.App.Views;
 using CommunityToolkit.Mvvm.Input;
 
@@ -6,13 +7,19 @@ namespace Bluewater.App.ViewModels;
 
 public partial class LoginViewModel : BaseViewModel
 {
+  public LoginViewModel(IActivityTraceService activityTraceService)
+    : base(activityTraceService)
+  {
+  }
+
   [RelayCommand]
   async Task LoginAsync()
   {
     try
     {
       IsBusy = true;
-      await Shell.Current.GoToAsync($"//{nameof(HomePage)}");
+      await TraceCommandAsync("Login", new { Target = nameof(HomePage) }).ConfigureAwait(false);
+      await Shell.Current.GoToAsync($"//{nameof(HomePage)}").ConfigureAwait(false);
     }
     finally
     {

--- a/src/Bluewater.App/ViewModels/MealCreditViewModel.cs
+++ b/src/Bluewater.App/ViewModels/MealCreditViewModel.cs
@@ -1,7 +1,12 @@
+using Bluewater.App.Interfaces;
 using Bluewater.App.ViewModels.Base;
 
 namespace Bluewater.App.ViewModels;
 
 public partial class MealCreditViewModel : BaseViewModel
 {
+  public MealCreditViewModel(IActivityTraceService activityTraceService)
+    : base(activityTraceService)
+  {
+  }
 }

--- a/src/Bluewater.App/ViewModels/PayrollViewModel.cs
+++ b/src/Bluewater.App/ViewModels/PayrollViewModel.cs
@@ -1,7 +1,12 @@
+using Bluewater.App.Interfaces;
 using Bluewater.App.ViewModels.Base;
 
 namespace Bluewater.App.ViewModels;
 
 public partial class PayrollViewModel : BaseViewModel
 {
+  public PayrollViewModel(IActivityTraceService activityTraceService)
+    : base(activityTraceService)
+  {
+  }
 }

--- a/src/Bluewater.App/ViewModels/ProfileViewModel.cs
+++ b/src/Bluewater.App/ViewModels/ProfileViewModel.cs
@@ -1,7 +1,12 @@
+using Bluewater.App.Interfaces;
 using Bluewater.App.ViewModels.Base;
 
 namespace Bluewater.App.ViewModels;
 
 public partial class ProfileViewModel : BaseViewModel
 {
+  public ProfileViewModel(IActivityTraceService activityTraceService)
+    : base(activityTraceService)
+  {
+  }
 }

--- a/src/Bluewater.App/ViewModels/ScheduleViewModel.cs
+++ b/src/Bluewater.App/ViewModels/ScheduleViewModel.cs
@@ -1,7 +1,12 @@
+using Bluewater.App.Interfaces;
 using Bluewater.App.ViewModels.Base;
 
 namespace Bluewater.App.ViewModels;
 
 public partial class ScheduleViewModel : BaseViewModel
 {
+  public ScheduleViewModel(IActivityTraceService activityTraceService)
+    : base(activityTraceService)
+  {
+  }
 }

--- a/src/Bluewater.App/ViewModels/SettingViewModel.cs
+++ b/src/Bluewater.App/ViewModels/SettingViewModel.cs
@@ -1,7 +1,12 @@
+using Bluewater.App.Interfaces;
 using Bluewater.App.ViewModels.Base;
 
 namespace Bluewater.App.ViewModels;
 
 public partial class SettingViewModel : BaseViewModel
 {
+  public SettingViewModel(IActivityTraceService activityTraceService)
+    : base(activityTraceService)
+  {
+  }
 }

--- a/src/Bluewater.App/ViewModels/TimesheetViewModel.cs
+++ b/src/Bluewater.App/ViewModels/TimesheetViewModel.cs
@@ -1,7 +1,12 @@
+using Bluewater.App.Interfaces;
 using Bluewater.App.ViewModels.Base;
 
 namespace Bluewater.App.ViewModels;
 
 public partial class TimesheetViewModel : BaseViewModel
 {
+  public TimesheetViewModel(IActivityTraceService activityTraceService)
+    : base(activityTraceService)
+  {
+  }
 }

--- a/src/Bluewater.App/ViewModels/UserViewModel.cs
+++ b/src/Bluewater.App/ViewModels/UserViewModel.cs
@@ -1,7 +1,12 @@
+using Bluewater.App.Interfaces;
 using Bluewater.App.ViewModels.Base;
 
 namespace Bluewater.App.ViewModels;
 
 public partial class UserViewModel : BaseViewModel
 {
+  public UserViewModel(IActivityTraceService activityTraceService)
+    : base(activityTraceService)
+  {
+  }
 }

--- a/tests/Bluewater.UnitTests/App/ActivityTraceServiceTests.cs
+++ b/tests/Bluewater.UnitTests/App/ActivityTraceServiceTests.cs
@@ -1,0 +1,56 @@
+using System.Text.Json;
+using Bluewater.App.Models;
+using Bluewater.App.Services;
+using FluentAssertions;
+
+namespace Bluewater.UnitTests.App;
+
+public sealed class ActivityTraceServiceTests : IDisposable
+{
+  private readonly string tempDirectory = Path.Combine(Path.GetTempPath(), $"trace-{Guid.NewGuid():N}");
+
+  [Fact]
+  public async Task LogNavigationAndCommand_AppendsEntries()
+  {
+    Directory.CreateDirectory(tempDirectory);
+
+    await using var service = new ActivityTraceService(tempDirectory);
+
+    await service.LogNavigationAsync("//login", "//home", new { Phase = "Navigating" });
+    await service.LogCommandAsync("SaveShift", new { Count = 2 });
+
+    string logPath = await service.GetCurrentLogPathAsync();
+    logPath.Should().StartWith(tempDirectory);
+    File.Exists(logPath).Should().BeTrue();
+
+    string[] lines = await File.ReadAllLinesAsync(logPath);
+    lines.Should().HaveCount(2);
+
+    var options = new JsonSerializerOptions
+    {
+      PropertyNameCaseInsensitive = true
+    };
+
+    ActivityTraceEntry? navigationEntry = JsonSerializer.Deserialize<ActivityTraceEntry>(lines[0], options);
+    navigationEntry.Should().NotBeNull();
+    navigationEntry!.EventType.Should().Be("Navigation");
+    navigationEntry.FromRoute.Should().Be("//login");
+    navigationEntry.ToRoute.Should().Be("//home");
+    navigationEntry.CommandName.Should().BeNull();
+
+    ActivityTraceEntry? commandEntry = JsonSerializer.Deserialize<ActivityTraceEntry>(lines[1], options);
+    commandEntry.Should().NotBeNull();
+    commandEntry!.EventType.Should().Be("Command");
+    commandEntry.CommandName.Should().Be("SaveShift");
+    commandEntry.FromRoute.Should().BeNull();
+    commandEntry.ToRoute.Should().BeNull();
+  }
+
+  public void Dispose()
+  {
+    if (Directory.Exists(tempDirectory))
+    {
+      Directory.Delete(tempDirectory, recursive: true);
+    }
+  }
+}

--- a/tests/Bluewater.UnitTests/Bluewater.UnitTests.csproj
+++ b/tests/Bluewater.UnitTests/Bluewater.UnitTests.csproj
@@ -39,6 +39,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Bluewater.Core\Bluewater.Core.csproj" />
     <ProjectReference Include="..\..\src\Bluewater.UseCases\Bluewater.UseCases.csproj" />
+    <ProjectReference Include="..\..\src\Bluewater.App\Bluewater.App.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add an activity trace service and entry model that write navigation and command events to daily log files
- wire AppShell and view model commands to record navigation destinations and command context via the new tracing service
- add unit coverage to confirm navigation and command traces append and deserialize correctly

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc3a7200e08329baa9a4c00e608c4f