### PR TITLE
Fix CalculateWorkHours: shift-based whole-hour totals, penalties, and configurable night-shift window

### DIFF
--- a/src/Bluewater.Core/AttendanceAggregate/Attendance.cs
+++ b/src/Bluewater.Core/AttendanceAggregate/Attendance.cs
@@ -7,7 +7,10 @@ namespace Bluewater.Core.AttendanceAggregate;
 public class Attendance(Guid employeeId, Guid? shiftId, Guid? timesheetId, Guid? leaveId, DateOnly? entryDate, decimal? workHrs, decimal? lateHrs, decimal? underHrs, decimal? overbreakHrs, decimal? nightShiftHours, bool isLocked = false) : EntityBase<Guid>, IAggregateRoot
 {
     private const double LatenessThresholdMinutes = 15;
+    private const double UndertimeThresholdMinutes = 15;
     private const double BreakToleranceMinutes = 10;
+    private static readonly TimeOnly DefaultNightShiftStart = new(22, 0);
+    private static readonly TimeOnly DefaultNightShiftEnd = new(6, 0);
 
     public Guid EmployeeId { get; private set; } = employeeId;
     public Guid? ShiftId { get; private set; } = shiftId;
@@ -51,7 +54,13 @@ public class Attendance(Guid employeeId, Guid? shiftId, Guid? timesheetId, Guid?
     }
 
   public (decimal totalWorkHours, decimal totalLateHours, decimal totalUndertimeHours,
-          decimal totalOverbreakHours, decimal totalNightShiftHours) CalculateWorkHours()
+          decimal totalOverbreakHours, decimal totalNightShiftHours) CalculateWorkHours(
+            double lateThresholdMinutes = LatenessThresholdMinutes,
+            double undertimeThresholdMinutes = UndertimeThresholdMinutes,
+            double overbreakThresholdMinutes = BreakToleranceMinutes,
+            bool enableNightShiftComputation = true,
+            TimeOnly? nightShiftStartTime = null,
+            TimeOnly? nightShiftEndTime = null)
   {
     try
     {
@@ -81,45 +90,58 @@ public class Attendance(Guid employeeId, Guid? shiftId, Guid? timesheetId, Guid?
         return (0, 0, 0, 0, 0);
       }
 
-      decimal workWithinSchedule = 0m;
-      workWithinSchedule += CalculateOverlapHours(ts.TimeIn1.Value, firstClockOut.Value, scheduledStart, scheduledEnd);
+      (DateTime breakStart, DateTime breakEnd) = GetScheduledBreakWindow(scheduledStart, scheduledEnd, sh, ts.TimeIn1.Value);
+      decimal shiftBreakHours = CalculateOverlapHours(breakStart, breakEnd, scheduledStart, scheduledEnd);
+      decimal shiftWorkHours = Math.Max(0, (decimal)(scheduledEnd - scheduledStart).TotalHours - shiftBreakHours);
 
       bool hasSecondSession = ts.TimeIn2.HasValue && ts.TimeOut2.HasValue;
+
+      decimal workWithinSchedule = CalculateNetSessionHours(ts.TimeIn1.Value, firstClockOut.Value, scheduledStart, scheduledEnd, breakStart, breakEnd);
       if (hasSecondSession)
       {
-        workWithinSchedule += CalculateOverlapHours(ts.TimeIn2!.Value, ts.TimeOut2!.Value, scheduledStart, scheduledEnd);
+        workWithinSchedule += CalculateNetSessionHours(ts.TimeIn2!.Value, ts.TimeOut2!.Value, scheduledStart, scheduledEnd, breakStart, breakEnd);
       }
 
-      decimal penaltyLate = CalculateRoundedHourPenalty((ts.TimeIn1.Value - scheduledStart).TotalMinutes, LatenessThresholdMinutes);
+      decimal penaltyLate = CalculateRoundedHourPenalty((ts.TimeIn1.Value - scheduledStart).TotalMinutes, lateThresholdMinutes);
 
       DateTime attendanceEnd = hasSecondSession ? ts.TimeOut2!.Value : firstClockOut.Value;
       decimal penaltyEarly = 0m;
       if (attendanceEnd < scheduledEnd)
       {
-        penaltyEarly = CalculateRoundedHourPenalty((scheduledEnd - attendanceEnd).TotalMinutes, 0);
+        penaltyEarly = CalculateRoundedHourPenalty((scheduledEnd - attendanceEnd).TotalMinutes, undertimeThresholdMinutes);
       }
 
       decimal penaltyBreak = 0m;
       if (hasSecondSession && ts.TimeOut1.HasValue)
       {
-        (DateTime breakStart, DateTime breakEnd) = GetScheduledBreakWindow(scheduledStart, scheduledEnd, sh, ts.TimeIn1.Value);
-
         double scheduledBreakMinutes = Math.Max(0, (breakEnd - breakStart).TotalMinutes);
         DateTime effectiveBreakStart = ts.TimeOut1.Value < breakStart ? breakStart : ts.TimeOut1.Value;
         double actualBreakMinutes = (ts.TimeIn2!.Value - effectiveBreakStart).TotalMinutes;
         double excessBreakMinutes = actualBreakMinutes - scheduledBreakMinutes;
 
-        penaltyBreak = CalculateRoundedHourPenalty(excessBreakMinutes, BreakToleranceMinutes);
+        penaltyBreak = CalculateRoundedHourPenalty(excessBreakMinutes, overbreakThresholdMinutes);
       }
 
-      decimal netWorkHours = Math.Max(0, workWithinSchedule);
-      decimal nightShiftHours = IsNightShift(sh) ? netWorkHours : 0m;
+      decimal netWorkHours = Math.Max(0, Math.Min(workWithinSchedule, shiftWorkHours));
+      decimal roundedWorkHours = RoundToWholeHours(netWorkHours);
+      decimal roundedLateHours = RoundToWholeHours(penaltyLate);
+      decimal roundedUnderHours = RoundToWholeHours(penaltyEarly);
+      decimal roundedOverbreakHours = RoundToWholeHours(penaltyBreak);
 
-      WorkHrs = Math.Round(netWorkHours, 2);
-      LateHrs = Math.Round(penaltyLate, 2);
-      UnderHrs = Math.Round(penaltyEarly, 2);
-      OverbreakHrs = Math.Round(penaltyBreak, 2);
-      NightShiftHours = Math.Round(nightShiftHours, 2);
+      decimal nightShiftHours = 0m;
+      if (enableNightShiftComputation)
+      {
+        TimeOnly nsStart = nightShiftStartTime ?? DefaultNightShiftStart;
+        TimeOnly nsEnd = nightShiftEndTime ?? DefaultNightShiftEnd;
+        nightShiftHours = CalculateNightShiftHours(ts, scheduledStart, scheduledEnd, breakStart, breakEnd, nsStart, nsEnd);
+      }
+      decimal roundedNightShiftHours = RoundToWholeHours(nightShiftHours);
+
+      WorkHrs = roundedWorkHours;
+      LateHrs = roundedLateHours;
+      UnderHrs = roundedUnderHours;
+      OverbreakHrs = roundedOverbreakHours;
+      NightShiftHours = roundedNightShiftHours;
 
       return (WorkHrs ?? 0, LateHrs ?? 0, UnderHrs ?? 0, OverbreakHrs ?? 0, NightShiftHours ?? 0);
     }
@@ -150,6 +172,19 @@ public class Attendance(Guid employeeId, Guid? shiftId, Guid? timesheetId, Guid?
       : 0m;
   }
 
+  private static decimal CalculateNetSessionHours(
+    DateTime sessionStart,
+    DateTime sessionEnd,
+    DateTime scheduledStart,
+    DateTime scheduledEnd,
+    DateTime breakStart,
+    DateTime breakEnd)
+  {
+    decimal grossOverlap = CalculateOverlapHours(sessionStart, sessionEnd, scheduledStart, scheduledEnd);
+    decimal breakOverlap = CalculateOverlapHours(sessionStart, sessionEnd, breakStart, breakEnd);
+    return Math.Max(0m, grossOverlap - breakOverlap);
+  }
+
   private static decimal CalculateRoundedHourPenalty(double minutes, double thresholdMinutes)
   {
     if (minutes <= thresholdMinutes)
@@ -158,6 +193,11 @@ public class Attendance(Guid employeeId, Guid? shiftId, Guid? timesheetId, Guid?
     }
 
     return (decimal)(Math.Floor((minutes - thresholdMinutes - 1) / 60) + 1);
+  }
+
+  private static decimal RoundToWholeHours(decimal value)
+  {
+    return Math.Round(value, 0, MidpointRounding.AwayFromZero);
   }
 
   private static (DateTime breakStart, DateTime breakEnd) GetScheduledBreakWindow(DateTime scheduledStart, DateTime scheduledEnd, Shift shift, DateTime referenceDate)
@@ -179,14 +219,45 @@ public class Attendance(Guid employeeId, Guid? shiftId, Guid? timesheetId, Guid?
     return (defaultBreakStart, defaultBreakEnd);
   }
 
-  private static bool IsNightShift(Shift shift)
+  private static decimal CalculateNightShiftHours(
+    Timesheet timesheet,
+    DateTime scheduledStart,
+    DateTime scheduledEnd,
+    DateTime breakStart,
+    DateTime breakEnd,
+    TimeOnly nightShiftStartTime,
+    TimeOnly nightShiftEndTime)
   {
-    if (!shift.ShiftStartTime.HasValue || !shift.ShiftEndTime.HasValue)
+    DateTime nightStart = BuildShiftDateTime(scheduledStart, nightShiftStartTime);
+    DateTime nightEnd = BuildShiftDateTime(scheduledStart, nightShiftEndTime);
+    if (nightEnd <= nightStart)
     {
-      return false;
+      nightEnd = nightEnd.AddDays(1);
     }
 
-    return shift.ShiftStartTime.Value.Hour >= 22 || shift.ShiftEndTime.Value.Hour <= 6;
+    DateTime effectiveNightStart = nightStart > scheduledStart ? nightStart : scheduledStart;
+    DateTime effectiveNightEnd = nightEnd < scheduledEnd ? nightEnd : scheduledEnd;
+    if (effectiveNightEnd <= effectiveNightStart)
+    {
+      return 0m;
+    }
+
+    decimal total = 0m;
+    if (timesheet.TimeOut1.HasValue)
+    {
+      total += CalculateNetSessionHours(timesheet.TimeIn1!.Value, timesheet.TimeOut1.Value, effectiveNightStart, effectiveNightEnd, breakStart, breakEnd);
+    }
+    else if (timesheet.TimeOut2.HasValue)
+    {
+      total += CalculateNetSessionHours(timesheet.TimeIn1!.Value, timesheet.TimeOut2.Value, effectiveNightStart, effectiveNightEnd, breakStart, breakEnd);
+    }
+
+    if (timesheet.TimeIn2.HasValue && timesheet.TimeOut2.HasValue)
+    {
+      total += CalculateNetSessionHours(timesheet.TimeIn2.Value, timesheet.TimeOut2.Value, effectiveNightStart, effectiveNightEnd, breakStart, breakEnd);
+    }
+
+    return total;
   }
 
 

--- a/tests/Bluewater.UnitTests/Core/AttendanceAggregate/AttendanceCalculateWorkHours.cs
+++ b/tests/Bluewater.UnitTests/Core/AttendanceAggregate/AttendanceCalculateWorkHours.cs
@@ -28,7 +28,7 @@ public class AttendanceCalculateWorkHours
 
     var result = attendance.CalculateWorkHours();
 
-    result.totalWorkHours.Should().Be(9m);
+    result.totalWorkHours.Should().Be(8m);
   }
 
   [Fact]
