### PR TITLE
Disable CommunityToolkit snackbars on Windows to avoid MSIX startup crash

### DIFF
--- a/src/Bluewater.App/MauiProgram.cs
+++ b/src/Bluewater.App/MauiProgram.cs
@@ -20,7 +20,20 @@ public static class MauiProgram
 				var builder = MauiApp.CreateBuilder();
 				builder
 					.UseMauiApp<App>()
-					.UseMauiCommunityToolkit(options => options.SetShouldEnableSnackbarOnWindows(true))
+					.UseMauiCommunityToolkit(options =>
+					{
+#if WINDOWS
+							// Enabling CommunityToolkit snackbars on Windows triggers an AppNotificationManager.Register()
+							// call, which requires packaged COM notification activation entries. Our MSIX currently
+							// doesn't provide those entries, causing startup crashes with:
+							// "No COM servers are registered for this app" (0x80004005).
+							//
+							// Keep snackbars disabled on Windows so startup is stable for MSIX installs.
+							options.SetShouldEnableSnackbarOnWindows(false);
+#else
+							options.SetShouldEnableSnackbarOnWindows(true);
+#endif
+					})
 					.ConfigureLifecycleEvents(lifecycle =>
 					{
 #if WINDOWS


### PR DESCRIPTION
### Motivation
- Prevent MSIX-installed app from crashing at startup due to CommunityToolkit triggering `AppNotificationManager.Register()` which requires packaged COM notification activation entries and produces `No COM servers are registered for this app (0x80004005)` when absent.

### Description
- Change `src/Bluewater.App/MauiProgram.cs` to conditionally call `options.SetShouldEnableSnackbarOnWindows(false)` on Windows and keep snackbars enabled on non-Windows platforms, and add an inline comment explaining the MSIX/COM rationale.

### Testing
- Attempted an automated build with `dotnet build src/Bluewater.App/Bluewater.App.csproj -c Release`, but the build tooling is unavailable in this environment (`dotnet: command not found`), so no build validation could be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48d5d0bf883299b670f380d905bc0)