### PR TITLE
Sync TimesheetDetails edits back to TimesheetView state

### DIFF
--- a/src/Bluewater.App/ViewModels/Modals/TimesheetDetailsViewModel.cs
+++ b/src/Bluewater.App/ViewModels/Modals/TimesheetDetailsViewModel.cs
@@ -152,6 +152,7 @@ public partial class TimesheetDetailsViewModel : BaseViewModel, IQueryAttributab
 						if (updated is not null)
 						{
 								selectedEntry.ApplySummary(updated);
+								UpdateSelectedEmployeeTimesheetEntry(updated);
 						}
 
 						await MainThread.InvokeOnMainThreadAsync(() =>
@@ -215,6 +216,7 @@ public partial class TimesheetDetailsViewModel : BaseViewModel, IQueryAttributab
 								}
 
 								entry.ApplySummary(updated);
+								UpdateSelectedEmployeeTimesheetEntry(updated);
 								anyUpdated = true;
 						}
 								catch (Exception ex)
@@ -305,5 +307,59 @@ public partial class TimesheetDetailsViewModel : BaseViewModel, IQueryAttributab
 				}
 
 				EditableTimesheets.Clear();
+		}
+
+		private void UpdateSelectedEmployeeTimesheetEntry(AttendanceTimesheetSummary updatedTimesheet)
+		{
+				if (SelectedEmployeeTimesheet is null)
+				{
+						return;
+				}
+
+				AttendanceTimesheetSummary? existing = SelectedEmployeeTimesheet.Timesheets
+					.FirstOrDefault(timesheet => timesheet.Id == updatedTimesheet.Id);
+
+				if (existing is null)
+				{
+						return;
+				}
+
+				existing.TimeIn1 = updatedTimesheet.TimeIn1;
+				existing.TimeOut1 = updatedTimesheet.TimeOut1;
+				existing.TimeIn2 = updatedTimesheet.TimeIn2;
+				existing.TimeOut2 = updatedTimesheet.TimeOut2;
+				existing.EntryDate = updatedTimesheet.EntryDate;
+				existing.IsEdited = updatedTimesheet.IsEdited;
+				existing.ScheduleId = updatedTimesheet.ScheduleId;
+				existing.ShiftId = updatedTimesheet.ShiftId;
+				existing.ShiftName = updatedTimesheet.ShiftName;
+				SelectedEmployeeTimesheet.IsShowAlert = SelectedEmployeeTimesheet.Timesheets.Any(ShouldShowAlertForTimesheet);
+		}
+
+		private static bool ShouldShowAlertForTimesheet(AttendanceTimesheetSummary timesheet)
+		{
+				int mask = 0;
+
+				if (timesheet.TimeOut2.HasValue)
+				{
+						mask |= 1 << 3;
+				}
+
+				if (timesheet.TimeIn2.HasValue)
+				{
+						mask |= 1 << 2;
+				}
+
+				if (timesheet.TimeOut1.HasValue)
+				{
+						mask |= 1 << 1;
+				}
+
+				if (timesheet.TimeIn1.HasValue)
+				{
+						mask |= 1;
+				}
+
+				return mask is not (0 or 3 or 9 or 12 or 15);
 		}
 }


### PR DESCRIPTION
### Motivation
- Ensure that when a single employee timesheet is edited in `TimesheetDetailsPage` and the app navigates back to `TimesheetView`, the in-memory employee summary reflects the latest edits so reopening details shows the updated values.

### Description
- Call `UpdateSelectedEmployeeTimesheetEntry` after successful `UpdateTimesheetAsync` responses in both `SaveTimesheetsAsync` and `ClearSelectedShiftAsync` in `TimesheetDetailsViewModel`.
- Implement `UpdateSelectedEmployeeTimesheetEntry` to locate and patch the matching `AttendanceTimesheetSummary` inside `SelectedEmployeeTimesheet.Timesheets` with the new timestamp/shift/schedule fields.
- Add a local `ShouldShowAlertForTimesheet` helper and recalculate `SelectedEmployeeTimesheet.IsShowAlert` after updates so the parent-row alert state stays correct.

### Testing
- Attempted to build the solution with `dotnet build Bluewater.sln -v minimal`, but the command failed in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`), so no automated build or tests were run successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de7a9419508329a06f6bdbc652e902)