### PR TITLE
Refresh selected timesheet via employee-scoped summaries API

### DIFF
--- a/src/Bluewater.App/Interfaces/ITimesheetApiService.cs
+++ b/src/Bluewater.App/Interfaces/ITimesheetApiService.cs
@@ -26,6 +26,16 @@ public interface ITimesheetApiService
     int? take = null,
     CancellationToken cancellationToken = default);
 
+  Task<PagedResult<EmployeeTimesheetSummary>> GetTimesheetSummariesByEmployeeIdAsync(
+    Guid employeeId,
+    string? charging,
+    DateOnly startDate,
+    DateOnly endDate,
+    TenantDto tenant,
+    int? skip = null,
+    int? take = null,
+    CancellationToken cancellationToken = default);
+
   Task<bool> CreateTimesheetEntryAsync(
     string username,
     DateTime? timeInput,

--- a/src/Bluewater.App/Services/TimesheetApiService.cs
+++ b/src/Bluewater.App/Services/TimesheetApiService.cs
@@ -25,7 +25,7 @@ public class TimesheetApiService(IApiClient apiClient) : ITimesheetApiService
       throw new ArgumentException("Employee ID must be provided", nameof(employeeId));
     }
 
-    string requestUri = BuildListAllRequestUri(startDate, endDate, tenant, skip, take, charging: null);
+    string requestUri = BuildListAllRequestUri(startDate, endDate, tenant, skip, take, charging: null, employeeId: null);
 
     TimesheetListAllResponseDto? response = await apiClient
       .GetAsync<TimesheetListAllResponseDto>(requestUri, cancellationToken)
@@ -62,7 +62,43 @@ public class TimesheetApiService(IApiClient apiClient) : ITimesheetApiService
     int? take = null,
     CancellationToken cancellationToken = default)
   {
-    string requestUri = BuildListAllRequestUri(startDate, endDate, tenant, skip, take, charging);
+    string requestUri = BuildListAllRequestUri(startDate, endDate, tenant, skip, take, charging, employeeId: null);
+
+    TimesheetListAllResponseDto? response = await apiClient
+      .GetAsync<TimesheetListAllResponseDto>(requestUri, cancellationToken)
+      .ConfigureAwait(false);
+
+    if (response?.Employees is not { Count: > 0 })
+    {
+      return new PagedResult<EmployeeTimesheetSummary>(Array.Empty<EmployeeTimesheetSummary>(), response?.TotalCount ?? 0);
+    }
+
+    IReadOnlyList<EmployeeTimesheetSummary> timesheets = response.Employees
+      .Where(employee => employee is not null)
+      .Select(employee => MapToEmployeeSummary(employee!))
+      .Where(summary => summary.Timesheets.Count > 0)
+      .OrderBy(summary => summary.Name, StringComparer.OrdinalIgnoreCase)
+      .ToList();
+
+    return new PagedResult<EmployeeTimesheetSummary>(timesheets, response.TotalCount);
+  }
+
+  public async Task<PagedResult<EmployeeTimesheetSummary>> GetTimesheetSummariesByEmployeeIdAsync(
+    Guid employeeId,
+    string? charging,
+    DateOnly startDate,
+    DateOnly endDate,
+    TenantDto tenant,
+    int? skip = null,
+    int? take = null,
+    CancellationToken cancellationToken = default)
+  {
+    if (employeeId == Guid.Empty)
+    {
+      throw new ArgumentException("Employee ID must be provided", nameof(employeeId));
+    }
+
+    string requestUri = BuildListAllRequestUri(startDate, endDate, tenant, skip, take, charging, employeeId);
 
     TimesheetListAllResponseDto? response = await apiClient
       .GetAsync<TimesheetListAllResponseDto>(requestUri, cancellationToken)
@@ -116,7 +152,8 @@ public class TimesheetApiService(IApiClient apiClient) : ITimesheetApiService
     TenantDto tenant,
     int? skip,
     int? take,
-    string? charging)
+    string? charging,
+    Guid? employeeId)
   {
     List<string> parameters =
     [
@@ -128,6 +165,11 @@ public class TimesheetApiService(IApiClient apiClient) : ITimesheetApiService
     if (!string.IsNullOrWhiteSpace(charging))
     {
       parameters.Add($"charging={Uri.EscapeDataString(charging)}");
+    }
+
+    if (employeeId.HasValue && employeeId.Value != Guid.Empty)
+    {
+      parameters.Add($"employeeId={employeeId.Value}");
     }
 
     if (skip.HasValue)

--- a/src/Bluewater.App/ViewModels/TimesheetsViewModel.cs
+++ b/src/Bluewater.App/ViewModels/TimesheetsViewModel.cs
@@ -764,7 +764,7 @@ public partial class TimesheetsViewModel : BaseViewModel
 				SelectedEmployeeTimesheet = updated;
 		}
 
-		public void RefreshSelectedTimesheetEntry()
+		public async Task RefreshSelectedTimesheetEntry()
 		{
 				if (SelectedEmployeeTimesheet is null || Timesheets.Count == 0)
 				{
@@ -781,10 +781,39 @@ public partial class TimesheetsViewModel : BaseViewModel
 						return;
 				}
 
-				UpdateSummaryAlert(SelectedEmployeeTimesheet);
-				UpdateTimesheetRowIndexes(SelectedEmployeeTimesheet);
-				Timesheets[selectedIndex] = SelectedEmployeeTimesheet;
-				UpdateCanSubmit();
+				try
+				{
+						PagedResult<EmployeeTimesheetSummary> refreshed = await timesheetApiService
+								.GetTimesheetSummariesByEmployeeIdAsync(
+										SelectedEmployeeTimesheet.EmployeeId,
+										SelectedCharging?.Name,
+										StartDate,
+										EndDate,
+										SelectedTenant,
+										skip: 0,
+										take: 1)
+								.ConfigureAwait(false);
+
+						EmployeeTimesheetSummary? refreshedSummary = refreshed.Items.FirstOrDefault();
+						if (refreshedSummary is null)
+						{
+								return;
+						}
+
+						UpdateSummaryAlert(refreshedSummary);
+						UpdateTimesheetRowIndexes(refreshedSummary);
+
+						await MainThread.InvokeOnMainThreadAsync(() =>
+						{
+								Timesheets[selectedIndex] = refreshedSummary;
+								SelectedEmployeeTimesheet = refreshedSummary;
+								UpdateCanSubmit();
+						});
+				}
+				catch (Exception ex)
+				{
+						ExceptionHandlingService.Handle(ex, "Refreshing selected timesheet entry");
+				}
 		}
 
 		private static void UpdateTimesheetRowIndexes(EmployeeTimesheetSummary summary)

--- a/src/Bluewater.App/Views/Controls/TimesheetView.xaml.cs
+++ b/src/Bluewater.App/Views/Controls/TimesheetView.xaml.cs
@@ -26,7 +26,7 @@ public partial class TimesheetView : ContentView
 						return;
 				}
 
