### PR TITLE
Align settings lists with employee styling

### DIFF
--- a/src/Bluewater.App/Models/ChargingSummary.cs
+++ b/src/Bluewater.App/Models/ChargingSummary.cs
@@ -2,10 +2,11 @@ using System;
 
 namespace Bluewater.App.Models;
 
-public class ChargingSummary
+public class ChargingSummary : IRowIndexed
 {
   public Guid Id { get; set; }
   public string Name { get; set; } = string.Empty;
   public string? Description { get; set; }
   public Guid? DepartmentId { get; set; }
+  public int RowIndex { get; set; }
 }

--- a/src/Bluewater.App/Models/DepartmentSummary.cs
+++ b/src/Bluewater.App/Models/DepartmentSummary.cs
@@ -2,10 +2,11 @@ using System;
 
 namespace Bluewater.App.Models;
 
-public class DepartmentSummary
+public class DepartmentSummary : IRowIndexed
 {
   public Guid Id { get; set; }
   public string Name { get; set; } = string.Empty;
   public string? Description { get; set; }
   public Guid DivisionId { get; set; }
+  public int RowIndex { get; set; }
 }

--- a/src/Bluewater.App/Models/DivisionSummary.cs
+++ b/src/Bluewater.App/Models/DivisionSummary.cs
@@ -2,9 +2,10 @@ using System;
 
 namespace Bluewater.App.Models;
 
-public class DivisionSummary
+public class DivisionSummary : IRowIndexed
 {
   public Guid Id { get; set; }
   public string Name { get; set; } = string.Empty;
   public string? Description { get; set; }
+  public int RowIndex { get; set; }
 }

--- a/src/Bluewater.App/Models/EmployeeSummary.cs
+++ b/src/Bluewater.App/Models/EmployeeSummary.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace Bluewater.App.Models;
 
