### PR TITLE
Add delete action for timesheet rows in TimesheetDetails

### DIFF
--- a/src/Bluewater.App/Interfaces/ITimesheetApiService.cs
+++ b/src/Bluewater.App/Interfaces/ITimesheetApiService.cs
@@ -46,4 +46,8 @@ public interface ITimesheetApiService
   Task<AttendanceTimesheetSummary?> UpdateTimesheetAsync(
     UpdateTimesheetRequestDto request,
     CancellationToken cancellationToken = default);
+
+  Task<bool> DeleteTimesheetAsync(
+    Guid timesheetId,
+    CancellationToken cancellationToken = default);
 }

--- a/src/Bluewater.App/Services/TimesheetApiService.cs
+++ b/src/Bluewater.App/Services/TimesheetApiService.cs
@@ -222,6 +222,21 @@ public class TimesheetApiService(IApiClient apiClient) : ITimesheetApiService
     };
   }
 
+
+  public async Task<bool> DeleteTimesheetAsync(
+    Guid timesheetId,
+    CancellationToken cancellationToken = default)
+  {
+    if (timesheetId == Guid.Empty)
+    {
+      throw new ArgumentException("Timesheet ID must be provided", nameof(timesheetId));
+    }
+
+    return await apiClient
+      .DeleteAsync($"Timesheets/{timesheetId}", cancellationToken)
+      .ConfigureAwait(false);
+  }
+
   private static EmployeeTimesheetSummary MapToEmployeeSummary(AllEmployeeTimesheetDto dto)
   {
     var summary = new EmployeeTimesheetSummary

--- a/src/Bluewater.App/ViewModels/Modals/TimesheetDetailsViewModel.cs
+++ b/src/Bluewater.App/ViewModels/Modals/TimesheetDetailsViewModel.cs
@@ -178,6 +178,69 @@ public partial class TimesheetDetailsViewModel : BaseViewModel, IQueryAttributab
 				}
 		}
 
+
+		[RelayCommand]
+		private async Task DeleteTimesheetAsync(EditableTimesheetEntry? timesheet)
+		{
+				if (IsBusy || IsReadOnlyMode || timesheet is null || timesheet.Id == Guid.Empty)
+				{
+						return;
+				}
+
+				bool confirmed = await MainThread.InvokeOnMainThreadAsync(() =>
+						Shell.Current.DisplayAlert(
+								"Delete Timesheet",
+								"Are you sure you want to delete this timesheet?",
+								"Delete",
+								"Cancel"));
+
+				if (!confirmed)
+				{
+						return;
+				}
+
+				try
+				{
+						IsBusy = true;
+						bool deleted = await timesheetApiService.DeleteTimesheetAsync(timesheet.Id).ConfigureAwait(false);
+						if (!deleted)
+						{
+								throw new InvalidOperationException("Failed to delete timesheet.");
+						}
+
+						await MainThread.InvokeOnMainThreadAsync(() =>
+						{
+								EditableTimesheets.Remove(timesheet);
+								timesheet.PropertyChanged -= OnEditableTimesheetPropertyChanged;
+								if (SelectedEditableTimesheet == timesheet)
+								{
+										SelectedEditableTimesheet = EditableTimesheets.FirstOrDefault();
+								}
+								if (SelectedEmployeeTimesheet is not null)
+								{
+										AttendanceTimesheetSummary? existing = SelectedEmployeeTimesheet.Timesheets
+												.FirstOrDefault(t => t.Id == timesheet.Id);
+										if (existing is not null)
+										{
+												SelectedEmployeeTimesheet.Timesheets.Remove(existing);
+										}
+										SelectedEmployeeTimesheet.IsShowAlert = SelectedEmployeeTimesheet.Timesheets.Any(ShouldShowAlertForTimesheet);
+								}
+								UpdateCanSaveTimesheets();
+						});
+
+						await TraceCommandAsync(nameof(DeleteTimesheetAsync), timesheet.Id).ConfigureAwait(false);
+				}
+				catch (Exception ex)
+				{
+						ExceptionHandlingService.Handle(ex, "Deleting timesheet");
+				}
+				finally
+				{
+						IsBusy = false;
+				}
+		}
+
 		[RelayCommand(CanExecute = nameof(CanSaveTimesheets))]
 		private async Task SaveTimesheetsAsync()
 		{

--- a/src/Bluewater.App/Views/TimesheetDetailsPage.xaml
+++ b/src/Bluewater.App/Views/TimesheetDetailsPage.xaml
@@ -120,7 +120,7 @@
 						BackgroundColor="{AppThemeBinding Light={StaticResource AccentColor}, Dark=#1F5AA8}">
 					<Grid ColumnSpacing="12"
 						  Padding="20"
-						  ColumnDefinitions="*,*,*,*,*,*">
+						  ColumnDefinitions="*,*,*,*,*,*,Auto">
 						<Label Text="Date"
 							   TextColor="White"
 							   HorizontalTextAlignment="Center"
@@ -150,6 +150,11 @@
 						   HorizontalTextAlignment="Center"
 						   TextColor="White"
 						   FontAttributes="Bold" />
+											<Label Grid.Column="6"
+							   Text="Action"
+							   HorizontalTextAlignment="Center"
+							   TextColor="White"
+							   FontAttributes="Bold" />
 					</Grid>
 				</Border>
 			</CollectionView.Header>
@@ -160,7 +165,7 @@
 							BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1F1F1F}"
 							Padding="16,12"
 							StrokeShape="RoundRectangle 12">
