### PR TITLE
Exclude holidays when counting absences

### DIFF
--- a/src/Bluewater.UseCases/Attendances/AttendanceSummaryCalculator.cs
+++ b/src/Bluewater.UseCases/Attendances/AttendanceSummaryCalculator.cs
@@ -12,11 +12,18 @@ public static class AttendanceSummaryCalculator
   public static int CountApprovedLeaves(IEnumerable<AttendanceDTO> attendances) =>
     attendances.Count(HasApprovedLeave);
 
-  public static int CountAbsencesExcludingApprovedLeaves(IEnumerable<AttendanceDTO> attendances) =>
-    attendances.Count(attendance =>
+  public static int CountAbsencesExcludingApprovedLeaves(
+    IEnumerable<AttendanceDTO> attendances,
+    IEnumerable<DateOnly>? holidayDates = null)
+  {
+    HashSet<DateOnly> holidayDateSet = holidayDates?.ToHashSet() ?? [];
+
+    return attendances.Count(attendance =>
       attendance.ShiftId != null
       && attendance.Shift != null
       && !attendance.Shift.Name.Equals("R", StringComparison.InvariantCultureIgnoreCase)
       && !HasApprovedLeave(attendance)
+      && (!attendance.EntryDate.HasValue || !holidayDateSet.Contains(attendance.EntryDate.Value))
       && (attendance.WorkHrs ?? 0) <= 0);
+  }
 }

--- a/tests/Bluewater.UnitTests/UseCases/Attendances/AttendanceSummaryCalculatorTests.cs
+++ b/tests/Bluewater.UnitTests/UseCases/Attendances/AttendanceSummaryCalculatorTests.cs
@@ -39,4 +39,23 @@ public class AttendanceSummaryCalculatorTests
 
     totalAbsences.Should().Be(1);
   }
+
+
+  [Fact]
+  public void CountAbsencesExcludingApprovedLeaves_DoesNotTreatHolidayAsAbsence()
+  {
+    ShiftDTO shift = new(Guid.NewGuid(), "D", new TimeOnly(8, 0), new TimeOnly(12, 0), new TimeOnly(13, 0), new TimeOnly(17, 0), 1);
+    DateOnly holidayDate = DateOnly.FromDateTime(DateTime.Today);
+
+    List<AttendanceDTO> attendances =
+    [
+      new AttendanceDTO(Guid.NewGuid(), Guid.NewGuid(), shift.Id, null, null, holidayDate, 0, 0, 0, 0, 0, shift: shift),
+      new AttendanceDTO(Guid.NewGuid(), Guid.NewGuid(), shift.Id, null, null, holidayDate.AddDays(1), 0, 0, 0, 0, 0, shift: shift)
+    ];
+
+    int totalAbsences = AttendanceSummaryCalculator.CountAbsencesExcludingApprovedLeaves(attendances, [holidayDate]);
+
+    totalAbsences.Should().Be(1);
+  }
+
 }


### PR DESCRIPTION
### Motivation
- Ensure attendance days that fall on defined holidays are not treated as absences when summarizing employee attendance.

### Description
- Changed `AttendanceSummaryCalculator.CountAbsencesExcludingApprovedLeaves` to accept an optional `IEnumerable<DateOnly>? holidayDates` and added logic to skip attendances whose `EntryDate` is in the provided holiday set, and added the unit test `CountAbsencesExcludingApprovedLeaves_DoesNotTreatHolidayAsAbsence` to validate the behavior.

### Testing
- Added a unit test but running `dotnet test --filter AttendanceSummaryCalculatorTests` in this environment failed because `dotnet` is not installed so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6025f664c83298cfa7264b00ab5fb)