### PR TITLE
Use LocalAppData for logs and create diagnostic ZIP on exception

### DIFF
--- a/src/Bluewater.App/Services/ActivityTraceService.cs
+++ b/src/Bluewater.App/Services/ActivityTraceService.cs
@@ -4,7 +4,6 @@ using System.Text.Json.Serialization;
 using System.Threading;
 using Bluewater.App.Interfaces;
 using Bluewater.App.Models;
-using Microsoft.Maui.Storage;
 
 namespace Bluewater.App.Services;
 
@@ -22,7 +21,8 @@ public sealed class ActivityTraceService : IActivityTraceService, IAsyncDisposab
 
 		public ActivityTraceService(string? appDataDirectory = null)
 		{
-				this.appDataDirectory = appDataDirectory ?? FileSystem.AppDataDirectory;
+				this.appDataDirectory = appDataDirectory ?? GetDefaultLogDirectory();
+				Directory.CreateDirectory(this.appDataDirectory);
 		}
 
 		public Task<string> GetCurrentLogPathAsync()
@@ -83,6 +83,12 @@ public sealed class ActivityTraceService : IActivityTraceService, IAsyncDisposab
 		{
 				string fileName = $"{LogFilePrefix}{timestamp:yyyyMMdd}.log";
 				return Path.Combine(appDataDirectory, fileName);
+		}
+
+		private static string GetDefaultLogDirectory()
+		{
+				string localAppDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+				return Path.Combine(localAppDataPath, "Bluewater", "App", "Logs");
 		}
 
 		public ValueTask DisposeAsync()

--- a/src/Bluewater.App/Services/ExceptionHandlingService.cs
+++ b/src/Bluewater.App/Services/ExceptionHandlingService.cs
@@ -13,7 +13,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Dispatching;
-using Microsoft.Maui.Storage;
 
 namespace Bluewater.App.Services;
 
@@ -100,7 +99,7 @@ public sealed class ExceptionHandlingService : IExceptionHandlingService, IDispo
     }
 
     LogException(source, exception, context, isTerminating);
-    _ = CopyLatestLogToDesktopAsync();
+    _ = CreateDiagnosticArchiveAsync(exception);
     ShowFatalErrorPage(new PresentationException(exception));
   }
 
@@ -264,7 +263,7 @@ public sealed class ExceptionHandlingService : IExceptionHandlingService, IDispo
     });
   }
 
