### PR TITLE
Replace deleted timesheet with blank EditableTimesheetEntry

### DIFF
--- a/src/Bluewater.App/ViewModels/Modals/TimesheetDetailsViewModel.cs
+++ b/src/Bluewater.App/ViewModels/Modals/TimesheetDetailsViewModel.cs
@@ -214,9 +214,14 @@ public partial class TimesheetDetailsViewModel : BaseViewModel, IQueryAttributab
 						{
 								EditableTimesheets.Remove(timesheet);
 								timesheet.PropertyChanged -= OnEditableTimesheetPropertyChanged;
+
+								EditableTimesheetEntry blankEntry = CreateBlankEditableTimesheetEntry(timesheet);
+								blankEntry.PropertyChanged += OnEditableTimesheetPropertyChanged;
+								EditableTimesheets.Add(blankEntry);
+
 								if (SelectedEditableTimesheet == timesheet)
 								{
-										SelectedEditableTimesheet = EditableTimesheets.FirstOrDefault();
+										SelectedEditableTimesheet = blankEntry;
 								}
 								if (SelectedEmployeeTimesheet is not null)
 								{
@@ -350,6 +355,29 @@ public partial class TimesheetDetailsViewModel : BaseViewModel, IQueryAttributab
 				SelectedShift = ShiftOptions.FirstOrDefault(s => s.Id == shiftId);
 		}
 
+
+		private static EditableTimesheetEntry CreateBlankEditableTimesheetEntry(EditableTimesheetEntry template)
+		{
+				EditableTimesheetEntry blankEntry = new()
+				{
+						Id = Guid.Empty,
+						EmployeeId = template.EmployeeId,
+						EntryDate = template.EntryDate,
+						TimeIn1 = null,
+						TimeOut1 = null,
+						TimeIn2 = null,
+						TimeOut2 = null,
+						IsEdited = false,
+						IsLocked = false,
+						ScheduleId = null,
+						ShiftId = null,
+						ShiftName = null,
+						HasShiftMismatchAlert = false
+				};
+
+				blankEntry.ResetChangeTracking();
+				return blankEntry;
+		}
 		private void UpdateCanSaveTimesheets()
 		{
 				OnPropertyChanged(nameof(CanSaveTimesheets));


### PR DESCRIPTION
### Motivation
- Ensure that when a timesheet is deleted (and the DB is updated), the UI stays editable by inserting a new blank `EditableTimesheetEntry` in the collection so users can continue editing without an empty slot gap.

### Description
- Modified `DeleteTimesheetAsync` in `TimesheetDetailsViewModel` to create and add a blank `EditableTimesheetEntry` after a successful delete, unsubscribe the deleted entry from property-change notifications, and subscribe the new blank entry. 
- Added a helper `CreateBlankEditableTimesheetEntry(EditableTimesheetEntry template)` that preserves `EmployeeId` and `EntryDate`, sets `Id = Guid.Empty`, clears time/shift/schedule fields, and calls `ResetChangeTracking()`.
- When the deleted entry was the selected row, selection is now moved to the newly created blank entry and `UpdateCanSaveTimesheets()` is invoked to refresh command state.

### Testing
- Attempted to run `dotnet build src/Bluewater.App/Bluewater.App.csproj`, but the build could not be executed in this environment because `dotnet` is not installed (no automated builds/tests ran successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f611396e208329b682e433341c4d66)