### PR TITLE
Persist "Remember sign in details" on LoginPage

### DIFF
--- a/src/Bluewater.App/Views/LoginPage.xaml
+++ b/src/Bluewater.App/Views/LoginPage.xaml
@@ -33,10 +33,14 @@
             VerticalOptions="Center">
             <Image Source="bluewater.png" HeightRequest="400" Aspect="AspectFit"/>
             <Entry Placeholder="Username"
+                   x:Name="UsernameEntry"
                    Text="{Binding Username}"
+                   TextChanged="OnCredentialTextChanged"
                    ReturnType="Next"/>
             <Entry Placeholder="Password"
+                   x:Name="PasswordEntry"
                    Text="{Binding Password}"
+                   TextChanged="OnCredentialTextChanged"
                    IsPassword="True"
                    ReturnType="Go"
                    ReturnCommand="{Binding LoginCommand}"/>
@@ -45,7 +49,10 @@
             <!--<Label Text="Forgot password?" VerticalTextAlignment="Center"/>-->
             <Grid ColumnDefinitions="*,40" HorizontalOptions="Fill">
                 <Label Grid.Column="0" Text="Remember sign in details" VerticalTextAlignment="Center" HorizontalOptions="Fill" HorizontalTextAlignment="Start"/>
-                <Switch Grid.Column="1" HorizontalOptions="End"/>
+                <Switch Grid.Column="1"
+                        x:Name="RememberSignInSwitch"
+                        HorizontalOptions="End"
+                        Toggled="OnRememberSignInToggled"/>
             </Grid>
             <!--<Label VerticalTextAlignment="Center" HorizontalTextAlignment="Center">
                 <Label.FormattedText>

--- a/src/Bluewater.App/Views/LoginPage.xaml.cs
+++ b/src/Bluewater.App/Views/LoginPage.xaml.cs
@@ -1,13 +1,19 @@
 using Bluewater.App.ViewModels;
+using Microsoft.Maui.Storage;
 
 namespace Bluewater.App.Views;
 
 public partial class LoginPage : ContentPage
 {
+  private const string RememberSignInKey = "Login.RememberSignIn";
+  private const string RememberedUsernameKey = "Login.RememberedUsername";
+  private const string RememberedPasswordKey = "Login.RememberedPassword";
+
   public LoginPage(LoginViewModel vm)
   {
     InitializeComponent();
     BindingContext = vm;
+    InitializeRememberedCredentials();
   }
 
   protected override async void OnAppearing()
@@ -18,5 +24,50 @@ public partial class LoginPage : ContentPage
     {
       await viewModel.InitializeAsync();
     }
+  }
+
+  private void InitializeRememberedCredentials()
+  {
+    bool shouldRemember = Preferences.Get(RememberSignInKey, false);
+    RememberSignInSwitch.IsToggled = shouldRemember;
+
+    if (!shouldRemember || BindingContext is not LoginViewModel viewModel)
+    {
+      return;
+    }
+
+    viewModel.Username = Preferences.Get(RememberedUsernameKey, string.Empty);
+    viewModel.Password = Preferences.Get(RememberedPasswordKey, string.Empty);
+  }
+
+  private void OnRememberSignInToggled(object? sender, ToggledEventArgs e)
+  {
+    Preferences.Set(RememberSignInKey, e.Value);
+
+    if (BindingContext is not LoginViewModel viewModel)
+    {
+      return;
+    }
+
+    if (!e.Value)
+    {
+      Preferences.Remove(RememberedUsernameKey);
+      Preferences.Remove(RememberedPasswordKey);
+      return;
+    }
+
+    Preferences.Set(RememberedUsernameKey, viewModel.Username);
+    Preferences.Set(RememberedPasswordKey, viewModel.Password);
+  }
+
+  private void OnCredentialTextChanged(object? sender, TextChangedEventArgs e)
+  {
+    if (!RememberSignInSwitch.IsToggled || BindingContext is not LoginViewModel viewModel)
+    {
+      return;
+    }
+
+    Preferences.Set(RememberedUsernameKey, viewModel.Username);
+    Preferences.Set(RememberedPasswordKey, viewModel.Password);
   }
 }


### PR DESCRIPTION
### Motivation
- Enable the "Remember sign in details" Switch to actually persist and restore the username/password when toggled, so users can opt in to remembering credentials across app runs.

### Description
- Wire up the XAML entries and switch by adding `x:Name` to the username/password `Entry` elements and `TextChanged="OnCredentialTextChanged"`, and give the `Switch` `x:Name="RememberSignInSwitch"` with `Toggled="OnRememberSignInToggled"` in `LoginPage.xaml`.
- Add `using Microsoft.Maui.Storage;` and three preference keys plus methods in `LoginPage.xaml.cs` to initialize remembered credentials (`InitializeRememberedCredentials`), persist/clear credentials on toggle (`OnRememberSignInToggled`), and update stored values as the user types when remembering is enabled (`OnCredentialTextChanged`).
- Populate the `LoginViewModel`'s `Username` and `Password` from `Preferences` when the page is created, and remove remembered values when the switch is turned off.

### Testing
- Attempted `dotnet build src/Bluewater.App/Bluewater.App.csproj -nologo`, but the build could not be run in this environment because `dotnet` is not installed, so compilation was not verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4feb671f483298577d272628a56b5)