@@ -52,5 +52,56 @@ public class AttendanceCalculateWorkHours
     var result = attendance.CalculateWorkHours();
 
     result.totalWorkHours.Should().Be(6m);
+  }
+
+  [Fact]
+  public void AppliesPenaltyThresholdsAsWholeHourDeductions()
+  {
+    DateTime shiftDate = new(2024, 1, 15, 0, 0, 0);
+    Shift shift = new("DAY", new TimeOnly(8, 0), new TimeOnly(12, 0), new TimeOnly(13, 0), new TimeOnly(17, 0), 1);
+    Timesheet timesheet = new(Guid.NewGuid(),
+      shiftDate.AddHours(8).AddMinutes(20),   // 20 mins late
+      shiftDate.AddHours(12),
+      shiftDate.AddHours(14).AddMinutes(20),  // 80-min break (20 mins excess)
+      shiftDate.AddHours(16).AddMinutes(40),  // 20 mins undertime
+      DateOnly.FromDateTime(shiftDate));
+
+    Attendance attendance = new(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), null, DateOnly.FromDateTime(shiftDate), null, null, null, null, null)
+    {
+      Shift = shift,
+      Timesheet = timesheet
+    };
+
+    var result = attendance.CalculateWorkHours();
+
+    result.totalLateHours.Should().Be(1m);
+    result.totalOverbreakHours.Should().Be(1m);
+    result.totalUndertimeHours.Should().Be(1m);
+  }
+
+  [Fact]
+  public void CalculatesNightShiftHoursUsingConfigurableWindow()
+  {
+    DateTime shiftDate = new(2024, 1, 15, 0, 0, 0);
+    Shift shift = new("NIGHT", new TimeOnly(20, 0), new TimeOnly(0, 0), new TimeOnly(1, 0), new TimeOnly(4, 0), 1);
+    Timesheet timesheet = new(Guid.NewGuid(),
+      shiftDate.AddHours(20),
+      shiftDate.AddDays(1).AddHours(0),
+      shiftDate.AddDays(1).AddHours(1),
+      shiftDate.AddDays(1).AddHours(4),
+      DateOnly.FromDateTime(shiftDate));
+
+    Attendance attendance = new(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), null, DateOnly.FromDateTime(shiftDate), null, null, null, null, null)
+    {
+      Shift = shift,
+      Timesheet = timesheet
+    };
+
+    var result = attendance.CalculateWorkHours(
+      enableNightShiftComputation: true,
+      nightShiftStartTime: new TimeOnly(21, 0),
+      nightShiftEndTime: new TimeOnly(3, 0));
+
+    result.totalNightShiftHours.Should().Be(5m);
   }
 }


