### PR TITLE
Add alert indicator for unmatched timesheet punch pairs

### DIFF
--- a/src/Bluewater.App/Models/EmployeeTimesheetSummary.cs
+++ b/src/Bluewater.App/Models/EmployeeTimesheetSummary.cs
@@ -18,5 +18,6 @@ public class EmployeeTimesheetSummary
   public decimal TotalOverbreaks { get; set; }
   public decimal TotalLeaves { get; set; }
   public bool HasPayrollCreated { get; set; }
+  public bool IsShowAlert { get; set; }
   public ObservableCollection<AttendanceTimesheetSummary> Timesheets { get; } = new();
 }

--- a/src/Bluewater.App/ViewModels/TimesheetsViewModel.cs
+++ b/src/Bluewater.App/ViewModels/TimesheetsViewModel.cs
@@ -632,6 +632,7 @@ public partial class TimesheetsViewModel : BaseViewModel
 								foreach (EmployeeTimesheetSummary summary in page.Items)
 								{
 										UpdateTimesheetRowIndexes(summary);
+										UpdateSummaryAlert(summary);
 										Timesheets.Add(summary);
 								}
 
@@ -743,6 +744,7 @@ public partial class TimesheetsViewModel : BaseViewModel
 				existing.TimeOut2 = updatedTimesheet.TimeOut2;
 				existing.EntryDate = updatedTimesheet.EntryDate;
 				existing.IsEdited = updatedTimesheet.IsEdited;
+				UpdateSummaryAlert(summary);
 		}
 
 		//private void SyncSelectedTimesheetSummary()
@@ -769,6 +771,38 @@ public partial class TimesheetsViewModel : BaseViewModel
 				{
 						summary.Timesheets[i].RowIndex = i;
 				}
+		}
+
+		private static void UpdateSummaryAlert(EmployeeTimesheetSummary summary)
+		{
+				summary.IsShowAlert = summary.Timesheets.Any(ShouldShowAlertForTimesheet);
+		}
+
+		private static bool ShouldShowAlertForTimesheet(AttendanceTimesheetSummary timesheet)
+		{
+				int mask = 0;
+
+				if (timesheet.TimeOut2.HasValue)
+				{
+						mask |= 1 << 3;
+				}
+
+				if (timesheet.TimeIn2.HasValue)
+				{
+						mask |= 1 << 2;
+				}
+
+				if (timesheet.TimeOut1.HasValue)
+				{
+						mask |= 1 << 1;
+				}
+
+				if (timesheet.TimeIn1.HasValue)
+				{
+						mask |= 1;
+				}
+
+				return mask is not (0 or 3 or 9 or 12 or 15);
 		}
 
 		private void UpdateCanSaveTimesheets()

--- a/src/Bluewater.App/Views/Controls/TimesheetView.xaml
+++ b/src/Bluewater.App/Views/Controls/TimesheetView.xaml
@@ -123,10 +123,16 @@
 							  VerticalOptions="Center">
 							<VerticalStackLayout Grid.Column="0"
 												 Spacing="4">
-								<Label Text="{Binding Name}"
-									   FontAttributes="Bold"
-									   FontSize="14"
-									   LineBreakMode="TailTruncation" />
+								<HorizontalStackLayout Spacing="6">
+									<Label Text="{Binding Name}"
+										   FontAttributes="Bold"
+										   FontSize="14"
+										   LineBreakMode="TailTruncation" />
+									<Label Text="{x:Static helpers:Icon.AlertTriangle}"
+										   FontFamily="Icons"
+										   TextColor="#EAA545"
+										   IsVisible="{Binding IsShowAlert}" />
+								</HorizontalStackLayout>
 								<Label FontSize="12"
 									   TextColor="{AppThemeBinding Light=#444444, Dark=#DDDDDD}">
 									<Label.FormattedText>


### PR DESCRIPTION
### Motivation
- Surface when an employee has any daily timesheet entry where a `TimeIn` has no matching `TimeOut` (or otherwise invalid combinations) so the user can spot incomplete punch pairs at a glance.

### Description
- Added `IsShowAlert` to `EmployeeTimesheetSummary` to expose per-employee alert state to the view.
- Compute alert state in `TimesheetsViewModel` when loading pages and after per-entry updates by adding `UpdateSummaryAlert` and calling it from load and `UpdateSummaryEntry`.
- Implemented the truth-table logic in `ShouldShowAlertForTimesheet` using a 4-bit bitmask for `TimeIn1`, `TimeOut1`, `TimeIn2`, `TimeOut2` and suppress alerts only for the combinations `0000`, `0011`, `1001`, `1100`, and `1111` (all other masks show an alert).
- Updated `TimesheetView.xaml` to render `helpers:Icon.AlertTriangle` beside the employee `Name` when `IsShowAlert` is true.

### Testing
- Attempted to build the app with `dotnet build src/Bluewater.App/Bluewater.App.csproj -v minimal`, but the build could not be run in this environment because `dotnet` is not installed (error: `dotnet: command not found`).
- No automated unit or integration tests were executed in this environment due to the missing .NET SDK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc3cf341148329bfad1722fdba930d)