-  private Task CopyLatestLogToDesktopAsync()
+  private Task CreateDiagnosticArchiveAsync(Exception exception)
   {
     return Task.Run(() =>
     {
@@ -276,7 +275,11 @@ public sealed class ExceptionHandlingService : IExceptionHandlingService, IDispo
           return;
         }
 
-        string appDataDirectory = FileSystem.AppDataDirectory;
+        string appDataDirectory = Path.Combine(
+          Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+          "Bluewater",
+          "App",
+          "Logs");
 
         if (!Directory.Exists(appDataDirectory))
         {
@@ -284,30 +287,32 @@ public sealed class ExceptionHandlingService : IExceptionHandlingService, IDispo
           return;
         }
 
-        FileInfo? latestLog = Directory
-          .EnumerateFiles(appDataDirectory, "activity-trace-*.log")
+        List<FileInfo> logFiles = Directory
+          .EnumerateFiles(appDataDirectory, "*.log")
           .Select(path => new FileInfo(path))
+          .Where(file => file.Exists)
           .OrderByDescending(file => file.LastWriteTimeUtc)
-          .ThenByDescending(file => file.CreationTimeUtc)
-          .FirstOrDefault(file => file.Exists);
+          .ToList();
 
-        if (latestLog is null)
+        if (logFiles.Count == 0)
         {
-          logger?.LogWarning("No activity trace logs found to archive.");
+          logger?.LogWarning("No logs found to archive from '{AppDataDirectory}'.", appDataDirectory);
           return;
         }
-        var downloadsDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Downloads");
-        //string downloadsDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
+        string downloadsDirectory = Path.Combine(
+          Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+          "Downloads",
+          "DiagnosticLogs");
 
         if (string.IsNullOrWhiteSpace(downloadsDirectory))
         {
-          logger?.LogWarning("Desktop directory could not be resolved; skipping log archive.");
+          logger?.LogWarning("Downloads directory could not be resolved; skipping log archive.");
           return;
         }
 
         Directory.CreateDirectory(downloadsDirectory);
 
-        string zipFileName = $"{Path.GetFileNameWithoutExtension(latestLog.Name)}-{DateTimeOffset.Now:yyyyMMddHHmmss}.zip";
+        string zipFileName = $"DiagnosticLogs_{DateTimeOffset.Now:yyyyMMdd_HHmmss}.zip";
         string destinationPath = Path.Combine(downloadsDirectory, zipFileName);
 
         if (File.Exists(destinationPath))
@@ -317,14 +322,23 @@ public sealed class ExceptionHandlingService : IExceptionHandlingService, IDispo
 
         using (ZipArchive archive = ZipFile.Open(destinationPath, ZipArchiveMode.Create))
         {
-          archive.CreateEntryFromFile(latestLog.FullName, latestLog.Name);
+          foreach (FileInfo logFile in logFiles)
+          {
+            archive.CreateEntryFromFile(logFile.FullName, logFile.Name);
+          }
+
+          string exceptionDetails = $"Generated: {DateTimeOffset.Now:O}{Environment.NewLine}{Environment.NewLine}{exception}";
+          ZipArchiveEntry exceptionEntry = archive.CreateEntry("exception.txt");
+          using Stream entryStream = exceptionEntry.Open();
+          using var writer = new StreamWriter(entryStream);
+          writer.Write(exceptionDetails);
         }
 
-        logger?.LogInformation("Copied latest activity log '{LogFile}' to Desktop as '{ArchivePath}'.", latestLog.FullName, destinationPath);
+        logger?.LogInformation("Created diagnostic archive at '{ArchivePath}' from '{AppDataDirectory}'.", destinationPath, appDataDirectory);
       }
       catch (Exception archiveException)
       {
-        logger?.LogError(archiveException, "Failed to archive the latest activity log to the Desktop.");
+        logger?.LogError(archiveException, "Failed to create diagnostic archive in Downloads.");
       }
     });
   }


### PR DESCRIPTION
### Motivation
- Standardize log storage away from platform-specific `FileSystem.AppDataDirectory` and ensure the log directory exists under the user's Local Application Data.
- Improve post-crash diagnostics by packaging recent logs and exception details into a zip file in the user's Downloads folder on Windows.

### Description
- Replaced usage of `FileSystem.AppDataDirectory` with a `GetDefaultLogDirectory()` that returns `Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Bluewater", "App", "Logs")` and ensured the directory is created in the `ActivityTraceService` constructor by calling `Directory.CreateDirectory` and when writing logs.
- Added `GetDefaultLogDirectory` helper to `ActivityTraceService` and removed the `Microsoft.Maui.Storage` dependency.
- Replaced `CopyLatestLogToDesktopAsync()` in `ExceptionHandlingService` with `CreateDiagnosticArchiveAsync(Exception)` which collects `*.log` files from the app log directory, creates a `DiagnosticLogs_{timestamp}.zip` under `Downloads/DiagnosticLogs`, includes all found logs, and writes an `exception.txt` entry containing the exception details.
- Updated the exception handling call site to pass the `exception` into `CreateDiagnosticArchiveAsync` and improved logging and error messages; the archive routine only runs on Windows (`OperatingSystem.IsWindows()`).

### Testing
- Built the solution with `dotnet build` to verify compilation after API changes, which succeeded.
- Ran the test suite with `dotnet test` to validate behavior, and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf94b9ae988329b2856d3184980a9d)