-				vm.RefreshSelectedTimesheetEntry();
+				await vm.RefreshSelectedTimesheetEntry();
 		}
 
 		private void ContentView_Unloaded(object sender, EventArgs e)


### PR DESCRIPTION
### Motivation
- `RefreshSelectedTimesheetEntry()` previously just re-used the in-memory `SelectedEmployeeTimesheet` and did not fetch fresh data for the selected employee from the backend, causing stale UI state when data changed server-side.

### Description
- Added a new API contract `ITimesheetApiService.GetTimesheetSummariesByEmployeeIdAsync(...)` to request timesheet summaries scoped to a specific `employeeId` (`src/Bluewater.App/Interfaces/ITimesheetApiService.cs`).
- Implemented `GetTimesheetSummariesByEmployeeIdAsync(...)` in `TimesheetApiService` and extended the shared `BuildListAllRequestUri(...)` helper to accept an optional `employeeId` query parameter so the same backend endpoint supports employee-scoped queries (`src/Bluewater.App/Services/TimesheetApiService.cs`).
- Updated `TimesheetsViewModel.RefreshSelectedTimesheetEntry()` to be asynchronous, call the new `GetTimesheetSummariesByEmployeeIdAsync(...)` for `SelectedEmployeeTimesheet.EmployeeId`, update row indexes/alert state, and replace the corresponding item in the `Timesheets` `ObservableCollection` on the main thread while handling exceptions (`src/Bluewater.App/ViewModels/TimesheetsViewModel.cs`).
- Updated `TimesheetView` load handler to `await` the now-async `RefreshSelectedTimesheetEntry()` so reloads properly wait for the refresh to complete (`src/Bluewater.App/Views/Controls/TimesheetView.xaml.cs`).

### Testing
- Attempted to build the solution with `dotnet build Bluewater.sln`, but the environment does not have the .NET SDK installed and the command failed with `/bin/bash: line 1: dotnet: command not found` so no compile/run tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dea60a057083298fc19ff970d1cdc8)