### PR TITLE
Avoid full timesheet reload when returning from details

### DIFF
--- a/src/Bluewater.App/ViewModels/TimesheetsViewModel.cs
+++ b/src/Bluewater.App/ViewModels/TimesheetsViewModel.cs
@@ -100,7 +100,6 @@ public partial class TimesheetsViewModel : BaseViewModel
 		{
 				if (hasInitialized)
 				{
-						await LoadTimesheetsAsync().ConfigureAwait(false);
 						return;
 				}
 

--- a/src/Bluewater.App/Views/Controls/TimesheetView.xaml.cs
+++ b/src/Bluewater.App/Views/Controls/TimesheetView.xaml.cs
@@ -4,6 +4,8 @@ namespace Bluewater.App.Views.Controls;
 
 public partial class TimesheetView : ContentView
 {
+		private bool hasLoadedOnce;
+
 		public TimesheetView(TimesheetsViewModel vm)
 		{
 				InitializeComponent();
@@ -12,6 +14,13 @@ public partial class TimesheetView : ContentView
 
 		private async void ContentView_Loaded(object sender, EventArgs e)
 		{
+				if (hasLoadedOnce)
+				{
+						return;
+				}
+
+				hasLoadedOnce = true;
+
 				if (BindingContext is TimesheetsViewModel vm)
 				{
 						await vm.InitializeAsync();


### PR DESCRIPTION
### Motivation
- Returning from the timesheet details screen caused a full list reload which made navigation slow and disrupted the user experience.

### Description
- Stop automatic reloading by removing the extra `LoadTimesheetsAsync()` call when `hasInitialized` is already true in `TimesheetsViewModel.InitializeAsync()` (file: `src/Bluewater.App/ViewModels/TimesheetsViewModel.cs`).
- Add a one-time guard `hasLoadedOnce` in the `TimesheetView` control so `ContentView_Loaded` only calls `InitializeAsync()` once per view instance (file: `src/Bluewater.App/Views/Controls/TimesheetView.xaml.cs`).
- Preserve explicit refresh behavior via the existing `RefreshAsync` and paging commands so manual reloads still work.

### Testing
- Attempted to run `dotnet build src/Bluewater.App/Bluewater.App.csproj -v minimal`, but the build could not be executed in this environment because `dotnet` is not installed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc410de62c8329b0e8aa14bb182d47)