### PR TITLE
Add gradient background template for content pages

### DIFF
--- a/src/Bluewater.App/Resources/Styles/Styles.xaml
+++ b/src/Bluewater.App/Resources/Styles/Styles.xaml
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
 <?xaml-comp compile="true" ?>
-<ResourceDictionary 
+<ResourceDictionary
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:shapes="clr-namespace:Microsoft.Maui.Controls.Shapes;assembly=Microsoft.Maui.Controls">
 
     <Style TargetType="ActivityIndicator">
         <Setter Property="Color" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
@@ -409,6 +410,68 @@
         </Setter>
     </Style>
     -->
+
+    <!-- Global content page background styling -->
+    <LinearGradientBrush x:Key="AppContentPageBackgroundBrush" EndPoint="0,1">
+        <GradientStop Color="#F9FBFF" Offset="0" />
+        <GradientStop Color="#F1F6FB" Offset="1" />
+    </LinearGradientBrush>
+
+    <RadialGradientBrush x:Key="AppContentPageBlobBrushOne" Radius="0.8" Center="0.35,0.3">
+        <GradientStop Color="#66FFFFFF" Offset="0" />
+        <GradientStop Color="#33AEC8FF" Offset="1" />
+    </RadialGradientBrush>
+
+    <RadialGradientBrush x:Key="AppContentPageBlobBrushTwo" Radius="0.85" Center="0.55,0.5">
+        <GradientStop Color="#44FFFFFF" Offset="0" />
+        <GradientStop Color="#3398E0FF" Offset="1" />
+    </RadialGradientBrush>
+
+    <RadialGradientBrush x:Key="AppContentPageBlobBrushThree" Radius="0.75" Center="0.6,0.6">
+        <GradientStop Color="#55FFFFFF" Offset="0" />
+        <GradientStop Color="#3385C7FF" Offset="1" />
+    </RadialGradientBrush>
+
+    <ControlTemplate x:Key="AppContentPageTemplate">
+        <Grid>
+            <Grid>
+                <Grid.Background>
+                    <StaticResource ResourceKey="AppContentPageBackgroundBrush" />
+                </Grid.Background>
+
+                <Grid InputTransparent="True">
+                    <shapes:Ellipse WidthRequest="320"
+                                    HeightRequest="260"
+                                    Fill="{StaticResource AppContentPageBlobBrushOne}"
+                                    HorizontalOptions="Start"
+                                    VerticalOptions="Start"
+                                    Margin="-120,-80,0,0" />
+
+                    <shapes:Ellipse WidthRequest="260"
+                                    HeightRequest="220"
+                                    Fill="{StaticResource AppContentPageBlobBrushTwo}"
+                                    HorizontalOptions="End"
+                                    VerticalOptions="Start"
+                                    Margin="0,60,-80,0" />
+
+                    <shapes:Ellipse WidthRequest="340"
+                                    HeightRequest="280"
+                                    Fill="{StaticResource AppContentPageBlobBrushThree}"
+                                    HorizontalOptions="End"
+                                    VerticalOptions="End"
+                                    Margin="0,0,-140,-120" />
+                </Grid>
+            </Grid>
+
+            <ContentPresenter Margin="{TemplateBinding Padding}" />
+        </Grid>
+    </ControlTemplate>
+
+    <Style TargetType="ContentPage" ApplyToDerivedTypes="True">
+        <Setter Property="ControlTemplate" Value="{StaticResource AppContentPageTemplate}" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="BackgroundColor" Value="Transparent" />
+    </Style>
 
     <Style TargetType="Page" ApplyToDerivedTypes="True">
         <Setter Property="Padding" Value="0"/>


### PR DESCRIPTION
## Summary
- add a shapes namespace and brush resources to support a soft gradient background
- create a reusable content page control template with translucent accent blobs
- apply the template to all content pages for a consistent light design

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e291e8258c8329ad7b1d5b92fa6871