-public class EmployeeSummary
+public class EmployeeSummary : IRowIndexed
 {
   public Guid Id { get; init; }
   public string FirstName { get; init; } = string.Empty;

--- a/src/Bluewater.App/Models/IRowIndexed.cs
+++ b/src/Bluewater.App/Models/IRowIndexed.cs
@@ -1,0 +1,6 @@
+namespace Bluewater.App.Models;
+
+public interface IRowIndexed
+{
+  int RowIndex { get; set; }
+}

--- a/src/Bluewater.App/Models/PositionSummary.cs
+++ b/src/Bluewater.App/Models/PositionSummary.cs
@@ -2,10 +2,11 @@ using System;
 
 namespace Bluewater.App.Models;
 
-public class PositionSummary
+public class PositionSummary : IRowIndexed
 {
   public Guid Id { get; set; }
   public string Name { get; set; } = string.Empty;
   public string? Description { get; set; }
   public Guid SectionId { get; set; }
+  public int RowIndex { get; set; }
 }

--- a/src/Bluewater.App/Models/SectionSummary.cs
+++ b/src/Bluewater.App/Models/SectionSummary.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Bluewater.App.Models;
 
-public class SectionSummary
+public class SectionSummary : IRowIndexed
 {
   public Guid Id { get; set; }
   public string Name { get; set; } = string.Empty;
@@ -11,4 +11,5 @@ public class SectionSummary
   public string? Approved2Id { get; set; }
   public string? Approved3Id { get; set; }
   public Guid DepartmentId { get; set; }
+  public int RowIndex { get; set; }
 }

--- a/src/Bluewater.App/Selectors/AlternateEmployeeTemplateSelector.cs
+++ b/src/Bluewater.App/Selectors/AlternateEmployeeTemplateSelector.cs
@@ -11,12 +11,12 @@ public class AlternateEmployeeTemplateSelector : DataTemplateSelector
 
   protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
   {
-    if (item is not EmployeeSummary employee)
+    if (item is not IRowIndexed rowIndexed)
     {
       return PrimaryTemplate ?? AlternateTemplate ?? new DataTemplate();
     }
 
-    if (employee.RowIndex % 2 == 1 && AlternateTemplate is not null)
+    if (rowIndexed.RowIndex % 2 == 1 && AlternateTemplate is not null)
     {
       return AlternateTemplate;
     }

--- a/src/Bluewater.App/ViewModels/SettingViewModel.cs
+++ b/src/Bluewater.App/ViewModels/SettingViewModel.cs
@@ -1,8 +1,11 @@
-﻿using System.Collections.ObjectModel;
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
 using Bluewater.App.Interfaces;
 using Bluewater.App.Models;
 using Bluewater.App.Services;
 using Bluewater.App.ViewModels.Base;
+using CommunityToolkit.Mvvm.Input;
 
 namespace Bluewater.App.ViewModels;
 
@@ -35,10 +38,122 @@ public partial class SettingViewModel : BaseViewModel
     _positionApiService = positionApiService;
   }
 
+  [RelayCommand]
+  private async Task EditDivisionAsync(DivisionSummary? division)
+  {
+    if (division is null)
+    {
+      return;
+    }
+
+    await TraceCommandAsync(nameof(EditDivisionAsync), division.Id);
+  }
+
+  [RelayCommand]
+  private async Task DeleteDivisionAsync(DivisionSummary? division)
+  {
+    if (division is null)
+    {
+      return;
+    }
+
+    await TraceCommandAsync(nameof(DeleteDivisionAsync), division.Id);
+  }
+
+  [RelayCommand]
+  private async Task EditDepartmentAsync(DepartmentSummary? department)
+  {
+    if (department is null)
+    {
+      return;
+    }
+
+    await TraceCommandAsync(nameof(EditDepartmentAsync), department.Id);
+  }
+
+  [RelayCommand]
+  private async Task DeleteDepartmentAsync(DepartmentSummary? department)
+  {
+    if (department is null)
+    {
+      return;
+    }
+
+    await TraceCommandAsync(nameof(DeleteDepartmentAsync), department.Id);
+  }
+
+  [RelayCommand]
+  private async Task EditSectionAsync(SectionSummary? section)
+  {
+    if (section is null)
+    {
+      return;
+    }
+
+    await TraceCommandAsync(nameof(EditSectionAsync), section.Id);
+  }
+
+  [RelayCommand]
+  private async Task DeleteSectionAsync(SectionSummary? section)
+  {
+    if (section is null)
+    {
+      return;
+    }
+
+    await TraceCommandAsync(nameof(DeleteSectionAsync), section.Id);
+  }
+
+  [RelayCommand]
+  private async Task EditChargingAsync(ChargingSummary? charging)
+  {
+    if (charging is null)
+    {
+      return;
+    }
+
+    await TraceCommandAsync(nameof(EditChargingAsync), charging.Id);
+  }
+
+  [RelayCommand]
+  private async Task DeleteChargingAsync(ChargingSummary? charging)
+  {
+    if (charging is null)
+    {
+      return;
+    }
+
+    await TraceCommandAsync(nameof(DeleteChargingAsync), charging.Id);
+  }
+
+  [RelayCommand]
+  private async Task EditPositionAsync(PositionSummary? position)
+  {
+    if (position is null)
+    {
+      return;
+    }
+
+    await TraceCommandAsync(nameof(EditPositionAsync), position.Id);
+  }
+
+  [RelayCommand]
+  private async Task DeletePositionAsync(PositionSummary? position)
+  {
+    if (position is null)
+    {
+      return;
+    }
+
+    await TraceCommandAsync(nameof(DeletePositionAsync), position.Id);
+  }
+
   public override async Task InitializeAsync()
   {
     if (IsBusy)
+    {
       return;
+    }
 
     try
     {
@@ -58,27 +173,40 @@ public partial class SettingViewModel : BaseViewModel
 
       await Task.WhenAll(divisionTask, departmentTask, sectionTask, chargingTask, positionTask);
 
-      foreach (var division in divisionTask.Result)
+      int index = 0;
+      foreach (var division in divisionTask.Result.OrderBy(d => d.Name))
       {
+        division.RowIndex = index++;
         Divisions.Add(division);
       }
-      foreach (var department in departmentTask.Result)
+
+      index = 0;
+      foreach (var department in departmentTask.Result.OrderBy(d => d.Name))
       {
+        department.RowIndex = index++;
         Departments.Add(department);
       }
-      foreach (var section in sectionTask.Result)
+
+      index = 0;
+      foreach (var section in sectionTask.Result.OrderBy(s => s.Name))
       {
+        section.RowIndex = index++;
         Sections.Add(section);
       }
-      foreach (var charging in chargingTask.Result)
+
+      index = 0;
+      foreach (var charging in chargingTask.Result.OrderBy(c => c.Name))
       {
+        charging.RowIndex = index++;
         Chargings.Add(charging);
       }
-      foreach (var position in positionTask.Result)
+
+      index = 0;
+      foreach (var position in positionTask.Result.OrderBy(p => p.Name))
       {
+        position.RowIndex = index++;
         Positions.Add(position);
       }
-
     }
     catch (Exception ex)
     {

--- a/src/Bluewater.App/Views/SettingPage.xaml
+++ b/src/Bluewater.App/Views/SettingPage.xaml
@@ -1,135 +1,608 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Bluewater.App.Views.SettingPage"
              xmlns:vm="clr-namespace:Bluewater.App.ViewModels"
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              xmlns:model="clr-namespace:Bluewater.App.Models"
              xmlns:helpers="clr-namespace:Bluewater.App.Helpers"
+             xmlns:selectors="clr-namespace:Bluewater.App.Selectors"
+             x:Class="Bluewater.App.Views.SettingPage"
+             x:Name="SettingPageView"
              Title="SettingsPage">
     <ContentPage.Resources>
         <ResourceDictionary>
             <Style x:Key="SettingsRowBorderStyle" TargetType="Border">
+                <Setter Property="StrokeThickness" Value="1" />
                 <Setter Property="Stroke" Value="Transparent" />
-                <Setter Property="Padding" Value="12" />
-                <Setter Property="Margin" Value="8,0,8,12" />
+                <Setter Property="Padding" Value="8" />
             </Style>
 
-            <DataTemplate x:Key="DivisionTemplate" x:DataType="model:DivisionSummary">
+            <DataTemplate x:Key="DivisionPrimaryTemplate" x:DataType="model:DivisionSummary">
                 <Border Style="{StaticResource SettingsRowBorderStyle}"
                         BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1F1F1F}">
-                    <Label Text="{Binding Name}"
-                           FontSize="14"
-                           TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+                    <Grid ColumnSpacing="12"
+                          ColumnDefinitions="2*,*,Auto"
+                          VerticalOptions="Center">
+                        <Label Text="{Binding Name}"
+                               FontAttributes="Bold"
+                               FontSize="14" />
+                        <Label Grid.Column="1"
+                               Text="{Binding Description}"
+                               LineBreakMode="TailTruncation"
+                               FontSize="13"
+                               TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+                        <HorizontalStackLayout Grid.Column="2"
+                                               Spacing="8"
+                                               HorizontalOptions="End"
+                                               VerticalOptions="Center">
+                            <Label Text="{x:Static helpers:Icon.Edit}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" TextColor="{StaticResource TextSecondaryColor}">
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding Source={x:Reference SettingPageView}, Path=BindingContext.EditDivisionCommand}" CommandParameter="{Binding .}" />
+                                </Label.GestureRecognizers>
+                            </Label>
+                            <Label Text="{x:Static helpers:Icon.Trash}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" TextColor="{StaticResource TextPrimaryColor}">
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding Source={x:Reference SettingPageView}, Path=BindingContext.DeleteDivisionCommand}" CommandParameter="{Binding .}" />
+                                </Label.GestureRecognizers>
+                            </Label>
+                        </HorizontalStackLayout>
+                    </Grid>
                 </Border>
             </DataTemplate>
 
