### PR TITLE
Fix timesheet entry matching and refresh selected summary totals

### DIFF
--- a/src/Bluewater.App/Models/TimesheetDtos.cs
+++ b/src/Bluewater.App/Models/TimesheetDtos.cs
@@ -39,7 +39,11 @@ public class AllEmployeeTimesheetDto : EmployeeTimesheetDto
 
 public class TimesheetInfoDto
 {
+  [JsonPropertyName("timesheetId")]
   public Guid TimesheetId { get; set; }
+
+  [JsonPropertyName("id")]
+  public Guid Id { get; set; }
   public Guid? ScheduleId { get; set; }
   public Guid? ShiftId { get; set; }
   public string? ShiftName { get; set; }

--- a/src/Bluewater.App/Services/TimesheetApiService.cs
+++ b/src/Bluewater.App/Services/TimesheetApiService.cs
@@ -217,9 +217,11 @@ public class TimesheetApiService(IApiClient apiClient) : ITimesheetApiService
 
   private static AttendanceTimesheetSummary MapToSummary(Guid employeeId, TimesheetInfoDto dto)
   {
+    Guid timesheetId = dto.TimesheetId != Guid.Empty ? dto.TimesheetId : dto.Id;
+
     return new AttendanceTimesheetSummary
     {
-      Id = dto.TimesheetId,
+      Id = timesheetId,
       EmployeeId = employeeId,
       TimeIn1 = dto.TimeIn1,
       TimeOut1 = dto.TimeOut1,

--- a/src/Bluewater.App/ViewModels/Modals/TimesheetDetailsViewModel.cs
+++ b/src/Bluewater.App/ViewModels/Modals/TimesheetDetailsViewModel.cs
@@ -321,6 +321,13 @@ public partial class TimesheetDetailsViewModel : BaseViewModel, IQueryAttributab
 
 				if (existing is null)
 				{
+						existing = SelectedEmployeeTimesheet.Timesheets.FirstOrDefault(timesheet =>
+								timesheet.EmployeeId == updatedTimesheet.EmployeeId &&
+								timesheet.EntryDate == updatedTimesheet.EntryDate);
+				}
+
+				if (existing is null)
+				{
 						return;
 				}
 

--- a/src/Bluewater.App/ViewModels/TimesheetsViewModel.cs
+++ b/src/Bluewater.App/ViewModels/TimesheetsViewModel.cs
@@ -635,7 +635,7 @@ public partial class TimesheetsViewModel : BaseViewModel
 										Timesheets.Add(summary);
 								}
 
-								//SyncSelectedTimesheetSummary();
+								SyncSelectedTimesheetSummary();
 								UpdateCanSubmit();
 						});
 				}
@@ -746,23 +746,23 @@ public partial class TimesheetsViewModel : BaseViewModel
 				UpdateSummaryAlert(summary);
 		}
 
-		//private void SyncSelectedTimesheetSummary()
-		//{
-		//		if (!IsDetailsOpen || SelectedEmployeeTimesheet is null)
-		//		{
-		//				return;
-		//		}
+		private void SyncSelectedTimesheetSummary()
+		{
+				if (SelectedEmployeeTimesheet is null)
+				{
+						return;
+				}
 
-		//		EmployeeTimesheetSummary? updated = Timesheets
-		//			.FirstOrDefault(item => item.EmployeeId == SelectedEmployeeTimesheet.EmployeeId);
+				EmployeeTimesheetSummary? updated = Timesheets
+					.FirstOrDefault(item => item.EmployeeId == SelectedEmployeeTimesheet.EmployeeId);
 
-		//		if (updated is null || ReferenceEquals(updated, SelectedEmployeeTimesheet))
-		//		{
-		//				return;
-		//		}
+				if (updated is null || ReferenceEquals(updated, SelectedEmployeeTimesheet))
+				{
+						return;
+				}
 
-		//		SelectedEmployeeTimesheet = updated;
-		//}
+				SelectedEmployeeTimesheet = updated;
+		}
 
 		private static void UpdateTimesheetRowIndexes(EmployeeTimesheetSummary summary)
 		{

--- a/src/Bluewater.App/Views/Controls/TimesheetView.xaml.cs
+++ b/src/Bluewater.App/Views/Controls/TimesheetView.xaml.cs
@@ -14,17 +14,19 @@ public partial class TimesheetView : ContentView
 
 		private async void ContentView_Loaded(object sender, EventArgs e)
 		{
-				if (hasLoadedOnce)
+				if (BindingContext is not TimesheetsViewModel vm)
 				{
 						return;
 				}
 
-				hasLoadedOnce = true;
-
-				if (BindingContext is TimesheetsViewModel vm)
+				if (!hasLoadedOnce)
 				{
+						hasLoadedOnce = true;
 						await vm.InitializeAsync();
+						return;
 				}
+
+				await vm.RefreshCommand.ExecuteAsync(null);
 		}
 
 		private void ContentView_Unloaded(object sender, EventArgs e)


### PR DESCRIPTION
### Motivation
- Timesheet entries returned by the API sometimes used different JSON fields for the entry ID which caused `SelectedEmployeeTimesheet.Timesheets` to contain items with empty or mismatched `Id` values, so updates could not find the existing entry. 
- The UI did not refresh the selected employee summary when the list reloaded or when the view was revisited, so totals (`TotalWorkHours`, `TotalBreak`, `TotalLates`, `TotalAbsents`, `TotalUndertimes`, `TotalOverbreaks`, `TotalLeaves`) could become stale.

### Description
- Added JSON property mappings for `TimesheetInfoDto` to accept both `timesheetId` and `id` so deserialization reliably populates the timesheet identifier (`src/Bluewater.App/Models/TimesheetDtos.cs`).
- Updated `MapToSummary` in `TimesheetApiService` to prefer `TimesheetId` and fall back to `Id` when `TimesheetId` is empty so `AttendanceTimesheetSummary.Id` is set correctly (`src/Bluewater.App/Services/TimesheetApiService.cs`).
- Hardened `UpdateSelectedEmployeeTimesheetEntry` to fall back to matching an entry by `EmployeeId` and `EntryDate` when direct `Id` matching fails, allowing updates to apply even for legacy/mismatched IDs (`src/Bluewater.App/ViewModels/Modals/TimesheetDetailsViewModel.cs`).
- Re-enabled and implemented syncing of the `SelectedEmployeeTimesheet` after timesheet list reload so the selected summary object (and its totals) are replaced with the fresh server data, and updated the timesheet view to trigger a refresh on subsequent loads to pull updated summaries (`src/Bluewater.App/ViewModels/TimesheetsViewModel.cs`, `src/Bluewater.App/Views/Controls/TimesheetView.xaml.cs`).

### Testing
- Attempted to build the app with `dotnet build src/Bluewater.App/Bluewater.App.csproj`, but the environment does not have `dotnet` installed so the build could not be executed in this container and therefore automated build tests did not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de9b592eec8329bea358d70cb3acbc)