### PR DESCRIPTION
### Motivation
- Ensure attendance totals are computed strictly against the assigned shift window and scheduled break so a fully compliant timesheet equals the shift's work hours. 
- Enforce whole-hour deductions for lateness, undertime and overbreak using configurable thresholds, and provide a configurable night-shift window for night-hour calculations. 
- No external skill was used for this change.

### Description
- Rewrote `Attendance.CalculateWorkHours` to compute work hours only inside the scheduled shift window and subtract scheduled break time, and to clamp worked hours to the shift's expected work-hours. (`src/Bluewater.Core/AttendanceAggregate/Attendance.cs`).
- Added configurable thresholds and parameters: `lateThresholdMinutes`, `undertimeThresholdMinutes`, `overbreakThresholdMinutes`, `enableNightShiftComputation`, `nightShiftStartTime`, and `nightShiftEndTime`, plus defaults and constants for night-shift time. (`Attendance.CalculateWorkHours` signature and constants).
- Implemented helper functions `CalculateNetSessionHours`, `RoundToWholeHours`, and `CalculateNightShiftHours`, and adjusted penalty computations to produce whole-hour deductions using the specified thresholds. (`Attendance.cs`).
- Updated unit tests to reflect break-exclusion, added tests for penalty rounding and configurable night-shift behavior in `tests/Bluewater.UnitTests/Core/AttendanceAggregate/AttendanceCalculateWorkHours.cs`.

### Testing
- Updated unit tests in `tests/Bluewater.UnitTests/Core/AttendanceAggregate/AttendanceCalculateWorkHours.cs` to cover single-session shift counting, multi-session overlap, whole-hour penalties, and configurable night-shift computation. 
- Attempted to run the focused tests with `dotnet test tests/Bluewater.UnitTests/Bluewater.UnitTests.csproj --filter AttendanceCalculateWorkHours` but the test run could not be executed in this environment because `dotnet` is not installed (so automated tests were not run here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e16e058bf0832999b33e0bad5d696d)