-            <DataTemplate x:Key="DepartmentTemplate" x:DataType="model:DepartmentSummary">
+            <DataTemplate x:Key="DivisionAlternateTemplate" x:DataType="model:DivisionSummary">
                 <Border Style="{StaticResource SettingsRowBorderStyle}"
-                        BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1F1F1F}">
-                    <Label Text="{Binding Name}"
-                           FontSize="14"
-                           TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+                        BackgroundColor="{AppThemeBinding Light=#0A386eb3, Dark=#262626}">
+                    <Grid ColumnSpacing="12"
+                          ColumnDefinitions="2*,*,Auto"
+                          VerticalOptions="Center">
+                        <Label Text="{Binding Name}"
+                               FontAttributes="Bold"
+                               FontSize="14" />
+                        <Label Grid.Column="1"
+                               Text="{Binding Description}"
+                               LineBreakMode="TailTruncation"
+                               FontSize="13"
+                               TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+                        <HorizontalStackLayout Grid.Column="2"
+                                               Spacing="8"
+                                               HorizontalOptions="End"
+                                               VerticalOptions="Center">
+                            <Label Text="{x:Static helpers:Icon.Edit}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" TextColor="{StaticResource TextSecondaryColor}">
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding Source={x:Reference SettingPageView}, Path=BindingContext.EditDivisionCommand}" CommandParameter="{Binding .}" />
+                                </Label.GestureRecognizers>
+                            </Label>
+                            <Label Text="{x:Static helpers:Icon.Trash}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" TextColor="{StaticResource TextPrimaryColor}">
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding Source={x:Reference SettingPageView}, Path=BindingContext.DeleteDivisionCommand}" CommandParameter="{Binding .}" />
+                                </Label.GestureRecognizers>
+                            </Label>
+                        </HorizontalStackLayout>
+                    </Grid>
                 </Border>
             </DataTemplate>
 
-            <DataTemplate x:Key="SectionTemplate" x:DataType="model:SectionSummary">
+            <DataTemplate x:Key="DepartmentPrimaryTemplate" x:DataType="model:DepartmentSummary">
                 <Border Style="{StaticResource SettingsRowBorderStyle}"
                         BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1F1F1F}">
-                    <Label Text="{Binding Name}"
-                           FontSize="14"
-                           TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+                    <Grid ColumnSpacing="12"
+                          ColumnDefinitions="2*,*,Auto"
+                          VerticalOptions="Center">
+                        <Label Text="{Binding Name}"
+                               FontAttributes="Bold"
+                               FontSize="14" />
+                        <Label Grid.Column="1"
+                               Text="{Binding Description}"
+                               LineBreakMode="TailTruncation"
+                               FontSize="13"
+                               TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+                        <HorizontalStackLayout Grid.Column="2"
+                                               Spacing="8"
+                                               HorizontalOptions="End"
+                                               VerticalOptions="Center">
+                            <Label Text="{x:Static helpers:Icon.Edit}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" TextColor="{StaticResource TextSecondaryColor}">
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding Source={x:Reference SettingPageView}, Path=BindingContext.EditDepartmentCommand}" CommandParameter="{Binding .}" />
+                                </Label.GestureRecognizers>
+                            </Label>
+                            <Label Text="{x:Static helpers:Icon.Trash}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" TextColor="{StaticResource TextPrimaryColor}">
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding Source={x:Reference SettingPageView}, Path=BindingContext.DeleteDepartmentCommand}" CommandParameter="{Binding .}" />
+                                </Label.GestureRecognizers>
+                            </Label>
+                        </HorizontalStackLayout>
+                    </Grid>
                 </Border>
             </DataTemplate>
 
