### PR TITLE
Apply employee collection view styling across shifts and settings

### DIFF
--- a/src/Bluewater.App/Views/SettingPage.xaml
+++ b/src/Bluewater.App/Views/SettingPage.xaml
@@ -6,6 +6,61 @@
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              xmlns:model="clr-namespace:Bluewater.App.Models"
              Title="SettingsPage">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <Style x:Key="SettingsRowBorderStyle" TargetType="Border">
+                <Setter Property="StrokeThickness" Value="1" />
+                <Setter Property="Stroke" Value="Transparent" />
+                <Setter Property="Padding" Value="12" />
+                <Setter Property="Margin" Value="0,0,0,12" />
+            </Style>
+
+            <DataTemplate x:Key="DivisionTemplate" x:DataType="model:DivisionSummary">
+                <Border Style="{StaticResource SettingsRowBorderStyle}"
+                        BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1F1F1F}">
+                    <Label Text="{Binding Name}"
+                           FontSize="14"
+                           TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+                </Border>
+            </DataTemplate>
+
+            <DataTemplate x:Key="DepartmentTemplate" x:DataType="model:DepartmentSummary">
+                <Border Style="{StaticResource SettingsRowBorderStyle}"
+                        BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1F1F1F}">
+                    <Label Text="{Binding Name}"
+                           FontSize="14"
+                           TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+                </Border>
+            </DataTemplate>
+
+            <DataTemplate x:Key="SectionTemplate" x:DataType="model:SectionSummary">
+                <Border Style="{StaticResource SettingsRowBorderStyle}"
+                        BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1F1F1F}">
+                    <Label Text="{Binding Name}"
+                           FontSize="14"
+                           TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+                </Border>
+            </DataTemplate>
+
+            <DataTemplate x:Key="ChargingTemplate" x:DataType="model:ChargingSummary">
+                <Border Style="{StaticResource SettingsRowBorderStyle}"
+                        BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1F1F1F}">
+                    <Label Text="{Binding Name}"
+                           FontSize="14"
+                           TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+                </Border>
+            </DataTemplate>
+
+            <DataTemplate x:Key="PositionTemplate" x:DataType="model:PositionSummary">
+                <Border Style="{StaticResource SettingsRowBorderStyle}"
+                        BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1F1F1F}">
+                    <Label Text="{Binding Name}"
+                           FontSize="14"
+                           TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+                </Border>
+            </DataTemplate>
+        </ResourceDictionary>
+    </ContentPage.Resources>
     <Grid VerticalOptions="Fill" HorizontalOptions="Fill"
           Padding="20,0">
         <ScrollView Padding="20">
@@ -16,9 +71,7 @@
                     </toolkit:Expander.Header>
                     <CollectionView ItemsSource="{Binding Divisions}" HeightRequest="300">
                         <CollectionView.ItemTemplate>
-                            <DataTemplate x:DataType="model:DivisionSummary">
-                                <Label Text="{Binding Name}"/>
-                            </DataTemplate>
+                            <StaticResource ResourceKey="DivisionTemplate" />
                         </CollectionView.ItemTemplate>
                     </CollectionView>
                 </toolkit:Expander>
@@ -28,9 +81,7 @@
                     </toolkit:Expander.Header>
                     <CollectionView ItemsSource="{Binding Departments}" HeightRequest="300">
                         <CollectionView.ItemTemplate>
-                            <DataTemplate x:DataType="model:DepartmentSummary">
-                                <Label Text="{Binding Name}"/>
-                            </DataTemplate>
+                            <StaticResource ResourceKey="DepartmentTemplate" />
                         </CollectionView.ItemTemplate>
                     </CollectionView>
                 </toolkit:Expander>
@@ -40,9 +91,7 @@
                     </toolkit:Expander.Header>
                     <CollectionView ItemsSource="{Binding Sections}" HeightRequest="300">
                         <CollectionView.ItemTemplate>
-                            <DataTemplate x:DataType="model:SectionSummary">
-                                <Label Text="{Binding Name}"/>
-                            </DataTemplate>
+                            <StaticResource ResourceKey="SectionTemplate" />
                         </CollectionView.ItemTemplate>
                     </CollectionView>
                 </toolkit:Expander>
@@ -52,9 +101,7 @@
                     </toolkit:Expander.Header>
                     <CollectionView ItemsSource="{Binding Chargings}" HeightRequest="300">
                         <CollectionView.ItemTemplate>
-                            <DataTemplate x:DataType="model:ChargingSummary">
-                                <Label Text="{Binding Name}"/>
-                            </DataTemplate>
+                            <StaticResource ResourceKey="ChargingTemplate" />
                         </CollectionView.ItemTemplate>
                     </CollectionView>
                 </toolkit:Expander>
@@ -65,9 +112,7 @@
                     <CollectionView ItemsSource="{Binding Positions}"
                     HeightRequest="300">
                         <CollectionView.ItemTemplate>
-                            <DataTemplate x:DataType="model:PositionSummary">
-                                <Label Text="{Binding Name}"/>
-                            </DataTemplate>
+                            <StaticResource ResourceKey="PositionTemplate" />
                         </CollectionView.ItemTemplate>
                     </CollectionView>
                 </toolkit:Expander>

--- a/src/Bluewater.App/Views/ShiftsPage.xaml
+++ b/src/Bluewater.App/Views/ShiftsPage.xaml
@@ -4,6 +4,16 @@
              xmlns:models="clr-namespace:Bluewater.App.Models"
              x:Class="Bluewater.App.Views.ShiftsPage"
              Title="Shifts">
+  <ContentPage.Resources>
+    <ResourceDictionary>
+      <Style x:Key="ShiftRowBorderStyle" TargetType="Border">
+        <Setter Property="StrokeThickness" Value="1" />
+        <Setter Property="Stroke" Value="Transparent" />
+        <Setter Property="Padding" Value="16" />
+        <Setter Property="Margin" Value="0,0,0,12" />
+      </Style>
+    </ResourceDictionary>
+  </ContentPage.Resources>
   <Grid Padding="16" RowDefinitions="Auto,Auto,*" RowSpacing="16">
     <Label Text="Shifts"
            FontAttributes="Bold"
@@ -36,9 +46,8 @@
         </CollectionView.EmptyView>
         <CollectionView.ItemTemplate>
           <DataTemplate x:DataType="models:ShiftSummary">
-            <Border StrokeThickness="1"
-                    Padding="12"
-                    Margin="0,0,0,12">
+            <Border Style="{StaticResource ShiftRowBorderStyle}"
+                    BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1F1F1F}">
               <Border.StrokeShape>
                 <RoundRectangle CornerRadius="12" />
               </Border.StrokeShape>


### PR DESCRIPTION
## Summary
- align the Shifts page collection view item template with the employee row styling
- add reusable styled data templates for each settings collection view to match the employee layout

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e2de31920c83298789d5cf63f456f6