### PR TITLE
Replace MAUI Snackbars with `Shell.Current.DisplayAlert` in Bluewater.App

### DIFF
--- a/src/Bluewater.App/ViewModels/Modals/EmployeeDetailsViewModel.cs
+++ b/src/Bluewater.App/ViewModels/Modals/EmployeeDetailsViewModel.cs
@@ -3,7 +3,6 @@ using Bluewater.App.Enums;
 using Bluewater.App.Interfaces;
 using Bluewater.App.Models;
 using Bluewater.App.ViewModels.Base;
-using CommunityToolkit.Maui.Alerts;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -162,10 +161,10 @@ public partial class EmployeeDetailsViewModel : BaseViewModel, IQueryAttributabl
 						UpdateEmployeeRequestDto request = EditableEmployee.ToUpdateRequest(summary);
 						var updated = await _employeeApiService.UpdateEmployeeAsync(request, summary);
 						if (updated != null) {
-								await Snackbar.Make(
-										"Employee has been successfully updated.",
-										duration: TimeSpan.FromSeconds(3)
-								).Show();
+                                await Shell.Current.DisplayAlert(
+                                        "Employee Updated",
+                                        "Employee has been successfully updated.",
+                                        "OK");
 								await TraceCommandAsync(nameof(SaveEmployeeAsync), new { Action = "Updated", EmployeeId = updated.Id }).ConfigureAwait(false);
 								await NavigateAsync("..",
 										new Dictionary<string, object>
@@ -342,17 +341,17 @@ public partial class EmployeeDetailsViewModel : BaseViewModel, IQueryAttributabl
 				var created = await _employeeApiService.CreateEmployeeAsync(request);
 				if (!created)
 				{
-						await Snackbar.Make(
-								"Employee create failed. Please check required fields and try again.",
-								duration: TimeSpan.FromSeconds(3)
-						).Show();
+                        await Shell.Current.DisplayAlert(
+                                "Employee Create Failed",
+                                "Employee create failed. Please check required fields and try again.",
+                                "OK");
 						return;
 				}
 
-				await Snackbar.Make(
-						"Employee has been successfully created.",
-						duration: TimeSpan.FromSeconds(3)
-				).Show();
+                await Shell.Current.DisplayAlert(
+                        "Employee Created",
+                        "Employee has been successfully created.",
+                        "OK");
 				await TraceCommandAsync(nameof(SaveEmployeeAsync), new { Action = "Created" }).ConfigureAwait(false);
 				await NavigateAsync("..",
 						new Dictionary<string, object>

--- a/src/Bluewater.App/ViewModels/Modals/TimesheetDetailsViewModel.cs
+++ b/src/Bluewater.App/ViewModels/Modals/TimesheetDetailsViewModel.cs
@@ -4,7 +4,6 @@ using Bluewater.App.Enums;
 using Bluewater.App.Interfaces;
 using Bluewater.App.Models;
 using Bluewater.App.ViewModels.Base;
-using CommunityToolkit.Maui.Alerts;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -237,11 +236,11 @@ public partial class TimesheetDetailsViewModel : BaseViewModel, IQueryAttributab
 
 				if (anyUpdated)
 				{
-						await MainThread.InvokeOnMainThreadAsync(() =>
-								Snackbar.Make(
-										"Timesheet has been successfully updated.",
-										duration: TimeSpan.FromSeconds(3)
-								).Show());
+            await MainThread.InvokeOnMainThreadAsync(() =>
+                Shell.Current.DisplayAlert(
+                    "Timesheet Updated",
+                    "Timesheet has been successfully updated.",
+                    "OK"));
 						await NavigateAsync("..",
 								new Dictionary<string, object>
 								{

--- a/src/Bluewater.App/ViewModels/PayrollViewModel.cs
+++ b/src/Bluewater.App/ViewModels/PayrollViewModel.cs
@@ -7,7 +7,6 @@ using Bluewater.App.Interfaces;
 using Bluewater.App.Models;
 using Bluewater.App.ViewModels.Base;
 using Bluewater.App.Views.Modals;
-using CommunityToolkit.Maui.Alerts;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -236,11 +235,11 @@ public partial class PayrollViewModel : BaseViewModel
 						EditablePayroll = CreateNewPayroll();
 						await LoadPayrollsAsync().ConfigureAwait(false);
 
-						await MainThread.InvokeOnMainThreadAsync(() =>
-								Snackbar.Make(
-										$"Saved {savedCount} payroll record(s) for {PeriodRangeDisplay}. Skipped {pendingPayrolls.Count - savedCount} record(s).",
-										duration: TimeSpan.FromSeconds(3))
-									.Show());
+            await MainThread.InvokeOnMainThreadAsync(() =>
+                Shell.Current.DisplayAlert(
+                    "Payroll Saved",
+                    $"Saved {savedCount} payroll record(s) for {PeriodRangeDisplay}. Skipped {pendingPayrolls.Count - savedCount} record(s).",
+                    "OK"));
 
 						await TraceCommandAsync(nameof(SavePayrollAsync), new
 						{
@@ -294,8 +293,8 @@ public partial class PayrollViewModel : BaseViewModel
 										EditablePayroll = refreshedPayroll;
 								}
 
-								await MainThread.InvokeOnMainThreadAsync(() =>
-										Snackbar.Make($"Submitted payroll entry for {refreshedPayroll.Name}.", duration: TimeSpan.FromSeconds(3)).Show());
+                await MainThread.InvokeOnMainThreadAsync(() =>
+                    Shell.Current.DisplayAlert("Payroll Submitted", $"Submitted payroll entry for {refreshedPayroll.Name}.", "OK"));
 						}
 
 						await TraceCommandAsync(nameof(SubmitPayrollAsync), new

--- a/src/Bluewater.App/ViewModels/TimesheetsViewModel.cs
+++ b/src/Bluewater.App/ViewModels/TimesheetsViewModel.cs
@@ -8,7 +8,6 @@ using Bluewater.App.ViewModels.Base;
 using Bluewater.App.Views;
 using Bluewater.App.Views.Modals;
 using Bluewater.Core.EmployeeAggregate;
-using CommunityToolkit.Maui.Alerts;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -516,10 +515,10 @@ public partial class TimesheetsViewModel : BaseViewModel
 								}
 						}
 
-						await Snackbar.Make(
-								"Timesheet and attendance have been successfully updated.",
-								duration: TimeSpan.FromSeconds(3)
-						).Show();
+            await Shell.Current.DisplayAlert(
+                "Timesheets Updated",
+                "Timesheet and attendance have been successfully updated.",
+                "OK");
 
 						await TraceCommandAsync(nameof(SubmitAsync), new
 						{


### PR DESCRIPTION
### Motivation
- Toast/Snackbar notifications provided by the CommunityToolkit are not working reliably in `Bluewater.App`, so user-facing notifications need a stable replacement. 
- Use the built-in MAUI dialog API to ensure feedback is shown without changing business logic or flows.

### Description
- Replaced `Snackbar.Make(...).Show()` calls with `Shell.Current.DisplayAlert(...)` in payroll, timesheet, and employee view models to show user notifications. 
- Removed now-unused `using CommunityToolkit.Maui.Alerts;` imports from the modified view models. 
- Preserved threading behaviour by keeping `MainThread.InvokeOnMainThreadAsync`/`MainThread.BeginInvokeOnMainThread` where notifications were previously invoked. 
- Changes applied to `PayrollViewModel`, `TimesheetsViewModel`, `Modals/TimesheetDetailsViewModel`, and `Modals/EmployeeDetailsViewModel`.

### Testing
- Ran a repository scan with `rg -n "Snackbar\.Make|CommunityToolkit\.Maui\.Alerts" src/Bluewater.App/ViewModels` to verify removed Snackbars and imports, which returned no remaining Snackbar usages in the view models (success). 
- Attempted to run `dotnet build src/Bluewater.App/Bluewater.App.csproj -v minimal`, but the environment lacks the `dotnet` CLI (`dotnet: command not found`), so a full compile validation could not be completed (warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4fcd6c11083298a4e44215e42bd7c)