### PR TITLE
Avoid full timesheet reload after returning from details

### DIFF
--- a/src/Bluewater.App/ViewModels/TimesheetsViewModel.cs
+++ b/src/Bluewater.App/ViewModels/TimesheetsViewModel.cs
@@ -764,6 +764,29 @@ public partial class TimesheetsViewModel : BaseViewModel
 				SelectedEmployeeTimesheet = updated;
 		}
 
+		public void RefreshSelectedTimesheetEntry()
+		{
+				if (SelectedEmployeeTimesheet is null || Timesheets.Count == 0)
+				{
+						return;
+				}
+
+				int selectedIndex = Timesheets
+					.Select((item, index) => new { item, index })
+					.FirstOrDefault(entry => entry.item.EmployeeId == SelectedEmployeeTimesheet.EmployeeId)
+					?.index ?? -1;
+
+				if (selectedIndex < 0)
+				{
+						return;
+				}
+
+				UpdateSummaryAlert(SelectedEmployeeTimesheet);
+				UpdateTimesheetRowIndexes(SelectedEmployeeTimesheet);
+				Timesheets[selectedIndex] = SelectedEmployeeTimesheet;
+				UpdateCanSubmit();
+		}
+
 		private static void UpdateTimesheetRowIndexes(EmployeeTimesheetSummary summary)
 		{
 				for (int i = 0; i < summary.Timesheets.Count; i++)

--- a/src/Bluewater.App/Views/Controls/TimesheetView.xaml.cs
+++ b/src/Bluewater.App/Views/Controls/TimesheetView.xaml.cs
@@ -26,7 +26,7 @@ public partial class TimesheetView : ContentView
 						return;
 				}
 
-				await vm.RefreshCommand.ExecuteAsync(null);
+				vm.RefreshSelectedTimesheetEntry();
 		}
 
 		private void ContentView_Unloaded(object sender, EventArgs e)


### PR DESCRIPTION
### Motivation
- Returning from `TimesheetDetailsPage` was triggering a full reload of the `Timesheets` collection, causing unnecessary network calls and UI refreshes. 
- The goal is to update only the edited/selected employee row when coming back to the `TimesheetView` so the UI reflects the saved changes without reloading all entries.

### Description
- Stop executing a full refresh on subsequent loads by changing `TimesheetView.ContentView_Loaded` to only initialize on first load and to avoid calling `RefreshCommand` on later loads.
- Add `RefreshSelectedTimesheetEntry()` to `TimesheetsViewModel` which locates the selected employee row in `Timesheets`, recomputes alerts and row indexes, replaces that single item in the collection, and updates command state.
- Wire `TimesheetView` to call `RefreshSelectedTimesheetEntry()` on subsequent loads so returning from the details page updates only the edited entry instead of re-fetching the entire list.

### Testing
- Attempted to run `dotnet build src/Bluewater.App/Bluewater.App.csproj -v minimal`, but the build could not be executed in this environment because the `dotnet` CLI is not installed (build failed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de9fbeea8c8329a9dff299f5b2bafb)