-            <DataTemplate x:Key="ChargingTemplate" x:DataType="model:ChargingSummary">
+            <DataTemplate x:Key="DepartmentAlternateTemplate" x:DataType="model:DepartmentSummary">
                 <Border Style="{StaticResource SettingsRowBorderStyle}"
-                        BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1F1F1F}">
-                    <Label Text="{Binding Name}"
-                           FontSize="14"
-                           TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+                        BackgroundColor="{AppThemeBinding Light=#0A386eb3, Dark=#262626}">
+                    <Grid ColumnSpacing="12"
+                          ColumnDefinitions="2*,*,Auto"
+                          VerticalOptions="Center">
+                        <Label Text="{Binding Name}"
+                               FontAttributes="Bold"
+                               FontSize="14" />
+                        <Label Grid.Column="1"
+                               Text="{Binding Description}"
+                               LineBreakMode="TailTruncation"
+                               FontSize="13"
+                               TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+                        <HorizontalStackLayout Grid.Column="2"
+                                               Spacing="8"
+                                               HorizontalOptions="End"
+                                               VerticalOptions="Center">
+                            <Label Text="{x:Static helpers:Icon.Edit}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" TextColor="{StaticResource TextSecondaryColor}">
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding Source={x:Reference SettingPageView}, Path=BindingContext.EditDepartmentCommand}" CommandParameter="{Binding .}" />
+                                </Label.GestureRecognizers>
+                            </Label>
+                            <Label Text="{x:Static helpers:Icon.Trash}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" TextColor="{StaticResource TextPrimaryColor}">
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding Source={x:Reference SettingPageView}, Path=BindingContext.DeleteDepartmentCommand}" CommandParameter="{Binding .}" />
+                                </Label.GestureRecognizers>
+                            </Label>
+                        </HorizontalStackLayout>
+                    </Grid>
                 </Border>
             </DataTemplate>
 
-            <DataTemplate x:Key="PositionTemplate" x:DataType="model:PositionSummary">
+            <DataTemplate x:Key="SectionPrimaryTemplate" x:DataType="model:SectionSummary">
                 <Border Style="{StaticResource SettingsRowBorderStyle}"
                         BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1F1F1F}">
-                    <Label Text="{Binding Name}"
-                           FontSize="14"
-                           TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+                    <Grid ColumnSpacing="12"
+                          ColumnDefinitions="2*,*,Auto"
+                          VerticalOptions="Center">
+                        <Label Text="{Binding Name}"
+                               FontAttributes="Bold"
+                               FontSize="14" />
+                        <Label Grid.Column="1"
+                               Text="{Binding Description}"
+                               LineBreakMode="TailTruncation"
+                               FontSize="13"
+                               TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+                        <HorizontalStackLayout Grid.Column="2"
+                                               Spacing="8"
+                                               HorizontalOptions="End"
+                                               VerticalOptions="Center">
+                            <Label Text="{x:Static helpers:Icon.Edit}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" TextColor="{StaticResource TextSecondaryColor}">
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding Source={x:Reference SettingPageView}, Path=BindingContext.EditSectionCommand}" CommandParameter="{Binding .}" />
+                                </Label.GestureRecognizers>
+                            </Label>
+                            <Label Text="{x:Static helpers:Icon.Trash}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" TextColor="{StaticResource TextPrimaryColor}">
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding Source={x:Reference SettingPageView}, Path=BindingContext.DeleteSectionCommand}" CommandParameter="{Binding .}" />
+                                </Label.GestureRecognizers>
+                            </Label>
+                        </HorizontalStackLayout>
+                    </Grid>
                 </Border>
             </DataTemplate>
