### PR TITLE
Prefer MSIX/AppInstaller update flow over EXE self-update

### DIFF
--- a/src/Bluewater.App/Services/AppUpdaterService.cs
+++ b/src/Bluewater.App/Services/AppUpdaterService.cs
@@ -96,9 +96,20 @@ public sealed class AppUpdaterService : IAppUpdaterService
       Message = "Self-update is currently supported on Windows builds only."
     };
 #else
-    if (IsRunningPackaged())
+    bool hasMsixUpdateSource = !string.IsNullOrWhiteSpace(manifest.AppInstallerUrl) || !string.IsNullOrWhiteSpace(manifest.MsixUrl);
+    if (hasMsixUpdateSource)
     {
       return await StartMsixUpdateFlowAsync(manifest).ConfigureAwait(false);
+    }
+
+    if (IsRunningPackaged())
+    {
+      return new AppUpdateInstallResult
+      {
+        IsSuccess = false,
+        RequiresRestart = false,
+        Message = "Packaged builds require appInstallerUrl or msixUrl in version.json."
+      };
     }
 
     if (string.IsNullOrWhiteSpace(manifest.ZipUrl))
@@ -222,7 +233,8 @@ public sealed class AppUpdaterService : IAppUpdaterService
     if (!string.IsNullOrWhiteSpace(appInstallerUrl) &&
         Uri.TryCreate(appInstallerUrl, UriKind.Absolute, out Uri? parsedAppInstaller))
     {
-      return parsedAppInstaller;
+      string encodedSource = Uri.EscapeDataString(parsedAppInstaller.ToString());
+      return new Uri($"ms-appinstaller:?source={encodedSource}", UriKind.Absolute);
     }
 
     string? msixUrl = manifest.MsixUrl?.Trim();


### PR DESCRIPTION
### Motivation

- Allow updates to be installed via MSIX/AppInstaller rather than relying on replacing the unpackaged EXE, so an `.appinstaller` or `.msix` source can be used for updates. 
- Ensure packaged builds explicitly require an `appInstallerUrl` or `msixUrl` and avoid falling back to ZIP/EXE replacement when the package-based installer flow is intended.

### Description

- Updated `DownloadAndInstallAsync` to detect `hasMsixUpdateSource` (when `appInstallerUrl` or `msixUrl` is present) and prefer the MSIX/AppInstaller flow by calling `StartMsixUpdateFlowAsync` first. 
- Added a packaged-build guard that returns a clear failure `AppUpdateInstallResult` when running packaged and no `appInstallerUrl`/`msixUrl` is provided. 
- Changed `TryBuildInstallerUri` to wrap `appInstallerUrl` with the `ms-appinstaller:?source=...` scheme so the Windows App Installer is launched consistently for both `appInstallerUrl` and `msixUrl`. 
- File modified: `src/Bluewater.App/Services/AppUpdaterService.cs`.

### Testing

- Attempted to run `dotnet build src/Bluewater.App/Bluewater.App.csproj -v minimal`, but the command failed in this environment with `/bin/bash: line 1: dotnet: command not found` so a full build could not be verified automatically.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e49685e6a48329a3ec23fa5e681716)