-						<Grid ColumnDefinitions="*,*,*,*,*,*">
+						<Grid ColumnDefinitions="*,*,*,*,*,*,Auto">
 							<Label Grid.Column="0"
 								   HorizontalTextAlignment="Center"
 								   Text="{Binding EntryDate, StringFormat='{0: MMM dd yyyy (ddd)}'}" />
@@ -179,6 +184,12 @@
 							<Label Grid.Column="5"
 								   HorizontalTextAlignment="Center"
 								   Text="{Binding ShiftName}" />
+								<Button Grid.Column="6"
+										Text="Delete"
+										Command="{Binding BindingContext.DeleteTimesheetCommand, Source={x:Reference timeCollection}}"
+										CommandParameter="{Binding .}"
+										IsEnabled="{Binding Source={RelativeSource AncestorType={x:Type vm:TimesheetDetailsViewModel}}, Path=CanEditTimesheets}"
+										Style="{StaticResource SecondaryButtonStyle}" />
 						</Grid>
 					</Border>
 				</DataTemplate>


### PR DESCRIPTION
### Motivation
- Provide a way to delete a specific timesheet row from the details modal when a timesheet record exists and is not null.
- Keep the UI and ViewModel behavior consistent with existing edit/delete patterns (confirm before delete and update local collections on success).

### Description
- Added `DeleteTimesheetAsync(Guid timesheetId)` to `ITimesheetApiService` to expose a delete API contract to the ViewModel.
- Implemented `DeleteTimesheetAsync` in `TimesheetApiService` to call `DELETE Timesheets/{id}` and validate the provided GUID.
- Added a `DeleteTimesheetAsync(EditableTimesheetEntry? timesheet)` RelayCommand in `TimesheetDetailsViewModel` that shows a confirmation dialog with `Shell.Current.DisplayAlert`, calls the API, removes the entry from `EditableTimesheets` and from `SelectedEmployeeTimesheet.Timesheets`, updates selection and alert state, and traces the action.
- Updated `TimesheetDetailsPage.xaml` to add an `Action` column and a per-row `Delete` button bound to the ViewModel `DeleteTimesheetCommand` via `x:Reference timeCollection`, with enabled state tied to `CanEditTimesheets`.

### Testing
- Attempted to build the app with `dotnet build src/Bluewater.App/Bluewater.App.csproj`, but the build could not run in this environment because the `dotnet` SDK is not installed (`/bin/bash: dotnet: command not found`).
- No automated unit/integration tests were executed in this environment due to the missing SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f7decb9883298cc282556ad02b58)