### PR TITLE
Add global exception handling and trace coverage

### DIFF
--- a/src/Bluewater.App/Interfaces/IExceptionHandlingService.cs
+++ b/src/Bluewater.App/Interfaces/IExceptionHandlingService.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Bluewater.App.Interfaces;
+
+public interface IExceptionHandlingService
+{
+  void Initialize();
+
+  void Handle(Exception exception, string context);
+}

--- a/src/Bluewater.App/MauiProgram.cs
+++ b/src/Bluewater.App/MauiProgram.cs
@@ -5,6 +5,7 @@ using Bluewater.App.Services;
 using Bluewater.App.ViewModels;
 using Bluewater.App.Views;
 using CommunityToolkit.Maui;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Bluewater.App;
@@ -66,6 +67,7 @@ public static class MauiProgram
     builder.Services.AddSingleton<IPayrollApiService, PayrollApiService>();
     builder.Services.AddSingleton<IScheduleApiService, ScheduleApiService>();
     builder.Services.AddSingleton<IActivityTraceService, ActivityTraceService>();
+    builder.Services.AddSingleton<IExceptionHandlingService, ExceptionHandlingService>();
 
     builder.Services.AddSingleton<AppShell>();
 
@@ -99,6 +101,11 @@ public static class MauiProgram
     builder.Services.AddSingleton<TimesheetViewModel>();
     builder.Services.AddSingleton<UserViewModel>();
 
-    return builder.Build();
+    MauiApp app = builder.Build();
+
+    IExceptionHandlingService exceptionHandlingService = app.Services.GetRequiredService<IExceptionHandlingService>();
+    exceptionHandlingService.Initialize();
+
+    return app;
   }
 }

--- a/src/Bluewater.App/Services/ExceptionHandlingService.cs
+++ b/src/Bluewater.App/Services/ExceptionHandlingService.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Bluewater.App.Interfaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Dispatching;
+
+namespace Bluewater.App.Services;
+
+public sealed class ExceptionHandlingService : IExceptionHandlingService, IDisposable
+{
+  private readonly IActivityTraceService activityTraceService;
+  private readonly ILogger<ExceptionHandlingService>? logger;
+  private bool isInitialized;
+  private IDispatcher? dispatcher;
+
+  public ExceptionHandlingService(
+    IActivityTraceService activityTraceService,
+    ILogger<ExceptionHandlingService>? logger = null)
+  {
+    this.activityTraceService = activityTraceService ?? throw new ArgumentNullException(nameof(activityTraceService));
+    this.logger = logger;
+  }
+
+  public void Initialize()
+  {
+    if (isInitialized)
+    {
+      return;
+    }
+
+    AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
+    TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
+
+    dispatcher = Application.Current?.Dispatcher;
+    if (dispatcher is not null)
+    {
+      dispatcher.UnhandledException += OnDispatcherUnhandledException;
+    }
+
+    isInitialized = true;
+  }
+
+  public void Handle(Exception exception, string context)
+  {
+    if (exception is null)
+    {
+      throw new ArgumentNullException(nameof(exception));
+    }
+
+    LogException("Handled", exception, context);
+  }
+
+  private void OnUnhandledException(object? sender, UnhandledExceptionEventArgs e)
+  {
+    if (e.ExceptionObject is Exception exception)
+    {
+      LogException("AppDomain", exception, context: null, e.IsTerminating);
+    }
+    else
+    {
+      LogMessage("AppDomain", $"Non-exception object encountered: {e.ExceptionObject}");
+    }
+  }
+
+  private void OnUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
+  {
+    LogException("TaskScheduler", e.Exception, context: null);
+    e.SetObserved();
+  }
+
+  private void OnDispatcherUnhandledException(object? sender, DispatcherUnhandledExceptionEventArgs e)
+  {
+    LogException("Dispatcher", e.Exception, context: null);
+  }
+
+  private void LogException(string source, Exception exception, string? context, bool isTerminating = false)
+  {
+    logger?.LogError(exception, "Exception captured from {Source} (Context: {Context})", source, context);
+
+    var metadata = new Dictionary<string, object?>
+    {
+      ["source"] = source,
+      ["context"] = context,
+      ["exceptionType"] = exception.GetType().FullName,
+      ["message"] = exception.Message,
+      ["stackTrace"] = exception.StackTrace,
+      ["isTerminating"] = isTerminating,
+    };
+
+    if (exception.InnerException is not null)
+    {
+      metadata["innerException"] = exception.InnerException.ToString();
+    }
+
+    _ = WriteTraceAsync("Exception", metadata);
+  }
+
+  private void LogMessage(string source, string message)
+  {
+    logger?.LogError("Unhandled exception notification from {Source}: {Message}", source, message);
+
+    var metadata = new Dictionary<string, object?>
+    {
+      ["source"] = source,
+      ["message"] = message
+    };
+
+    _ = WriteTraceAsync("Exception", metadata);
+  }
+
+  private Task WriteTraceAsync(string eventName, object metadata)
+  {
+    return Task.Run(async () =>
+    {
+      try
+      {
+        await activityTraceService.LogCommandAsync(eventName, metadata).ConfigureAwait(false);
+      }
+      catch (Exception loggingException)
+      {
+        logger?.LogError(loggingException, "Failed to write exception trace for {EventName}", eventName);
+      }
+    });
+  }
+
+  public void Dispose()
+  {
+    AppDomain.CurrentDomain.UnhandledException -= OnUnhandledException;
+    TaskScheduler.UnobservedTaskException -= OnUnobservedTaskException;
+
+    if (dispatcher is not null)
+    {
+      dispatcher.UnhandledException -= OnDispatcherUnhandledException;
+    }
+  }
+}

