### PR TITLE
Add presentation exception handling

### DIFF
--- a/src/Bluewater.App/Exceptions/PresentationException.cs
+++ b/src/Bluewater.App/Exceptions/PresentationException.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Bluewater.App.Exceptions;
+
+public sealed class PresentationException : Exception
+{
+  public const string GenericErrorMessage = "Something went wrong. Please try again later.";
+
+  public PresentationException()
+    : base(GenericErrorMessage)
+  {
+  }
+
+  public PresentationException(string message)
+    : base(string.IsNullOrWhiteSpace(message) ? GenericErrorMessage : message)
+  {
+  }
+
+  public PresentationException(Exception innerException)
+    : base(GenericErrorMessage, innerException)
+  {
+  }
+
+  public PresentationException(string message, Exception innerException)
+    : base(string.IsNullOrWhiteSpace(message) ? GenericErrorMessage : message, innerException)
+  {
+  }
+}

--- a/src/Bluewater.App/Views/OutOfSyncContentView.xaml
+++ b/src/Bluewater.App/Views/OutOfSyncContentView.xaml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Bluewater.App.Views.OutOfSyncContentView">
+  <Border
+    BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1F1F1F}"
+    Padding="24"
+    StrokeThickness="0">
+    <Border.StrokeShape>
+      <RoundRectangle CornerRadius="16" />
+    </Border.StrokeShape>
+
+    <VerticalStackLayout
+      Spacing="16"
+      WidthRequest="320"
+      HorizontalOptions="Center"
+      VerticalOptions="Center">
+      <Label
+        Text="Something went wrong"
+        FontSize="24"
+        FontAttributes="Bold"
+        HorizontalTextAlignment="Center" />
+      <Label
+        Text="{Binding Message}"
+        FontSize="16"
+        HorizontalTextAlignment="Center"
+        LineBreakMode="WordWrap" />
+      <Button
+        Text="Close"
+        HorizontalOptions="Center"
+        Clicked="OnCloseClicked" />
+    </VerticalStackLayout>
+  </Border>
+</ContentView>

--- a/src/Bluewater.App/Views/OutOfSyncContentView.xaml.cs
+++ b/src/Bluewater.App/Views/OutOfSyncContentView.xaml.cs
@@ -1,0 +1,19 @@
+using System;
+using Microsoft.Maui.Controls;
+
+namespace Bluewater.App.Views;
+
+public partial class OutOfSyncContentView : ContentView
+{
+  public event EventHandler? DismissRequested;
+
+  public OutOfSyncContentView()
+  {
+    InitializeComponent();
+  }
+
+  private void OnCloseClicked(object sender, EventArgs e)
+  {
+    DismissRequested?.Invoke(this, EventArgs.Empty);
+  }
+}

--- a/src/Bluewater.App/Views/OutOfSyncPopup.xaml
+++ b/src/Bluewater.App/Views/OutOfSyncPopup.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<toolkit:Popup xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+               xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+               xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+               xmlns:views="clr-namespace:Bluewater.App.Views"
+               x:Class="Bluewater.App.Views.OutOfSyncPopup"
+               CanBeDismissedByTappingOutsideOfPopup="True">
+  <views:OutOfSyncContentView DismissRequested="OnDismissRequested" />
+</toolkit:Popup>

--- a/src/Bluewater.App/Views/OutOfSyncPopup.xaml.cs
+++ b/src/Bluewater.App/Views/OutOfSyncPopup.xaml.cs
@@ -1,0 +1,21 @@
+using System;
+using Bluewater.App.Exceptions;
+using CommunityToolkit.Maui.Views;
+
+namespace Bluewater.App.Views;
+
+public partial class OutOfSyncPopup : Popup
+{
+  public OutOfSyncPopup(PresentationException exception)
+  {
+    ArgumentNullException.ThrowIfNull(exception);
+
+    InitializeComponent();
+    BindingContext = exception;
+  }
+
+  private void OnDismissRequested(object? sender, EventArgs e)
+  {
+    Close();
+  }
+}


### PR DESCRIPTION
## Summary
- add a PresentationException to encapsulate unexpected errors with a generic message
- update the exception handling service to log, convert, and surface PresentationExceptions via an OutOfSync popup
- introduce an OutOfSync content view and popup to display a generic error message to end users

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dff136dcc483299faed66374e48cb7