+
+            <DataTemplate x:Key="SectionAlternateTemplate" x:DataType="model:SectionSummary">
+                <Border Style="{StaticResource SettingsRowBorderStyle}"
+                        BackgroundColor="{AppThemeBinding Light=#0A386eb3, Dark=#262626}">
+                    <Grid ColumnSpacing="12"
+                          ColumnDefinitions="2*,*,Auto"
+                          VerticalOptions="Center">
+                        <Label Text="{Binding Name}"
+                               FontAttributes="Bold"
+                               FontSize="14" />
+                        <Label Grid.Column="1"
+                               Text="{Binding Description}"
+                               LineBreakMode="TailTruncation"
+                               FontSize="13"
+                               TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+                        <HorizontalStackLayout Grid.Column="2"
+                                               Spacing="8"
+                                               HorizontalOptions="End"
+                                               VerticalOptions="Center">
+                            <Label Text="{x:Static helpers:Icon.Edit}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" TextColor="{StaticResource TextSecondaryColor}">
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding Source={x:Reference SettingPageView}, Path=BindingContext.EditSectionCommand}" CommandParameter="{Binding .}" />
+                                </Label.GestureRecognizers>
+                            </Label>
+                            <Label Text="{x:Static helpers:Icon.Trash}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" TextColor="{StaticResource TextPrimaryColor}">
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding Source={x:Reference SettingPageView}, Path=BindingContext.DeleteSectionCommand}" CommandParameter="{Binding .}" />
+                                </Label.GestureRecognizers>
+                            </Label>
+                        </HorizontalStackLayout>
+                    </Grid>
+                </Border>
+            </DataTemplate>
+
+            <DataTemplate x:Key="ChargingPrimaryTemplate" x:DataType="model:ChargingSummary">
+                <Border Style="{StaticResource SettingsRowBorderStyle}"
+                        BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1F1F1F}">
+                    <Grid ColumnSpacing="12"
+                          ColumnDefinitions="2*,*,Auto"
+                          VerticalOptions="Center">
+                        <Label Text="{Binding Name}"
+                               FontAttributes="Bold"
+                               FontSize="14" />
+                        <Label Grid.Column="1"
+                               Text="{Binding Description}"
+                               LineBreakMode="TailTruncation"
+                               FontSize="13"
+                               TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+                        <HorizontalStackLayout Grid.Column="2"
+                                               Spacing="8"
+                                               HorizontalOptions="End"
+                                               VerticalOptions="Center">
+                            <Label Text="{x:Static helpers:Icon.Edit}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" TextColor="{StaticResource TextSecondaryColor}">
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding Source={x:Reference SettingPageView}, Path=BindingContext.EditChargingCommand}" CommandParameter="{Binding .}" />
+                                </Label.GestureRecognizers>
+                            </Label>
+                            <Label Text="{x:Static helpers:Icon.Trash}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" TextColor="{StaticResource TextPrimaryColor}">
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding Source={x:Reference SettingPageView}, Path=BindingContext.DeleteChargingCommand}" CommandParameter="{Binding .}" />
+                                </Label.GestureRecognizers>
+                            </Label>
+                        </HorizontalStackLayout>
+                    </Grid>
+                </Border>
+            </DataTemplate>
+
+            <DataTemplate x:Key="ChargingAlternateTemplate" x:DataType="model:ChargingSummary">
+                <Border Style="{StaticResource SettingsRowBorderStyle}"
+                        BackgroundColor="{AppThemeBinding Light=#0A386eb3, Dark=#262626}">
+                    <Grid ColumnSpacing="12"
+                          ColumnDefinitions="2*,*,Auto"
+                          VerticalOptions="Center">
+                        <Label Text="{Binding Name}"
+                               FontAttributes="Bold"
+                               FontSize="14" />
+                        <Label Grid.Column="1"
+                               Text="{Binding Description}"
+                               LineBreakMode="TailTruncation"
+                               FontSize="13"
+                               TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+                        <HorizontalStackLayout Grid.Column="2"
+                                               Spacing="8"
+                                               HorizontalOptions="End"
+                                               VerticalOptions="Center">
+                            <Label Text="{x:Static helpers:Icon.Edit}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" TextColor="{StaticResource TextSecondaryColor}">
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding Source={x:Reference SettingPageView}, Path=BindingContext.EditChargingCommand}" CommandParameter="{Binding .}" />
+                                </Label.GestureRecognizers>
+                            </Label>
+                            <Label Text="{x:Static helpers:Icon.Trash}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" TextColor="{StaticResource TextPrimaryColor}">
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding Source={x:Reference SettingPageView}, Path=BindingContext.DeleteChargingCommand}" CommandParameter="{Binding .}" />
+                                </Label.GestureRecognizers>
+                            </Label>
+                        </HorizontalStackLayout>
+                    </Grid>
+                </Border>
+            </DataTemplate>
+
+            <DataTemplate x:Key="PositionPrimaryTemplate" x:DataType="model:PositionSummary">
+                <Border Style="{StaticResource SettingsRowBorderStyle}"
+                        BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1F1F1F}">
+                    <Grid ColumnSpacing="12"
+                          ColumnDefinitions="2*,*,Auto"
+                          VerticalOptions="Center">
+                        <Label Text="{Binding Name}"
+                               FontAttributes="Bold"
+                               FontSize="14" />
+                        <Label Grid.Column="1"
+                               Text="{Binding Description}"
+                               LineBreakMode="TailTruncation"
+                               FontSize="13"
+                               TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+                        <HorizontalStackLayout Grid.Column="2"
+                                               Spacing="8"
+                                               HorizontalOptions="End"
+                                               VerticalOptions="Center">
+                            <Label Text="{x:Static helpers:Icon.Edit}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" TextColor="{StaticResource TextSecondaryColor}">
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding Source={x:Reference SettingPageView}, Path=BindingContext.EditPositionCommand}" CommandParameter="{Binding .}" />
+                                </Label.GestureRecognizers>
+                            </Label>
+                            <Label Text="{x:Static helpers:Icon.Trash}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" TextColor="{StaticResource TextPrimaryColor}">
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding Source={x:Reference SettingPageView}, Path=BindingContext.DeletePositionCommand}" CommandParameter="{Binding .}" />
+                                </Label.GestureRecognizers>
+                            </Label>
+                        </HorizontalStackLayout>
+                    </Grid>
+                </Border>
+            </DataTemplate>
+
+            <DataTemplate x:Key="PositionAlternateTemplate" x:DataType="model:PositionSummary">
+                <Border Style="{StaticResource SettingsRowBorderStyle}"
+                        BackgroundColor="{AppThemeBinding Light=#0A386eb3, Dark=#262626}">
+                    <Grid ColumnSpacing="12"
+                          ColumnDefinitions="2*,*,Auto"
+                          VerticalOptions="Center">
+                        <Label Text="{Binding Name}"
+                               FontAttributes="Bold"
+                               FontSize="14" />
+                        <Label Grid.Column="1"
+                               Text="{Binding Description}"
+                               LineBreakMode="TailTruncation"
+                               FontSize="13"
+                               TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}" />
+                        <HorizontalStackLayout Grid.Column="2"
+                                               Spacing="8"
+                                               HorizontalOptions="End"
+                                               VerticalOptions="Center">
+                            <Label Text="{x:Static helpers:Icon.Edit}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" TextColor="{StaticResource TextSecondaryColor}">
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding Source={x:Reference SettingPageView}, Path=BindingContext.EditPositionCommand}" CommandParameter="{Binding .}" />
+                                </Label.GestureRecognizers>
+                            </Label>
+                            <Label Text="{x:Static helpers:Icon.Trash}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" TextColor="{StaticResource TextPrimaryColor}">
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding Source={x:Reference SettingPageView}, Path=BindingContext.DeletePositionCommand}" CommandParameter="{Binding .}" />
+                                </Label.GestureRecognizers>
+                            </Label>
+                        </HorizontalStackLayout>
+                    </Grid>
+                </Border>
+            </DataTemplate>
+
+            <selectors:AlternateEmployeeTemplateSelector x:Key="DivisionTemplateSelector"
+                                                          PrimaryTemplate="{StaticResource DivisionPrimaryTemplate}"
+                                                          AlternateTemplate="{StaticResource DivisionAlternateTemplate}" />
+            <selectors:AlternateEmployeeTemplateSelector x:Key="DepartmentTemplateSelector"
+                                                          PrimaryTemplate="{StaticResource DepartmentPrimaryTemplate}"
+                                                          AlternateTemplate="{StaticResource DepartmentAlternateTemplate}" />
+            <selectors:AlternateEmployeeTemplateSelector x:Key="SectionTemplateSelector"
+                                                          PrimaryTemplate="{StaticResource SectionPrimaryTemplate}"
+                                                          AlternateTemplate="{StaticResource SectionAlternateTemplate}" />
+            <selectors:AlternateEmployeeTemplateSelector x:Key="ChargingTemplateSelector"
+                                                          PrimaryTemplate="{StaticResource ChargingPrimaryTemplate}"
+                                                          AlternateTemplate="{StaticResource ChargingAlternateTemplate}" />
+            <selectors:AlternateEmployeeTemplateSelector x:Key="PositionTemplateSelector"
+                                                          PrimaryTemplate="{StaticResource PositionPrimaryTemplate}"
+                                                          AlternateTemplate="{StaticResource PositionAlternateTemplate}" />
         </ResourceDictionary>
     </ContentPage.Resources>
