### PR TITLE
Use template selector and add employee images

### DIFF
--- a/src/Bluewater.App/Models/EmployeeListResponseDto.cs
+++ b/src/Bluewater.App/Models/EmployeeListResponseDto.cs
@@ -20,6 +20,7 @@ public class EmployeeDto
   public string? Department { get; set; }
   public string? Type { get; set; }
   public string? Level { get; set; }
+  public string? Image { get; set; }
 }
 
 public class ContactInfoDto

--- a/src/Bluewater.App/Models/EmployeeSummary.cs
+++ b/src/Bluewater.App/Models/EmployeeSummary.cs
@@ -15,6 +15,8 @@ public class EmployeeSummary
   public string? Type { get; init; }
   public string? Level { get; init; }
   public string? Email { get; init; }
+  public string? Image { get; init; }
+  public int RowIndex { get; set; }
 
   public string FullName
   {
@@ -55,6 +57,8 @@ public class EmployeeSummary
   }
 
   public string EmailDisplay => string.IsNullOrWhiteSpace(Email) ? string.Empty : Email;
+
+  public bool HasImage => !string.IsNullOrWhiteSpace(Image);
 
   private static string FormatDetail(string label, string? value)
   {

--- a/src/Bluewater.App/Selectors/AlternateEmployeeTemplateSelector.cs
+++ b/src/Bluewater.App/Selectors/AlternateEmployeeTemplateSelector.cs
@@ -1,0 +1,26 @@
+using Bluewater.App.Models;
+using Microsoft.Maui.Controls;
+
+namespace Bluewater.App.Selectors;
+
+public class AlternateEmployeeTemplateSelector : DataTemplateSelector
+{
+  public DataTemplate? PrimaryTemplate { get; set; }
+
+  public DataTemplate? AlternateTemplate { get; set; }
+
+  protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+  {
+    if (item is not EmployeeSummary employee)
+    {
+      return PrimaryTemplate ?? AlternateTemplate ?? new DataTemplate();
+    }
+
+    if (employee.RowIndex % 2 == 1 && AlternateTemplate is not null)
+    {
+      return AlternateTemplate;
+    }
+
+    return PrimaryTemplate ?? AlternateTemplate ?? new DataTemplate();
+  }
+}

--- a/src/Bluewater.App/Services/EmployeeApiService.cs
+++ b/src/Bluewater.App/Services/EmployeeApiService.cs
@@ -64,7 +64,8 @@ public class EmployeeApiService(IApiClient apiClient) : IEmployeeApiService
       Position = dto.Position,
       Type = dto.Type,
       Level = dto.Level,
-      Email = dto.ContactInfo?.Email
+      Email = dto.ContactInfo?.Email,
+      Image = dto.Image
     };
   }
 }

--- a/src/Bluewater.App/ViewModels/EmployeeViewModel.cs
+++ b/src/Bluewater.App/ViewModels/EmployeeViewModel.cs
@@ -60,10 +60,13 @@ public partial class EmployeeViewModel : BaseViewModel
       Employees.Clear();
       IReadOnlyList<EmployeeSummary> employees = await employeeApiService.GetEmployeesAsync();
 
+      int index = 0;
+
       foreach (EmployeeSummary employee in employees
         .OrderBy(e => e.LastName ?? string.Empty)
         .ThenBy(e => e.FirstName ?? string.Empty))
       {
+        employee.RowIndex = index++;
         Employees.Add(employee);
       }
 

--- a/src/Bluewater.App/Views/EmployeePage.xaml
+++ b/src/Bluewater.App/Views/EmployeePage.xaml
@@ -2,69 +2,162 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:models="clr-namespace:Bluewater.App.Models"
+             xmlns:selectors="clr-namespace:Bluewater.App.Selectors"
              x:Class="Bluewater.App.Views.EmployeePage"
              x:Name="EmployeePageView"
              Title="Employees">
