### PR TITLE
Handle optional EmployeeId in timesheet list-all endpoint

### DIFF
--- a/src/Bluewater.UseCases/Timesheets/List/ListAllTimesheetHandler.cs
+++ b/src/Bluewater.UseCases/Timesheets/List/ListAllTimesheetHandler.cs
@@ -31,14 +31,26 @@ internal class ListAllTimesheetHandler(
     using (var scope = serviceScopeFactory.CreateScope())
     {
       var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
-      Result<Common.PagedResult<EmployeeDTO>> employeeResult = string.IsNullOrWhiteSpace(request.charging)
-        ? await mediator.Send(new ListEmployeeQuery(request.skip, request.take, request.tenant), cancellationToken)
-        : await mediator.Send(new ListEmployeeByChargingQuery(request.skip, request.take, request.charging, request.tenant), cancellationToken);
-
-      if (employeeResult.IsSuccess)
+      if (request.employeeId.HasValue)
       {
-        employees = employeeResult.Value.Items.ToList();
-        totalCount = employeeResult.Value.TotalCount;
+        Result<EmployeeDTO> employeeResult = await mediator.Send(new GetEmployeeQuery(request.employeeId.Value), cancellationToken);
+        if (employeeResult.IsSuccess)
+        {
+          employees = [employeeResult.Value];
+          totalCount = employees.Count;
+        }
+      }
+      else
+      {
+        Result<Common.PagedResult<EmployeeDTO>> employeeResult = string.IsNullOrWhiteSpace(request.charging)
+          ? await mediator.Send(new ListEmployeeQuery(request.skip, request.take, request.tenant), cancellationToken)
+          : await mediator.Send(new ListEmployeeByChargingQuery(request.skip, request.take, request.charging, request.tenant), cancellationToken);
+
+        if (employeeResult.IsSuccess)
+        {
+          employees = employeeResult.Value.Items.ToList();
+          totalCount = employeeResult.Value.TotalCount;
+        }
       }
     }
 

--- a/src/Bluewater.UseCases/Timesheets/List/ListAllTimesheetQuery.cs
+++ b/src/Bluewater.UseCases/Timesheets/List/ListAllTimesheetQuery.cs
@@ -4,4 +4,4 @@ using Bluewater.Core.EmployeeAggregate.Enum;
 using Bluewater.UseCases.Common;
 
 namespace Bluewater.UseCases.Timesheets.List;
-public record ListAllTimesheetQuery(int? skip, int? take, string charging, DateOnly startDate, DateOnly endDate, Tenant tenant) : IQuery<Result<Common.PagedResult<AllEmployeeTimesheetDTO>>>;
+public record ListAllTimesheetQuery(int? skip, int? take, string charging, DateOnly startDate, DateOnly endDate, Tenant tenant, Guid? employeeId = null) : IQuery<Result<Common.PagedResult<AllEmployeeTimesheetDTO>>>;

--- a/src/Bluewater.Web/Timesheets/ListAll.TimesheetListAllRequest.cs
+++ b/src/Bluewater.Web/Timesheets/ListAll.TimesheetListAllRequest.cs
@@ -21,4 +21,6 @@ public class TimesheetListAllRequest
 
   [Required]
   public Tenant Tenant { get; set; }
+
+  public Guid? EmployeeId { get; set; }
 }

--- a/src/Bluewater.Web/Timesheets/ListAll.cs
+++ b/src/Bluewater.Web/Timesheets/ListAll.cs
@@ -23,7 +23,7 @@ public class ListAll(IMediator _mediator) : Endpoint<TimesheetListAllRequest, Ti
   public override async Task HandleAsync(TimesheetListAllRequest request, CancellationToken cancellationToken)
   {
     Result<UseCases.Common.PagedResult<AllEmployeeTimesheetDTO>> result = await _mediator.Send(
-      new ListAllTimesheetQuery(request.Skip, request.Take, request.Charging, request.StartDate, request.EndDate, request.Tenant),
+      new ListAllTimesheetQuery(request.Skip, request.Take, request.Charging, request.StartDate, request.EndDate, request.Tenant, request.EmployeeId),
       cancellationToken);
 
     if (result.Status == ResultStatus.NotFound)


### PR DESCRIPTION
### Motivation

- Allow callers to request timesheet summaries for a single employee when an `EmployeeId` is supplied to the list-all endpoint. 

### Description

- Added an optional `EmployeeId` property to the request model at `src/Bluewater.Web/Timesheets/ListAll.TimesheetListAllRequest.cs` as `public Guid? EmployeeId { get; set; }`.
- Forwarded `request.EmployeeId` from the web endpoint in `src/Bluewater.Web/Timesheets/ListAll.cs` into the query by calling `new ListAllTimesheetQuery(..., request.EmployeeId)`.
- Extended `ListAllTimesheetQuery` in `src/Bluewater.UseCases/Timesheets/List/ListAllTimesheetQuery.cs` to accept an optional `Guid? employeeId = null` parameter.
- Updated `ListAllTimesheetHandler` in `src/Bluewater.UseCases/Timesheets/List/ListAllTimesheetHandler.cs` to call `GetEmployeeQuery` and build a one-item `employees` list when `request.employeeId` is present, otherwise preserving the existing list-by-charging or list-all behavior.
- No repository/skill tools were used for additional code generation beyond these direct edits.

### Testing

- Attempted to run `dotnet build Bluewater.sln` in the environment but it failed with `dotnet: command not found`, so no automated build or test run completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e163aabd888329bc537d42b6afa162)