-    <Grid VerticalOptions="Fill" HorizontalOptions="Fill"
+    <Grid VerticalOptions="Fill"
+          HorizontalOptions="Fill"
           Padding="20,0">
         <ScrollView Padding="20">
-            <VerticalStackLayout x:DataType="vm:SettingViewModel" Spacing="20">
+            <VerticalStackLayout x:DataType="vm:SettingViewModel"
+                                 Spacing="20">
                 <toolkit:Expander>
                     <toolkit:Expander.Header>
                         <Label>
                             <Label.FormattedText>
                                 <FormattedString>
-                                    <Span Text="{x:Static helpers:Icon.ChevronRight}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}"/>
-                                    <Span Text="Divisions" Style="{StaticResource HeadingTextStyle}"/>
+                                    <Span Text="{x:Static helpers:Icon.ChevronRight}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" />
+                                    <Span Text="Divisions" Style="{StaticResource HeadingTextStyle}" />
                                 </FormattedString>
                             </Label.FormattedText>
                         </Label>
                     </toolkit:Expander.Header>
-                    <CollectionView ItemsSource="{Binding Divisions}" HeightRequest="300" ItemTemplate="{StaticResource DivisionTemplate}"/>
+                    <CollectionView ItemsSource="{Binding Divisions}"
+                                    SelectionMode="None"
+                                    HeightRequest="300"
+                                    ItemTemplate="{StaticResource DivisionTemplateSelector}">
+                        <CollectionView.Header>
+                            <Border StrokeShape="RoundRectangle 10 10 0 0"
+                                    BackgroundColor="{AppThemeBinding Light={StaticResource AccentColor}, Dark=#1F5AA8}">
+                                <Grid ColumnSpacing="12"
+                                      Padding="20"
+                                      ColumnDefinitions="2*,*,Auto">
+                                    <Label Text="Name"
+                                           TextColor="White"
+                                           FontAttributes="Bold" />
+                                    <Label Grid.Column="1"
+                                           Text="Description"
+                                           TextColor="White"
+                                           FontAttributes="Bold" />
+                                    <Label Grid.Column="2"
+                                           Text="Actions"
+                                           TextColor="White"
+                                           HorizontalOptions="End"
+                                           FontAttributes="Bold" />
+                                </Grid>
+                            </Border>
+                        </CollectionView.Header>
+                        <CollectionView.EmptyView>
+                            <VerticalStackLayout HorizontalOptions="Center"
+                                                 VerticalOptions="Center"
+                                                 Spacing="8">
+                                <Label Text="No divisions found" />
+                                <Label Text="Divisions will appear here once they are available." FontSize="12" />
+                            </VerticalStackLayout>
+                        </CollectionView.EmptyView>
+                    </CollectionView>
                 </toolkit:Expander>