+  <ContentPage.Resources>
+    <ResourceDictionary>
+      <Style x:Key="EmployeeRowBorderStyle" TargetType="Border">
+        <Setter Property="StrokeThickness" Value="1" />
+        <Setter Property="Stroke" Value="{AppThemeBinding Light=#E0E0E0, Dark=#303030}" />
+        <Setter Property="Padding" Value="12,8" />
+        <Setter Property="Margin" Value="0,0,0,4" />
+        <Setter Property="StrokeShape">
+          <Setter.Value>
+            <RoundRectangle CornerRadius="8" />
+          </Setter.Value>
+        </Setter>
+      </Style>
+
+      <DataTemplate x:Key="EmployeePrimaryTemplate" x:DataType="models:EmployeeSummary">
+        <Border Style="{StaticResource EmployeeRowBorderStyle}"
+                BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1F1F1F}">
+          <Grid ColumnSpacing="12"
+                ColumnDefinitions="Auto,2*,*,*,*,*,*,*,Auto"
+                VerticalOptions="Center">
+            <Grid WidthRequest="40"
+                  HeightRequest="40"
+                  VerticalOptions="Center"
+                  HorizontalOptions="Start">
+              <Image Source="{Binding Image}"
+                     IsVisible="{Binding HasImage}"
+                     HeightRequest="40"
+                     WidthRequest="40"
+                     Aspect="AspectFill">
+                <Image.Clip>
+                  <EllipseGeometry Center="20,20" RadiusX="20" RadiusY="20" />
+                </Image.Clip>
+              </Image>
+            </Grid>
+            <Label Grid.Column="1" Text="{Binding FullName}" FontAttributes="Bold" FontSize="14" />
+            <Label Grid.Column="2" Text="{Binding Position}" FontSize="13" TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+            <Label Grid.Column="3" Text="{Binding Department}" FontSize="13" TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+            <Label Grid.Column="4" Text="{Binding Section}" FontSize="13" TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+            <Label Grid.Column="5" Text="{Binding Type}" FontSize="13" TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+            <Label Grid.Column="6" Text="{Binding Level}" FontSize="13" TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+            <Label Grid.Column="7"
+                   Text="{Binding Email}"
+                   FontSize="13"
+                   TextColor="{AppThemeBinding Light=#0A84FF, Dark=#63A4FF}" />
+            <HorizontalStackLayout Grid.Column="8" Spacing="8" HorizontalOptions="End" VerticalOptions="Center">
+              <Button Text="Edit"
+                      Command="{Binding Source={x:Reference EmployeePageView}, Path=BindingContext.EditEmployeeCommand}"
+                      CommandParameter="{Binding .}"
+                      StyleClass="TableActionButton" />
+              <Button Text="Delete"
+                      Command="{Binding Source={x:Reference EmployeePageView}, Path=BindingContext.DeleteEmployeeCommand}"
+                      CommandParameter="{Binding .}"
+                      StyleClass="TableActionButton"
+                      TextColor="{AppThemeBinding Light=#D14343, Dark=#FF8B8B}" />
+            </HorizontalStackLayout>
+          </Grid>
+        </Border>
+      </DataTemplate>
+
+      <DataTemplate x:Key="EmployeeAlternateTemplate" x:DataType="models:EmployeeSummary">
+        <Border Style="{StaticResource EmployeeRowBorderStyle}"
+                BackgroundColor="{AppThemeBinding Light=#F7F7F7, Dark=#262626}">
+          <Grid ColumnSpacing="12"
+                ColumnDefinitions="Auto,2*,*,*,*,*,*,*,Auto"
+                VerticalOptions="Center">
+            <Grid WidthRequest="40"
+                  HeightRequest="40"
+                  VerticalOptions="Center"
+                  HorizontalOptions="Start">
+              <Image Source="{Binding Image}"
+                     IsVisible="{Binding HasImage}"
+                     HeightRequest="40"
+                     WidthRequest="40"
+                     Aspect="AspectFill">
+                <Image.Clip>
+                  <EllipseGeometry Center="20,20" RadiusX="20" RadiusY="20" />
+                </Image.Clip>
+              </Image>
+            </Grid>
+            <Label Grid.Column="1" Text="{Binding FullName}" FontAttributes="Bold" FontSize="14" />
+            <Label Grid.Column="2" Text="{Binding Position}" FontSize="13" TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+            <Label Grid.Column="3" Text="{Binding Department}" FontSize="13" TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+            <Label Grid.Column="4" Text="{Binding Section}" FontSize="13" TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+            <Label Grid.Column="5" Text="{Binding Type}" FontSize="13" TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+            <Label Grid.Column="6" Text="{Binding Level}" FontSize="13" TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+            <Label Grid.Column="7"
+                   Text="{Binding Email}"
+                   FontSize="13"
+                   TextColor="{AppThemeBinding Light=#0A84FF, Dark=#63A4FF}" />
+            <HorizontalStackLayout Grid.Column="8" Spacing="8" HorizontalOptions="End" VerticalOptions="Center">
+              <Button Text="Edit"
+                      Command="{Binding Source={x:Reference EmployeePageView}, Path=BindingContext.EditEmployeeCommand}"
+                      CommandParameter="{Binding .}"
+                      StyleClass="TableActionButton" />
+              <Button Text="Delete"
+                      Command="{Binding Source={x:Reference EmployeePageView}, Path=BindingContext.DeleteEmployeeCommand}"
+                      CommandParameter="{Binding .}"
+                      StyleClass="TableActionButton"
+                      TextColor="{AppThemeBinding Light=#D14343, Dark=#FF8B8B}" />
+            </HorizontalStackLayout>
+          </Grid>
+        </Border>
+      </DataTemplate>
+
+      <selectors:AlternateEmployeeTemplateSelector x:Key="EmployeeRowTemplateSelector"
+                                                    PrimaryTemplate="{StaticResource EmployeePrimaryTemplate}"
+                                                    AlternateTemplate="{StaticResource EmployeeAlternateTemplate}" />
+    </ResourceDictionary>
+  </ContentPage.Resources>
   <Grid Padding="16" RowDefinitions="Auto,*" RowSpacing="16">
     <Grid Grid.Row="1">
       <CollectionView ItemsSource="{Binding Employees}"