--- a/src/Bluewater.App/ViewModels/AttendanceViewModel.cs
+++ b/src/Bluewater.App/ViewModels/AttendanceViewModel.cs
@@ -5,8 +5,8 @@ namespace Bluewater.App.ViewModels;
 
 public partial class AttendanceViewModel : BaseViewModel
 {
-  public AttendanceViewModel(IActivityTraceService activityTraceService)
-    : base(activityTraceService)
+  public AttendanceViewModel(IActivityTraceService activityTraceService, IExceptionHandlingService exceptionHandlingService)
+    : base(activityTraceService, exceptionHandlingService)
   {
   }
 }

--- a/src/Bluewater.App/ViewModels/Base/BaseViewModel.cs
+++ b/src/Bluewater.App/ViewModels/Base/BaseViewModel.cs
@@ -5,12 +5,15 @@ namespace Bluewater.App.ViewModels.Base;
 
 public abstract partial class BaseViewModel : ObservableObject
 {
-  protected BaseViewModel(IActivityTraceService activityTraceService)
+  protected BaseViewModel(IActivityTraceService activityTraceService, IExceptionHandlingService exceptionHandlingService)
   {
     ActivityTraceService = activityTraceService;
+    ExceptionHandlingService = exceptionHandlingService;
   }
 
   protected IActivityTraceService ActivityTraceService { get; }
+
+  protected IExceptionHandlingService ExceptionHandlingService { get; }
 
   [ObservableProperty]
   public partial bool IsBusy { get; set; }

--- a/src/Bluewater.App/ViewModels/EmployeeViewModel.cs
+++ b/src/Bluewater.App/ViewModels/EmployeeViewModel.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Linq;
 using Bluewater.App.Interfaces;
 using Bluewater.App.Models;
@@ -14,8 +13,11 @@ public partial class EmployeeViewModel : BaseViewModel
   private readonly IEmployeeApiService employeeApiService;
   private bool hasInitialized;
 
-  public EmployeeViewModel(IEmployeeApiService employeeApiService, IActivityTraceService activityTraceService)
-    : base(activityTraceService)
+  public EmployeeViewModel(
+    IEmployeeApiService employeeApiService,
+    IActivityTraceService activityTraceService,
+    IExceptionHandlingService exceptionHandlingService)
+    : base(activityTraceService, exceptionHandlingService)
   {
     this.employeeApiService = employeeApiService;
   }
@@ -46,7 +48,7 @@ public partial class EmployeeViewModel : BaseViewModel
     }
     catch (Exception ex)
     {
-      Debug.WriteLine($"Failed to load employees: {ex.Message}");
+      ExceptionHandlingService.Handle(ex, "Loading employees");
     }
     finally
     {

--- a/src/Bluewater.App/ViewModels/HomeViewModel.cs
+++ b/src/Bluewater.App/ViewModels/HomeViewModel.cs
@@ -5,8 +5,8 @@ namespace Bluewater.App.ViewModels;
 
 public partial class HomeViewModel : BaseViewModel
 {
-  public HomeViewModel(IActivityTraceService activityTraceService)
-    : base(activityTraceService)
+  public HomeViewModel(IActivityTraceService activityTraceService, IExceptionHandlingService exceptionHandlingService)
+    : base(activityTraceService, exceptionHandlingService)
   {
   }
 }

--- a/src/Bluewater.App/ViewModels/LeaveViewModel.cs
+++ b/src/Bluewater.App/ViewModels/LeaveViewModel.cs
@@ -5,8 +5,8 @@ namespace Bluewater.App.ViewModels;
 
 public partial class LeaveViewModel : BaseViewModel
 {
-  public LeaveViewModel(IActivityTraceService activityTraceService)
-    : base(activityTraceService)
+  public LeaveViewModel(IActivityTraceService activityTraceService, IExceptionHandlingService exceptionHandlingService)
+    : base(activityTraceService, exceptionHandlingService)
   {
   }
 }

--- a/src/Bluewater.App/ViewModels/LoginViewModel.cs
+++ b/src/Bluewater.App/ViewModels/LoginViewModel.cs
@@ -7,8 +7,8 @@ namespace Bluewater.App.ViewModels;
 
 public partial class LoginViewModel : BaseViewModel
 {
-  public LoginViewModel(IActivityTraceService activityTraceService)
-    : base(activityTraceService)
+  public LoginViewModel(IActivityTraceService activityTraceService, IExceptionHandlingService exceptionHandlingService)
+    : base(activityTraceService, exceptionHandlingService)
   {
   }
 

--- a/src/Bluewater.App/ViewModels/MealCreditViewModel.cs
+++ b/src/Bluewater.App/ViewModels/MealCreditViewModel.cs
@@ -5,8 +5,8 @@ namespace Bluewater.App.ViewModels;
 
 public partial class MealCreditViewModel : BaseViewModel
 {
-  public MealCreditViewModel(IActivityTraceService activityTraceService)
-    : base(activityTraceService)
+  public MealCreditViewModel(IActivityTraceService activityTraceService, IExceptionHandlingService exceptionHandlingService)
+    : base(activityTraceService, exceptionHandlingService)
   {
   }
 }

--- a/src/Bluewater.App/ViewModels/PayrollViewModel.cs
+++ b/src/Bluewater.App/ViewModels/PayrollViewModel.cs
@@ -5,8 +5,8 @@ namespace Bluewater.App.ViewModels;
 
 public partial class PayrollViewModel : BaseViewModel
 {
-  public PayrollViewModel(IActivityTraceService activityTraceService)
-    : base(activityTraceService)
+  public PayrollViewModel(IActivityTraceService activityTraceService, IExceptionHandlingService exceptionHandlingService)
+    : base(activityTraceService, exceptionHandlingService)
   {
   }
 }

--- a/src/Bluewater.App/ViewModels/ProfileViewModel.cs
+++ b/src/Bluewater.App/ViewModels/ProfileViewModel.cs
@@ -5,8 +5,8 @@ namespace Bluewater.App.ViewModels;
 
 public partial class ProfileViewModel : BaseViewModel
 {
-  public ProfileViewModel(IActivityTraceService activityTraceService)
-    : base(activityTraceService)
+  public ProfileViewModel(IActivityTraceService activityTraceService, IExceptionHandlingService exceptionHandlingService)
+    : base(activityTraceService, exceptionHandlingService)
   {
   }
 }

--- a/src/Bluewater.App/ViewModels/ScheduleViewModel.cs
+++ b/src/Bluewater.App/ViewModels/ScheduleViewModel.cs
@@ -5,8 +5,8 @@ namespace Bluewater.App.ViewModels;
 
 public partial class ScheduleViewModel : BaseViewModel
 {
-  public ScheduleViewModel(IActivityTraceService activityTraceService)
-    : base(activityTraceService)
+  public ScheduleViewModel(IActivityTraceService activityTraceService, IExceptionHandlingService exceptionHandlingService)
+    : base(activityTraceService, exceptionHandlingService)
   {
   }
 }

--- a/src/Bluewater.App/ViewModels/SettingViewModel.cs
+++ b/src/Bluewater.App/ViewModels/SettingViewModel.cs
@@ -5,8 +5,8 @@ namespace Bluewater.App.ViewModels;
 
 public partial class SettingViewModel : BaseViewModel
 {
-  public SettingViewModel(IActivityTraceService activityTraceService)
-    : base(activityTraceService)
+  public SettingViewModel(IActivityTraceService activityTraceService, IExceptionHandlingService exceptionHandlingService)
+    : base(activityTraceService, exceptionHandlingService)
   {
   }
 }

--- a/src/Bluewater.App/ViewModels/ShiftsViewModel.cs
+++ b/src/Bluewater.App/ViewModels/ShiftsViewModel.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Linq;
 using Bluewater.App.Interfaces;
 using Bluewater.App.Models;
@@ -16,8 +15,11 @@ public partial class ShiftsViewModel : BaseViewModel
   private readonly IShiftApiService shiftApiService;
   private bool hasInitialized;
 
-  public ShiftsViewModel(IShiftApiService shiftApiService, IActivityTraceService activityTraceService)
-    : base(activityTraceService)
+  public ShiftsViewModel(
+    IShiftApiService shiftApiService,
+    IActivityTraceService activityTraceService,
+    IExceptionHandlingService exceptionHandlingService)
+    : base(activityTraceService, exceptionHandlingService)
   {
     this.shiftApiService = shiftApiService;
   }
@@ -136,7 +138,7 @@ public partial class ShiftsViewModel : BaseViewModel
     }
     catch (Exception ex)
     {
-      Debug.WriteLine($"Failed to persist shift: {ex.Message}");
+      ExceptionHandlingService.Handle(ex, "Persisting shift");
     }
     finally
     {
@@ -178,7 +180,7 @@ public partial class ShiftsViewModel : BaseViewModel
     }
     catch (Exception ex)
     {
-      Debug.WriteLine($"Failed to load shifts: {ex.Message}");
+      ExceptionHandlingService.Handle(ex, "Loading shifts");
     }
     finally
     {

--- a/src/Bluewater.App/ViewModels/TimesheetViewModel.cs
+++ b/src/Bluewater.App/ViewModels/TimesheetViewModel.cs
@@ -5,8 +5,8 @@ namespace Bluewater.App.ViewModels;
 
 public partial class TimesheetViewModel : BaseViewModel
 {
-  public TimesheetViewModel(IActivityTraceService activityTraceService)
-    : base(activityTraceService)
+  public TimesheetViewModel(IActivityTraceService activityTraceService, IExceptionHandlingService exceptionHandlingService)
+    : base(activityTraceService, exceptionHandlingService)
   {
   }
 }

--- a/src/Bluewater.App/ViewModels/UserViewModel.cs
+++ b/src/Bluewater.App/ViewModels/UserViewModel.cs
@@ -5,8 +5,8 @@ namespace Bluewater.App.ViewModels;
 
 public partial class UserViewModel : BaseViewModel
 {
-  public UserViewModel(IActivityTraceService activityTraceService)
-    : base(activityTraceService)
+  public UserViewModel(IActivityTraceService activityTraceService, IExceptionHandlingService exceptionHandlingService)
+    : base(activityTraceService, exceptionHandlingService)
   {
   }
 }

--- a/tests/Bluewater.IntegrationTests/Bluewater.IntegrationTests.csproj
+++ b/tests/Bluewater.IntegrationTests/Bluewater.IntegrationTests.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Bluewater.Infrastructure\Bluewater.Infrastructure.csproj" />
     <ProjectReference Include="..\Bluewater.UnitTests\Bluewater.UnitTests.csproj" />
+    <ProjectReference Include="..\..\src\Bluewater.App\Bluewater.App.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Bluewater.IntegrationTests/ExceptionHandling/ExceptionHandlingServiceTests.cs
+++ b/tests/Bluewater.IntegrationTests/ExceptionHandling/ExceptionHandlingServiceTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Bluewater.App.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Bluewater.IntegrationTests.ExceptionHandling;
+
+public class ExceptionHandlingServiceTests : IAsyncLifetime
+{
+  private readonly string logDirectory = Path.Combine(Path.GetTempPath(), "BluewaterTests", Guid.NewGuid().ToString("N"));
+
+  public Task InitializeAsync()
+  {
+    Directory.CreateDirectory(logDirectory);
+    return Task.CompletedTask;
+  }
+
+  public Task DisposeAsync()
+  {
+    if (Directory.Exists(logDirectory))
+    {
+      Directory.Delete(logDirectory, recursive: true);
+    }
+
+    return Task.CompletedTask;
+  }
+
+  [Fact]
+  public async Task Handle_RecordsObservedExceptionInTrace()
+  {
+    await using var activityTraceService = new ActivityTraceService(logDirectory);
+    using var exceptionHandlingService = new ExceptionHandlingService(activityTraceService, NullLogger<ExceptionHandlingService>.Instance);
+
+    var exception = new InvalidOperationException("Handled exception");
+    exceptionHandlingService.Handle(exception, "Loading employees");
+
+    string logPath = await activityTraceService.GetCurrentLogPathAsync().ConfigureAwait(false);
+    string[] entries = await WaitForLogEntriesAsync(logPath, minimumEntries: 1).ConfigureAwait(false);
+
+    JsonDocument document = JsonDocument.Parse(entries.Last());
+    JsonElement metadata = document.RootElement.GetProperty("metadata");
+
+    Assert.Equal("Exception", document.RootElement.GetProperty("commandName").GetString());
+    Assert.Equal("Handled", metadata.GetProperty("source").GetString());
+    Assert.Equal("Loading employees", metadata.GetProperty("context").GetString());
+    Assert.Equal(typeof(InvalidOperationException).FullName, metadata.GetProperty("exceptionType").GetString());
+  }
+
+  [Fact]
+  public async Task UnobservedTaskException_IsCapturedByTrace()
+  {
+    await using var activityTraceService = new ActivityTraceService(logDirectory);
+    using var exceptionHandlingService = new ExceptionHandlingService(activityTraceService, NullLogger<ExceptionHandlingService>.Instance);
+
+    exceptionHandlingService.Initialize();
+
+    GenerateUnobservedTaskException();
+
+    string logPath = await activityTraceService.GetCurrentLogPathAsync().ConfigureAwait(false);
+    string[] entries = await WaitForLogEntriesAsync(logPath, minimumEntries: 1).ConfigureAwait(false);
+
+    JsonDocument document = JsonDocument.Parse(entries.Last());
+    JsonElement metadata = document.RootElement.GetProperty("metadata");
+
+    Assert.Equal("Exception", document.RootElement.GetProperty("commandName").GetString());
+    Assert.Equal("TaskScheduler", metadata.GetProperty("source").GetString());
+    Assert.Equal(typeof(InvalidOperationException).FullName, metadata.GetProperty("exceptionType").GetString());
+  }
+
+  private static void GenerateUnobservedTaskException()
+  {
+    Task task = Task.Run(static () => throw new InvalidOperationException("Background failure"));
+    Task.Delay(50).Wait();
+    task = null!;
+
+    GC.Collect();
+    GC.WaitForPendingFinalizers();
+    GC.Collect();
+  }
+
+  private static async Task<string[]> WaitForLogEntriesAsync(string logPath, int minimumEntries)
+  {
+    DateTime endTime = DateTime.UtcNow.AddSeconds(5);
+    string[] entries = Array.Empty<string>();
+
+    while (DateTime.UtcNow < endTime)
+    {
+      if (File.Exists(logPath))
+      {
+        entries = await File.ReadAllLinesAsync(logPath).ConfigureAwait(false);
+        if (entries.Length >= minimumEntries)
+        {
+          return entries;
+        }
+      }
+
+      await Task.Delay(100).ConfigureAwait(false);
+    }
+
+    throw new TimeoutException($"Failed to find {minimumEntries} log entries in {logPath} within the allotted time.");
+  }
+}


### PR DESCRIPTION
## Summary
- add an exception handling service that logs handled and unhandled exceptions through the activity trace
- register the service in the Maui host and inject it into view models instead of writing to Debug
- add integration tests that verify handled exceptions and unobserved task exceptions are captured in the trace logs

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dcbcba4d7c8329ba7468c7292d4a50