### PR TITLE
Add row-level shift mismatch warning indicator in timesheet details

### DIFF
--- a/src/Bluewater.App/Models/EditableTimesheetEntry.cs
+++ b/src/Bluewater.App/Models/EditableTimesheetEntry.cs
@@ -50,6 +50,10 @@ public partial class EditableTimesheetEntry : ObservableObject
 		[ObservableProperty]
 		public partial string? ShiftName { get; set; }
 
+
+		[ObservableProperty]
+		public partial bool HasShiftMismatchAlert { get; set; }
+
 		public DateTime EntryDateDateTime
 		{
 				get => (EntryDate ?? DateOnly.FromDateTime(DateTime.Today)).ToDateTime(TimeOnly.MinValue);

--- a/src/Bluewater.App/ViewModels/Modals/TimesheetDetailsViewModel.cs
+++ b/src/Bluewater.App/ViewModels/Modals/TimesheetDetailsViewModel.cs
@@ -66,6 +66,7 @@ public partial class TimesheetDetailsViewModel : BaseViewModel, IQueryAttributab
 						foreach (EditableTimesheetEntry timesheet in timesheetList)
 						{
 								timesheet.PropertyChanged += OnEditableTimesheetPropertyChanged;
+								timesheet.HasShiftMismatchAlert = ShouldShowAlertForEntry(timesheet);
 								EditableTimesheets.Add(timesheet);
 						}
 				}
@@ -151,6 +152,7 @@ public partial class TimesheetDetailsViewModel : BaseViewModel, IQueryAttributab
 						if (updated is not null)
 						{
 								selectedEntry.ApplySummary(updated);
+								selectedEntry.HasShiftMismatchAlert = ShouldShowAlertForTimesheet(updated);
 								UpdateSelectedEmployeeTimesheetEntry(updated);
 						}
 
@@ -278,6 +280,7 @@ public partial class TimesheetDetailsViewModel : BaseViewModel, IQueryAttributab
 								}
 
 								entry.ApplySummary(updated);
+								entry.HasShiftMismatchAlert = ShouldShowAlertForTimesheet(updated);
 								UpdateSelectedEmployeeTimesheetEntry(updated);
 								anyUpdated = true;
 						}
@@ -333,6 +336,7 @@ public partial class TimesheetDetailsViewModel : BaseViewModel, IQueryAttributab
 
 				SelectedEditableTimesheet.ShiftId = value?.Id;
 				SelectedEditableTimesheet.ShiftName = value?.Name;
+				SelectedEditableTimesheet.HasShiftMismatchAlert = ShouldShowAlertForEntry(SelectedEditableTimesheet);
 		}
 
 		private void SyncSelectedShift()
@@ -355,6 +359,11 @@ public partial class TimesheetDetailsViewModel : BaseViewModel, IQueryAttributab
 
 		private void OnEditableTimesheetPropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
+				if (sender is EditableTimesheetEntry entry && e.PropertyName is nameof(EditableTimesheetEntry.TimeIn1) or nameof(EditableTimesheetEntry.TimeOut1) or nameof(EditableTimesheetEntry.TimeIn2) or nameof(EditableTimesheetEntry.TimeOut2))
+				{
+						entry.HasShiftMismatchAlert = ShouldShowAlertForEntry(entry);
+				}
+
 				if (e.PropertyName == nameof(EditableTimesheetEntry.HasChanges))
 				{
 						UpdateCanSaveTimesheets();
@@ -403,6 +412,34 @@ public partial class TimesheetDetailsViewModel : BaseViewModel, IQueryAttributab
 				existing.ShiftId = updatedTimesheet.ShiftId;
 				existing.ShiftName = updatedTimesheet.ShiftName;
 				SelectedEmployeeTimesheet.IsShowAlert = SelectedEmployeeTimesheet.Timesheets.Any(ShouldShowAlertForTimesheet);
+		}
+
+
+		private static bool ShouldShowAlertForEntry(EditableTimesheetEntry entry)
+		{
+				int mask = 0;
+
+				if (entry.TimeOut2.HasValue)
+				{
+						mask |= 1 << 3;
+				}
+
+				if (entry.TimeIn2.HasValue)
+				{
+						mask |= 1 << 2;
+				}
+
+				if (entry.TimeOut1.HasValue)
+				{
+						mask |= 1 << 1;
+				}
+
+				if (entry.TimeIn1.HasValue)
+				{
+						mask |= 1;
+				}
+
+				return mask is not (0 or 3 or 9 or 12 or 15);
 		}
 
 		private static bool ShouldShowAlertForTimesheet(AttendanceTimesheetSummary timesheet)

--- a/src/Bluewater.App/Views/TimesheetDetailsPage.xaml
+++ b/src/Bluewater.App/Views/TimesheetDetailsPage.xaml
@@ -185,6 +185,15 @@
 							<Label Grid.Column="5"
 								   HorizontalTextAlignment="Center"
 								   Text="{Binding ShiftName}" />
+                            <Label Grid.Column="6"
+                                   Text="{x:Static helpers:Icon.AlertTriangle}"
+                                   TextColor="#FBBF24"
+                                   FontSize="Small"
+                                   IsVisible="{Binding HasShiftMismatchAlert}"
+                                   HorizontalOptions="Fill"
+                                   HorizontalTextAlignment="Center"
+                                   VerticalOptions="Fill"
+                                   FontFamily="Icons" />
                             <Label Grid.Column="7"
                                    Text="{x:Static helpers:Icon.Trash}"
                                    FontSize="Small"


### PR DESCRIPTION
### Motivation
- Provide a per-row visual indicator in the timesheet details UI for entries that do not match expected shift/punch patterns (late/absent/undertime/overbreak cases). 

### Description
- Added a new observable flag `HasShiftMismatchAlert` to `EditableTimesheetEntry` so each row can control its own warning icon. (`src/Bluewater.App/Models/EditableTimesheetEntry.cs`)
- Updated `TimesheetDetailsViewModel` to compute and keep `HasShiftMismatchAlert` in sync during initial load, on punch time edits, when the selected shift changes, and after save/clear operations, and added a helper `ShouldShowAlertForEntry` that reuses the existing punch-pattern mask logic. (`src/Bluewater.App/ViewModels/Modals/TimesheetDetailsViewModel.cs`)
- Updated the item template in `TimesheetDetailsPage.xaml` to render a yellow `AlertTriangle` icon in column 6 bound to `HasShiftMismatchAlert`, while preserving the delete action in the final column. (`src/Bluewater.App/Views/TimesheetDetailsPage.xaml`)

### Testing
- Attempted an automated build with `dotnet build src/Bluewater.App/Bluewater.App.csproj`, but the `dotnet` CLI is not installed in this environment so the build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5ba2a27448329bff1ec57d8f30961)