### PR TITLE
Fix custom resource dictionary path

### DIFF
--- a/src/Bluewater.App/App.xaml
+++ b/src/Bluewater.App/App.xaml
@@ -8,7 +8,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Resources/Styles/Colors.xaml" />
                 <ResourceDictionary Source="Resources/Styles/Styles.xaml" />
-                <ResourceDictionary Source="/Resources/Styles/Custom.xaml"/>
+                <ResourceDictionary Source="Resources/Styles/Custom.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>


### PR DESCRIPTION
## Summary
- fix the Custom.xaml resource dictionary path so it loads at runtime

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dc44d09f80832987e3b3483508dd56