### PR TITLE
Treat shift "R" as rest day in Attendance.CalculateWorkHours

### DIFF
--- a/src/Bluewater.Core/AttendanceAggregate/Attendance.cs
+++ b/src/Bluewater.Core/AttendanceAggregate/Attendance.cs
@@ -64,6 +64,16 @@ public class Attendance(Guid employeeId, Guid? shiftId, Guid? timesheetId, Guid?
   {
     try
     {
+      if (Shift != null && string.Equals(Shift.Name?.Trim(), "R", StringComparison.OrdinalIgnoreCase))
+      {
+        WorkHrs = 0;
+        LateHrs = 0;
+        UnderHrs = 0;
+        OverbreakHrs = 0;
+        NightShiftHours = 0;
+        return (0, 0, 0, 0, 0);
+      }
+
       if (Timesheet == null || Shift == null || !Timesheet.TimeIn1.HasValue || !Shift.ShiftStartTime.HasValue || !Shift.ShiftEndTime.HasValue)
       {
         return (-1, 0, 0, 0, 0);


### PR DESCRIPTION
### Motivation
- Exclude shifts named `"R"` (rest days) from attendance hour computation so a rest day does not produce work/late/undertime/overbreak/night-shift penalties or trigger missing-time validation.

### Description
- In `Attendance.CalculateWorkHours()` added a case-insensitive trimmed check for `Shift.Name == "R"` that sets `WorkHrs`, `LateHrs`, `UnderHrs`, `OverbreakHrs`, and `NightShiftHours` to `0` and returns `(0, 0, 0, 0, 0)` early.

### Testing
- Attempted to run unit tests with `dotnet test tests/Bluewater.UnitTests/Bluewater.UnitTests.csproj` but could not execute in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6851c0dc083299c6c5c3282f2a2a1)