-                      AlternationCount="2"
                       SelectionMode="None"
-                      VerticalOptions="Fill">
-        <CollectionView.Resources>
-          <Style TargetType="Border">
-            <Setter Property="StrokeThickness" Value="1" />
-            <Setter Property="Stroke" Value="{AppThemeBinding Light=#E0E0E0, Dark=#303030}" />
-            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light=#FFFFFF, Dark=#1F1F1F}" />
-            <Setter Property="Padding" Value="12,8" />
-            <Setter Property="Margin" Value="0,0,0,4" />
-            <Setter Property="StrokeShape">
-              <Setter.Value>
-                <RoundRectangle CornerRadius="8" />
-              </Setter.Value>
-            </Setter>
-            <Style.Triggers>
-              <Trigger TargetType="Border"
-                       Property="ItemsView.AlternationIndex"
-                       Value="1">
-                <Setter Property="BackgroundColor" Value="{AppThemeBinding Light=#F7F7F7, Dark=#262626}" />
-              </Trigger>
-            </Style.Triggers>
-          </Style>
-        </CollectionView.Resources>
+                      VerticalOptions="Fill"
+                      ItemTemplateSelector="{StaticResource EmployeeRowTemplateSelector}">
         <CollectionView.Header>
           <Grid ColumnSpacing="12"
                 Padding="12,8"
                 BackgroundColor="{AppThemeBinding Light=#0A84FF, Dark=#1F5AA8}"