+
                 <toolkit:Expander>
                     <toolkit:Expander.Header>
                         <Label>
                             <Label.FormattedText>
                                 <FormattedString>
-                                    <Span Text="{x:Static helpers:Icon.ChevronRight}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}"/>
-                                    <Span Text="Departments" Style="{StaticResource HeadingTextStyle}"/>
+                                    <Span Text="{x:Static helpers:Icon.ChevronRight}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" />
+                                    <Span Text="Departments" Style="{StaticResource HeadingTextStyle}" />
                                 </FormattedString>
                             </Label.FormattedText>
                         </Label>
                     </toolkit:Expander.Header>
-                    <CollectionView ItemsSource="{Binding Departments}" HeightRequest="300" ItemTemplate="{StaticResource DepartmentTemplate}"/>
+                    <CollectionView ItemsSource="{Binding Departments}"
+                                    SelectionMode="None"
+                                    HeightRequest="300"
+                                    ItemTemplate="{StaticResource DepartmentTemplateSelector}">
+                        <CollectionView.Header>
+                            <Border StrokeShape="RoundRectangle 10 10 0 0"
+                                    BackgroundColor="{AppThemeBinding Light={StaticResource AccentColor}, Dark=#1F5AA8}">
+                                <Grid ColumnSpacing="12"
+                                      Padding="20"
+                                      ColumnDefinitions="2*,*,Auto">
+                                    <Label Text="Name"
+                                           TextColor="White"
+                                           FontAttributes="Bold" />
+                                    <Label Grid.Column="1"
+                                           Text="Description"
+                                           TextColor="White"
+                                           FontAttributes="Bold" />
+                                    <Label Grid.Column="2"
+                                           Text="Actions"
+                                           TextColor="White"
+                                           HorizontalOptions="End"
+                                           FontAttributes="Bold" />
+                                </Grid>
+                            </Border>
+                        </CollectionView.Header>
+                        <CollectionView.EmptyView>
+                            <VerticalStackLayout HorizontalOptions="Center"
+                                                 VerticalOptions="Center"
+                                                 Spacing="8">
+                                <Label Text="No departments found" />
+                                <Label Text="Departments will appear here once they are available." FontSize="12" />
+                            </VerticalStackLayout>
+                        </CollectionView.EmptyView>
+                    </CollectionView>
                 </toolkit:Expander>
+
                 <toolkit:Expander>
                     <toolkit:Expander.Header>
                         <Label>
                             <Label.FormattedText>
                                 <FormattedString>
-                                    <Span Text="{x:Static helpers:Icon.ChevronRight}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}"/>
-                                    <Span Text="Sections" Style="{StaticResource HeadingTextStyle}"/>
+                                    <Span Text="{x:Static helpers:Icon.ChevronRight}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" />
+                                    <Span Text="Sections" Style="{StaticResource HeadingTextStyle}" />
                                 </FormattedString>
                             </Label.FormattedText>
                         </Label>
                     </toolkit:Expander.Header>
-                    <CollectionView ItemsSource="{Binding Sections}" HeightRequest="300" ItemTemplate="{StaticResource SectionTemplate}"/>
+                    <CollectionView ItemsSource="{Binding Sections}"
+                                    SelectionMode="None"
+                                    HeightRequest="300"
+                                    ItemTemplate="{StaticResource SectionTemplateSelector}">
+                        <CollectionView.Header>
+                            <Border StrokeShape="RoundRectangle 10 10 0 0"
+                                    BackgroundColor="{AppThemeBinding Light={StaticResource AccentColor}, Dark=#1F5AA8}">
+                                <Grid ColumnSpacing="12"
+                                      Padding="20"
+                                      ColumnDefinitions="2*,*,Auto">
+                                    <Label Text="Name"
+                                           TextColor="White"
+                                           FontAttributes="Bold" />
+                                    <Label Grid.Column="1"
+                                           Text="Description"
+                                           TextColor="White"
+                                           FontAttributes="Bold" />
+                                    <Label Grid.Column="2"
+                                           Text="Actions"
+                                           TextColor="White"
+                                           HorizontalOptions="End"
+                                           FontAttributes="Bold" />
+                                </Grid>
+                            </Border>
+                        </CollectionView.Header>
+                        <CollectionView.EmptyView>
+                            <VerticalStackLayout HorizontalOptions="Center"
+                                                 VerticalOptions="Center"
+                                                 Spacing="8">
+                                <Label Text="No sections found" />
+                                <Label Text="Sections will appear here once they are available." FontSize="12" />
+                            </VerticalStackLayout>
+                        </CollectionView.EmptyView>
+                    </CollectionView>
                 </toolkit:Expander>
