### PR TITLE
Recover and persist remembered login credentials on startup

### DIFF
--- a/src/Bluewater.App/ViewModels/LoginViewModel.cs
+++ b/src/Bluewater.App/ViewModels/LoginViewModel.cs
@@ -6,12 +6,17 @@ using Bluewater.App.ViewModels.Base;
 using Bluewater.App.Views;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Maui.Storage;
 
 namespace Bluewater.App.ViewModels;
 
 [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "CommunityToolkit.Mvvm RelayCommand attributes are platform-agnostic in .NET MAUI view models.")]
 public partial class LoginViewModel : BaseViewModel
 {
+		private const string RememberSignInKey = "Login.RememberSignIn";
+		private const string RememberedUsernameKey = "Login.RememberedUsername";
+		private const string RememberedPasswordKey = "Login.RememberedPassword";
+
 		private readonly IReferenceDataService referenceDataService;
 		private readonly IUserApiService userApiService;
 		private readonly IApiBaseAddressRecoveryService apiBaseAddressRecoveryService;
@@ -38,8 +43,12 @@ public partial class LoginViewModel : BaseViewModel
 		[ObservableProperty]
 		public partial string Password { get; set; } = string.Empty;
 
+		[ObservableProperty]
+		public partial bool RememberSignIn { get; set; }
+
 		public override Task InitializeAsync()
 		{
+				RecoverRememberedCredentials();
 				ShowRefreshButton = referenceDataService.HasInitializationFailed;
 				if (!ShowRefreshButton)
 				{
@@ -162,5 +171,52 @@ public partial class LoginViewModel : BaseViewModel
 					.ConfigureAwait(false);
 
 				ShowRefreshButton = !hasRecovered;
+		}
+
+		partial void OnRememberSignInChanged(bool value)
+		{
+				Preferences.Set(RememberSignInKey, value);
+				if (!value)
+				{
+						Preferences.Remove(RememberedUsernameKey);
+						Preferences.Remove(RememberedPasswordKey);
+						return;
+				}
+
+				StoreCredentials();
+		}
+
+		partial void OnUsernameChanged(string value)
+		{
+				if (RememberSignIn)
+				{
+						StoreCredentials();
+				}
+		}
+
+		partial void OnPasswordChanged(string value)
+		{
+				if (RememberSignIn)
+				{
+						StoreCredentials();
+				}
+		}
+
+		private void RecoverRememberedCredentials()
+		{
+				RememberSignIn = Preferences.Get(RememberSignInKey, false);
+				if (!RememberSignIn)
+				{
+						return;
+				}
+
+				Username = Preferences.Get(RememberedUsernameKey, string.Empty);
+				Password = Preferences.Get(RememberedPasswordKey, string.Empty);
+		}
+
+		private void StoreCredentials()
+		{
+				Preferences.Set(RememberedUsernameKey, Username);
+				Preferences.Set(RememberedPasswordKey, Password);
 		}
 }

--- a/src/Bluewater.App/Views/LoginPage.xaml
+++ b/src/Bluewater.App/Views/LoginPage.xaml
@@ -35,12 +35,10 @@
             <Entry Placeholder="Username"
                    x:Name="UsernameEntry"
                    Text="{Binding Username}"
-                   TextChanged="OnCredentialTextChanged"
                    ReturnType="Next"/>
             <Entry Placeholder="Password"
                    x:Name="PasswordEntry"
                    Text="{Binding Password}"
-                   TextChanged="OnCredentialTextChanged"
                    IsPassword="True"
                    ReturnType="Go"
                    ReturnCommand="{Binding LoginCommand}"/>
@@ -52,7 +50,7 @@
                 <Switch Grid.Column="1"
                         x:Name="RememberSignInSwitch"
                         HorizontalOptions="End"
-                        Toggled="OnRememberSignInToggled"/>
+                        IsToggled="{Binding RememberSignIn}"/>
             </Grid>
             <!--<Label VerticalTextAlignment="Center" HorizontalTextAlignment="Center">
                 <Label.FormattedText>

--- a/src/Bluewater.App/Views/LoginPage.xaml.cs
+++ b/src/Bluewater.App/Views/LoginPage.xaml.cs
@@ -1,19 +1,13 @@
 using Bluewater.App.ViewModels;
-using Microsoft.Maui.Storage;
 
 namespace Bluewater.App.Views;
 
 public partial class LoginPage : ContentPage
 {
-  private const string RememberSignInKey = "Login.RememberSignIn";
-  private const string RememberedUsernameKey = "Login.RememberedUsername";
-  private const string RememberedPasswordKey = "Login.RememberedPassword";
-
   public LoginPage(LoginViewModel vm)
   {
     InitializeComponent();
     BindingContext = vm;
-    InitializeRememberedCredentials();
   }
 
   protected override async void OnAppearing()
@@ -24,50 +18,5 @@ public partial class LoginPage : ContentPage
     {
       await viewModel.InitializeAsync();
     }
-  }
-
-  private void InitializeRememberedCredentials()
-  {
-    bool shouldRemember = Preferences.Get(RememberSignInKey, false);
-    RememberSignInSwitch.IsToggled = shouldRemember;
-
-    if (!shouldRemember || BindingContext is not LoginViewModel viewModel)
-    {
-      return;
-    }
-
-    viewModel.Username = Preferences.Get(RememberedUsernameKey, string.Empty);
-    viewModel.Password = Preferences.Get(RememberedPasswordKey, string.Empty);
-  }
-
-  private void OnRememberSignInToggled(object? sender, ToggledEventArgs e)
-  {
-    Preferences.Set(RememberSignInKey, e.Value);
-
-    if (BindingContext is not LoginViewModel viewModel)
-    {
-      return;
-    }
-
-    if (!e.Value)
-    {
-      Preferences.Remove(RememberedUsernameKey);
-      Preferences.Remove(RememberedPasswordKey);
-      return;
-    }
-
-    Preferences.Set(RememberedUsernameKey, viewModel.Username);
-    Preferences.Set(RememberedPasswordKey, viewModel.Password);
-  }
-
-  private void OnCredentialTextChanged(object? sender, TextChangedEventArgs e)
-  {
-    if (!RememberSignInSwitch.IsToggled || BindingContext is not LoginViewModel viewModel)
-    {
-      return;
-    }
-
-    Preferences.Set(RememberedUsernameKey, viewModel.Username);
-    Preferences.Set(RememberedPasswordKey, viewModel.Password);
   }
 }


### PR DESCRIPTION
### Motivation
- Ensure saved username/password are recovered and populated automatically during app startup and when the login view initializes, and centralize preference handling in the view model for cleaner separation of concerns.

### Description
- Move remembered-credential recovery into `LoginViewModel.InitializeAsync()` so saved credentials are restored as part of login initialization.
- Add a bindable `RememberSignIn` property and generated change handlers `OnRememberSignInChanged`, `OnUsernameChanged`, and `OnPasswordChanged` which persist or clear credentials using `Preferences`.
- Update `LoginPage.xaml` to bind the remember switch to `RememberSignIn` and remove the previous code-behind preference and text-change handlers.
- Remove preference-management logic from `LoginPage.xaml.cs` so the page only wires the view model and invokes `InitializeAsync()` on appear.

### Testing
- Attempted to build the app with `dotnet build src/Bluewater.App/Bluewater.App.csproj -v minimal`, but the command failed in this environment because `dotnet` is not installed.
- No automated unit or integration test runs were performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e501519ef48329aea9cca494d2139a)