-                ColumnDefinitions="2*,*,*,*,*,*,*,Auto">
-            <Label Text="Name"
+                ColumnDefinitions="Auto,2*,*,*,*,*,*,*,Auto">
+            <Label Text="Photo"
                    TextColor="White"
                    FontAttributes="Bold" />
             <Label Grid.Column="1"
-                   Text="Position"
+                   Text="Name"
                    TextColor="White"
                    FontAttributes="Bold" />
             <Label Grid.Column="2"
-                   Text="Department"
+                   Text="Position"
                    TextColor="White"
                    FontAttributes="Bold" />
             <Label Grid.Column="3"
-                   Text="Section"
+                   Text="Department"
                    TextColor="White"
                    FontAttributes="Bold" />
             <Label Grid.Column="4"
-                   Text="Type"
+                   Text="Section"
                    TextColor="White"
                    FontAttributes="Bold" />
             <Label Grid.Column="5"
-                   Text="Level"
+                   Text="Type"
                    TextColor="White"
                    FontAttributes="Bold" />
             <Label Grid.Column="6"
-                   Text="Email"
+                   Text="Level"
                    TextColor="White"
                    FontAttributes="Bold" />
             <Label Grid.Column="7"
+                   Text="Email"
+                   TextColor="White"
+                   FontAttributes="Bold" />
+            <Label Grid.Column="8"
                    Text="Actions"
                    TextColor="White"
                    HorizontalOptions="End"
@@ -79,35 +172,6 @@
             <Label Text="Employees will appear here once they are available." FontSize="12" />
           </VerticalStackLayout>
         </CollectionView.EmptyView>
-        <CollectionView.ItemTemplate>
-          <DataTemplate x:DataType="models:EmployeeSummary">
-            <Border>
-              <Grid ColumnSpacing="12" ColumnDefinitions="2*,*,*,*,*,*,*,Auto" VerticalOptions="Center">
-                <Label Text="{Binding FullName}" FontAttributes="Bold" FontSize="14" />
-                <Label Grid.Column="1" Text="{Binding Position}" FontSize="13" TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
-                <Label Grid.Column="2" Text="{Binding Department}" FontSize="13" TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
-                <Label Grid.Column="3" Text="{Binding Section}" FontSize="13" TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
-                <Label Grid.Column="4" Text="{Binding Type}" FontSize="13" TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
-                <Label Grid.Column="5" Text="{Binding Level}" FontSize="13" TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
-                <Label Grid.Column="6"
-                       Text="{Binding Email}"
-                       FontSize="13"
-                       TextColor="{AppThemeBinding Light=#0A84FF, Dark=#63A4FF}" />
-                <HorizontalStackLayout Grid.Column="7" Spacing="8" HorizontalOptions="End" VerticalOptions="Center">
-                  <Button Text="Edit"
-                          Command="{Binding Source={x:Reference EmployeePageView}, Path=BindingContext.EditEmployeeCommand}"
-                          CommandParameter="{Binding .}"
-                          StyleClass="TableActionButton" />
-                  <Button Text="Delete"
-                          Command="{Binding Source={x:Reference EmployeePageView}, Path=BindingContext.DeleteEmployeeCommand}"
-                          CommandParameter="{Binding .}"
-                          StyleClass="TableActionButton"
-                          TextColor="{AppThemeBinding Light=#D14343, Dark=#FF8B8B}" />
-                </HorizontalStackLayout>
-              </Grid>
-            </Border>
-          </DataTemplate>
-        </CollectionView.ItemTemplate>
       </CollectionView>
 
       <ActivityIndicator IsRunning="{Binding IsBusy}"


### PR DESCRIPTION
## Summary
- add an Image field to employee DTOs and summaries so the UI can surface employee photos
- introduce an alternate row DataTemplateSelector and track row indexes in the view model
- refresh the employee list layout to display images and use the selector instead of AlternationCount

## Testing
- `dotnet build` *(fails: .NET SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d0d56d6483299518e17760331daf