+
                 <toolkit:Expander>
                     <toolkit:Expander.Header>
                         <Label>
                             <Label.FormattedText>
                                 <FormattedString>
-                                    <Span Text="{x:Static helpers:Icon.ChevronRight}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}"/>
-                                    <Span Text="Chargings" Style="{StaticResource HeadingTextStyle}"/>
+                                    <Span Text="{x:Static helpers:Icon.ChevronRight}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" />
+                                    <Span Text="Chargings" Style="{StaticResource HeadingTextStyle}" />
                                 </FormattedString>
                             </Label.FormattedText>
                         </Label>
                     </toolkit:Expander.Header>
-                    <CollectionView ItemsSource="{Binding Chargings}" HeightRequest="300" ItemTemplate="{StaticResource ChargingTemplate}"/>
+                    <CollectionView ItemsSource="{Binding Chargings}"
+                                    SelectionMode="None"
+                                    HeightRequest="300"
+                                    ItemTemplate="{StaticResource ChargingTemplateSelector}">
+                        <CollectionView.Header>
+                            <Border StrokeShape="RoundRectangle 10 10 0 0"
+                                    BackgroundColor="{AppThemeBinding Light={StaticResource AccentColor}, Dark=#1F5AA8}">
+                                <Grid ColumnSpacing="12"
+                                      Padding="20"
+                                      ColumnDefinitions="2*,*,Auto">
+                                    <Label Text="Name"
+                                           TextColor="White"
+                                           FontAttributes="Bold" />
+                                    <Label Grid.Column="1"
+                                           Text="Description"
+                                           TextColor="White"
+                                           FontAttributes="Bold" />
+                                    <Label Grid.Column="2"
+                                           Text="Actions"
+                                           TextColor="White"
+                                           HorizontalOptions="End"
+                                           FontAttributes="Bold" />
+                                </Grid>
+                            </Border>
+                        </CollectionView.Header>
+                        <CollectionView.EmptyView>
+                            <VerticalStackLayout HorizontalOptions="Center"
+                                                 VerticalOptions="Center"
+                                                 Spacing="8">
+                                <Label Text="No chargings found" />
+                                <Label Text="Chargings will appear here once they are available." FontSize="12" />
+                            </VerticalStackLayout>
+                        </CollectionView.EmptyView>
+                    </CollectionView>
                 </toolkit:Expander>
+
                 <toolkit:Expander>
                     <toolkit:Expander.Header>
                         <Label>
                             <Label.FormattedText>
                                 <FormattedString>
-                                    <Span Text="{x:Static helpers:Icon.ChevronRight}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}"/>
-                                    <Span Text="Positions" Style="{StaticResource HeadingTextStyle}"/>
+                                    <Span Text="{x:Static helpers:Icon.ChevronRight}" FontFamily="Icons" Style="{StaticResource HeadingTextStyle}" />
+                                    <Span Text="Positions" Style="{StaticResource HeadingTextStyle}" />
                                 </FormattedString>
                             </Label.FormattedText>
                         </Label>
                     </toolkit:Expander.Header>
-                    <CollectionView ItemsSource="{Binding Positions}" ItemTemplate="{StaticResource PositionTemplate}"
-                    HeightRequest="300"/>
+                    <CollectionView ItemsSource="{Binding Positions}"
+                                    SelectionMode="None"
+                                    HeightRequest="300"
+                                    ItemTemplate="{StaticResource PositionTemplateSelector}">
+                        <CollectionView.Header>
+                            <Border StrokeShape="RoundRectangle 10 10 0 0"
+                                    BackgroundColor="{AppThemeBinding Light={StaticResource AccentColor}, Dark=#1F5AA8}">
+                                <Grid ColumnSpacing="12"
+                                      Padding="20"
+                                      ColumnDefinitions="2*,*,Auto">
+                                    <Label Text="Name"
+                                           TextColor="White"
+                                           FontAttributes="Bold" />
+                                    <Label Grid.Column="1"
+                                           Text="Description"
+                                           TextColor="White"
+                                           FontAttributes="Bold" />
+                                    <Label Grid.Column="2"
+                                           Text="Actions"
+                                           TextColor="White"
+                                           HorizontalOptions="End"
+                                           FontAttributes="Bold" />
+                                </Grid>
+                            </Border>
+                        </CollectionView.Header>
+                        <CollectionView.EmptyView>
+                            <VerticalStackLayout HorizontalOptions="Center"
+                                                 VerticalOptions="Center"
+                                                 Spacing="8">
+                                <Label Text="No positions found" />
+                                <Label Text="Positions will appear here once they are available." FontSize="12" />
+                            </VerticalStackLayout>
+                        </CollectionView.EmptyView>
+                    </CollectionView>
                 </toolkit:Expander>
 
             </VerticalStackLayout>


### PR DESCRIPTION
## Summary
- restyle the settings CollectionViews to mirror the employee list with alternating rows, themed headers, and edit/delete actions
- add a shared row index contract and update setting summary models and view model to drive the alternate row template selector
- provide edit and delete commands on the settings view model for the new action buttons

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e49aedae088329be84b115d59d8db6