### PR TITLE
Support .appinstaller XML manifests in AppUpdaterService

### DIFF
--- a/src/Bluewater.App/Services/AppUpdaterService.cs
+++ b/src/Bluewater.App/Services/AppUpdaterService.cs
@@ -3,6 +3,7 @@ using System.IO.Compression;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
+using System.Xml.Linq;
 using Bluewater.App.Interfaces;
 using Bluewater.App.Models;
 using Microsoft.Maui.ApplicationModel;
@@ -26,7 +27,7 @@ public sealed class AppUpdaterService : IAppUpdaterService
   {
     if (!TryNormalizeUrl(candidateUrl, out Uri? manifestUri))
     {
-      validationMessage = "Please enter a valid absolute HTTP or HTTPS URL for version.json.";
+      validationMessage = "Please enter a valid absolute HTTP or HTTPS URL for version.json or .appinstaller.";
       return false;
     }
 
@@ -52,17 +53,14 @@ public sealed class AppUpdaterService : IAppUpdaterService
     response.EnsureSuccessStatusCode();
 
     await using Stream responseStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-    AppUpdateManifest? manifest = await JsonSerializer.DeserializeAsync<AppUpdateManifest>(
-      responseStream,
-      new JsonSerializerOptions { PropertyNameCaseInsensitive = true },
-      cancellationToken).ConfigureAwait(false);
+    AppUpdateManifest? manifest = await DeserializeManifestAsync(responseStream, manifestUrl, cancellationToken).ConfigureAwait(false);
 
     bool hasSelfUpdatePackage = !string.IsNullOrWhiteSpace(manifest?.ZipUrl);
     bool hasMsixPackage = !string.IsNullOrWhiteSpace(manifest?.AppInstallerUrl) || !string.IsNullOrWhiteSpace(manifest?.MsixUrl);
 
     if (manifest is null || string.IsNullOrWhiteSpace(manifest.Version) || (!hasSelfUpdatePackage && !hasMsixPackage))
     {
-      throw new InvalidOperationException("version.json is missing required values. Provide version and at least one update source: zipUrl, appInstallerUrl, or msixUrl.");
+      throw new InvalidOperationException("Update manifest is missing required values. Provide version and at least one update source: zipUrl, appInstallerUrl, or msixUrl.");
     }
 
     if (!Version.TryParse(manifest.Version.Trim(), out Version? availableVersion))
@@ -261,6 +259,87 @@ public sealed class AppUpdaterService : IAppUpdaterService
     }
 
     return Assembly.GetExecutingAssembly().GetName().Version ?? new Version(1, 0, 0, 0);
+  }
+
+  private static async Task<AppUpdateManifest?> DeserializeManifestAsync(Stream responseStream, string sourceUrl, CancellationToken cancellationToken)
+  {
+    using MemoryStream buffer = new();
+    await responseStream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+
+    if (buffer.Length == 0)
+    {
+      return null;
+    }
+
+    buffer.Position = 0;
+    if (LooksLikeXml(buffer))
+    {
+      return ParseAppInstallerManifest(buffer, sourceUrl);
+    }
+
+    buffer.Position = 0;
+    return await JsonSerializer.DeserializeAsync<AppUpdateManifest>(
+      buffer,
+      new JsonSerializerOptions { PropertyNameCaseInsensitive = true },
+      cancellationToken).ConfigureAwait(false);
+  }
+
+  private static bool LooksLikeXml(Stream stream)
+  {
+    stream.Position = 0;
+    int firstByte;
+    do
+    {
+      firstByte = stream.ReadByte();
+    } while (firstByte != -1 && char.IsWhiteSpace((char)firstByte));
+
+    stream.Position = 0;
+    return firstByte == '<';
+  }
+
+  private static AppUpdateManifest ParseAppInstallerManifest(Stream xmlStream, string sourceUrl)
+  {
+    XDocument document = XDocument.Load(xmlStream);
+    XElement? appInstaller = document.Root;
+    if (appInstaller is null || !string.Equals(appInstaller.Name.LocalName, "AppInstaller", StringComparison.OrdinalIgnoreCase))
+    {
+      throw new InvalidOperationException("The .appinstaller file does not contain an AppInstaller root element.");
+    }
+
+    string version = appInstaller.Attribute("Version")?.Value?.Trim() ?? string.Empty;
+    string? mainPackageUri =
+      appInstaller.Elements().FirstOrDefault(element => string.Equals(element.Name.LocalName, "MainBundle", StringComparison.OrdinalIgnoreCase))?.Attribute("Uri")?.Value?.Trim()
+      ?? appInstaller.Elements().FirstOrDefault(element => string.Equals(element.Name.LocalName, "MainPackage", StringComparison.OrdinalIgnoreCase))?.Attribute("Uri")?.Value?.Trim();
+
+    string resolvedMainPackageUri = ResolveAbsoluteUri(sourceUrl, mainPackageUri);
+
+    return new AppUpdateManifest
+    {
+      Version = version,
+      AppInstallerUrl = sourceUrl,
+      MsixUrl = resolvedMainPackageUri
+    };
+  }
+
+  private static string ResolveAbsoluteUri(string baseUrl, string? candidateUri)
+  {
+    if (string.IsNullOrWhiteSpace(candidateUri))
+    {
+      return string.Empty;
+    }
+
+    if (Uri.TryCreate(candidateUri.Trim(), UriKind.Absolute, out Uri? absoluteUri))
+    {
+      return absoluteUri.ToString();
+    }
+
+    if (Uri.TryCreate(baseUrl, UriKind.Absolute, out Uri? baseUri) &&
+        Uri.TryCreate(baseUri, candidateUri.Trim(), out Uri? relativeUri))
+    {
+      return relativeUri.ToString();
+    }
+
+    return string.Empty;
   }
 
   private static bool TryNormalizeUrl(string? input, out Uri? normalizedUri)


### PR DESCRIPTION
### Motivation
- `CheckForUpdatesAsync` assumed the manifest response was JSON, which caused a `JsonException` when the endpoint returned an `.appinstaller` XML file (leading `'<` invalid start of a value`).
- The updater needs to accept both `version.json` (JSON) and `.appinstaller` (XML) manifests so packaged update flows work when a feed uses AppInstaller files.

### Description
- Replace direct `JsonSerializer.DeserializeAsync` with `DeserializeManifestAsync` which buffers the response and detects JSON vs XML. 
- Add `LooksLikeXml`, `ParseAppInstallerManifest`, and `ResolveAbsoluteUri` helpers to parse `.appinstaller` XML, extract `AppInstaller/@Version` and the `MainBundle`/`MainPackage/@Uri`, and resolve package URIs to absolute URLs. 
- Populate `AppInstallerUrl` and `MsixUrl` on the returned `AppUpdateManifest` for downstream `ms-appinstaller` flows and preserve JSON deserialization for `version.json`. 
- Update user-facing validation/error text in `TryUpdateManifestUrl` and manifest validation to refer to a generic "update manifest" or `.appinstaller` in addition to `version.json`, and add `using System.Xml.Linq;`.

### Testing
- Attempted `dotnet build src/Bluewater.App/Bluewater.App.csproj -nologo`, which could not run in this environment because `dotnet` is not installed (build failed: `dotnet: command not found`).
- No automated unit tests were executed in this container; change committed locally and is ready for CI/agent validation where the .NET SDK is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c27f404083298c58bf215ae72f7a)