### PR TITLE
Add service charge API client and CSV upload support in PayrollViewModel

### DIFF
--- a/src/Bluewater.App/Interfaces/IServiceChargeApiService.cs
+++ b/src/Bluewater.App/Interfaces/IServiceChargeApiService.cs
@@ -1,0 +1,10 @@
+using Bluewater.App.Models;
+
+namespace Bluewater.App.Interfaces;
+
+public interface IServiceChargeApiService
+{
+  Task<IReadOnlyList<ServiceChargeSummary>> GetServiceChargesByDateAsync(DateOnly date, CancellationToken cancellationToken = default);
+
+  Task<Guid?> CreateServiceChargeAsync(ServiceChargeSummary serviceCharge, CancellationToken cancellationToken = default);
+}

--- a/src/Bluewater.App/MauiProgram.cs
+++ b/src/Bluewater.App/MauiProgram.cs
@@ -104,6 +104,7 @@ public static class MauiProgram
 				builder.Services.AddSingleton<IAttendanceApiService, AttendanceApiService>();
 				builder.Services.AddSingleton<ITimesheetApiService, TimesheetApiService>();
 				builder.Services.AddSingleton<IPayrollApiService, PayrollApiService>();
+				builder.Services.AddSingleton<IServiceChargeApiService, ServiceChargeApiService>();
 				builder.Services.AddSingleton<IPayApiService, PayApiService>();
 				builder.Services.AddSingleton<IUserApiService, UserApiService>();
 				builder.Services.AddSingleton<IScheduleApiService, ScheduleApiService>();

--- a/src/Bluewater.App/Models/ServiceChargeDtos.cs
+++ b/src/Bluewater.App/Models/ServiceChargeDtos.cs
@@ -1,0 +1,36 @@
+namespace Bluewater.App.Models;
+
+public sealed class ServiceChargeSummary
+{
+  public Guid Id { get; set; }
+  public string Username { get; set; } = string.Empty;
+  public decimal Amount { get; set; }
+  public DateOnly Date { get; set; }
+}
+
+public sealed class ServiceChargeRecordDto
+{
+  public Guid Id { get; set; }
+  public string Username { get; set; } = string.Empty;
+  public decimal Amount { get; set; }
+  public DateOnly Date { get; set; }
+}
+
+public sealed class ServiceChargeListResponseDto
+{
+  public List<ServiceChargeRecordDto> ServiceCharges { get; set; } = [];
+}
+
+public sealed class CreateServiceChargeRequestDto
+{
+  public const string Route = "ServiceCharges";
+
+  public string Username { get; set; } = string.Empty;
+  public decimal Amount { get; set; }
+  public DateOnly Date { get; set; }
+}
+
+public sealed class CreateServiceChargeResponseDto
+{
+  public ServiceChargeRecordDto? ServiceCharge { get; set; }
+}

--- a/src/Bluewater.App/Services/ServiceChargeApiService.cs
+++ b/src/Bluewater.App/Services/ServiceChargeApiService.cs
@@ -1,0 +1,35 @@
+using System.Globalization;
+using Bluewater.App.Interfaces;
+using Bluewater.App.Models;
+
+namespace Bluewater.App.Services;
+
+public class ServiceChargeApiService(IApiClient apiClient) : IServiceChargeApiService
+{
+  public async Task<IReadOnlyList<ServiceChargeSummary>> GetServiceChargesByDateAsync(DateOnly date, CancellationToken cancellationToken = default)
+  {
+    string requestUri = $"ServiceCharges?date={date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
+    ServiceChargeListResponseDto? response = await apiClient.GetAsync<ServiceChargeListResponseDto>(requestUri, cancellationToken);
+
+    return response?.ServiceCharges?.Select(sc => new ServiceChargeSummary
+    {
+      Id = sc.Id,
+      Username = sc.Username,
+      Amount = sc.Amount,
+      Date = sc.Date
+    }).ToList() ?? [];
+  }
+
+  public async Task<Guid?> CreateServiceChargeAsync(ServiceChargeSummary serviceCharge, CancellationToken cancellationToken = default)
+  {
+    CreateServiceChargeRequestDto request = new()
+    {
+      Username = serviceCharge.Username,
+      Amount = serviceCharge.Amount,
+      Date = serviceCharge.Date
+    };
+
+    CreateServiceChargeResponseDto? response = await apiClient.PostAsync<CreateServiceChargeRequestDto, CreateServiceChargeResponseDto>(CreateServiceChargeRequestDto.Route, request, cancellationToken);
+    return response?.ServiceCharge?.Id;
+  }
+}

--- a/src/Bluewater.App/ViewModels/PayrollViewModel.cs
+++ b/src/Bluewater.App/ViewModels/PayrollViewModel.cs
@@ -18,6 +18,8 @@ public partial class PayrollViewModel : BaseViewModel
 		private const int DownloadBatchSize = 200;
 		private readonly IPayrollApiService payrollApiService;
 		private readonly IReferenceDataService referenceDataService;
+		private readonly IServiceChargeApiService serviceChargeApiService;
+		private bool hasServiceChargeInPeriod;
 		private bool hasInitialized;
 		private bool isInitializing;
 		private bool hasPendingPayrollsInPeriod;
@@ -26,12 +28,14 @@ public partial class PayrollViewModel : BaseViewModel
 		public PayrollViewModel(
 			IPayrollApiService payrollApiService,
 			IReferenceDataService referenceDataService,
+			IServiceChargeApiService serviceChargeApiService,
 			IActivityTraceService activityTraceService,
 			IExceptionHandlingService exceptionHandlingService)
 			: base(activityTraceService, exceptionHandlingService)
 		{
 				this.payrollApiService = payrollApiService;
 				this.referenceDataService = referenceDataService;
+				this.serviceChargeApiService = serviceChargeApiService;
 				SetCurrentPayslipPeriod();
 				EditablePayroll = CreateNewPayroll();
 		}
@@ -53,6 +57,8 @@ public partial class PayrollViewModel : BaseViewModel
 		public bool CanSavePayrollPeriod => !IsBusy && hasPendingPayrollsInPeriod;
 
 		public bool CanDownloadPayrollPeriod => !IsBusy && payrollCountInPeriod > 0 && !hasPendingPayrollsInPeriod;
+
+		public bool CanUploadServiceCharge => !IsBusy && !hasServiceChargeInPeriod;
 
 		[ObservableProperty]
 		public partial DateOnly StartDate { get; set; }
@@ -383,7 +389,70 @@ public partial class PayrollViewModel : BaseViewModel
 				}
 		}
 
-		[RelayCommand]
+		
+		[RelayCommand(CanExecute = nameof(CanUploadServiceCharge))]
+		private async Task UploadServiceChargeAsync()
+		{
+			try
+			{
+				PickOptions options = new()
+				{
+					PickerTitle = "Select Service Charge CSV",
+					FileTypes = new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
+					{
+						[DevicePlatform.WinUI] = [".csv"],
+						[DevicePlatform.Android] = ["text/csv", "text/comma-separated-values"],
+						[DevicePlatform.iOS] = ["public.comma-separated-values-text"]
+					})
+				};
+
+				FileResult? file = await FilePicker.Default.PickAsync(options).ConfigureAwait(false);
+				if (file is null)
+				{
+					return;
+				}
+
+				List<ServiceChargeSummary> parsedRows = await ParseServiceChargeCsvAsync(file).ConfigureAwait(false);
+				if (parsedRows.Count == 0)
+				{
+					await MainThread.InvokeOnMainThreadAsync(() =>
+						Shell.Current.DisplayAlert("Upload SC", "No valid service charge rows were found.", "OK"));
+					return;
+				}
+
+				bool confirmed = await MainThread.InvokeOnMainThreadAsync(() =>
+					Shell.Current.DisplayAlert("Upload SC", $"Upload {parsedRows.Count} service charge entr{(parsedRows.Count == 1 ? "y" : "ies")} for {PeriodRangeDisplay}?", "Yes", "No"));
+
+				if (!confirmed)
+				{
+					return;
+				}
+
+				IsBusy = true;
+				int uploadedCount = 0;
+				foreach (ServiceChargeSummary row in parsedRows)
+				{
+					Guid? created = await serviceChargeApiService.CreateServiceChargeAsync(row).ConfigureAwait(false);
+					if (created.HasValue) uploadedCount++;
+				}
+
+				await MainThread.InvokeOnMainThreadAsync(() =>
+					Shell.Current.DisplayAlert("Upload SC", $"Successfully uploaded {uploadedCount} service charge entr{(uploadedCount == 1 ? "y" : "ies")}.", "OK"));
+
+				await RefreshAsync().ConfigureAwait(false);
+			}
+			catch (Exception ex)
+			{
+				ExceptionHandlingService.Handle(ex, "Uploading service charge");
+			}
+			finally
+			{
+				IsBusy = false;
+				UpdatePayrollCommandStates();
+			}
+		}
+
+[RelayCommand]
 		private async Task DeletePayrollAsync(PayrollSummary? payroll)
 		{
 				if (payroll is null)
@@ -577,7 +646,51 @@ public partial class PayrollViewModel : BaseViewModel
 				}
 		}
 
-		private static string EscapeCsv(string? value)
+		
+		private async Task<List<ServiceChargeSummary>> ParseServiceChargeCsvAsync(FileResult file)
+		{
+			List<ServiceChargeSummary> results = [];
+			using Stream stream = await file.OpenReadAsync().ConfigureAwait(false);
+			using StreamReader reader = new(stream);
+			string content = await reader.ReadToEndAsync().ConfigureAwait(false);
+			string normalizedContent = content.Replace("\r", string.Empty, StringComparison.Ordinal).Replace("\\n", "\n", StringComparison.Ordinal);
+
+			foreach (string rawLine in normalizedContent.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+			{
+				if (string.IsNullOrWhiteSpace(rawLine))
+				{
+					continue;
+				}
+
+				string[] cols = rawLine.Split(',');
+				if (cols.Length < 2)
+				{
+					continue;
+				}
+
+				string barcode = cols[0].Trim();
+				if (barcode.Equals("barcode", StringComparison.OrdinalIgnoreCase))
+				{
+					continue;
+				}
+
+				if (!decimal.TryParse(cols[1].Trim(), NumberStyles.Any, CultureInfo.InvariantCulture, out decimal amount))
+				{
+					continue;
+				}
+
+				results.Add(new ServiceChargeSummary
+				{
+					Username = barcode,
+					Amount = amount,
+					Date = EndDate
+				});
+			}
+
+			return results;
+		}
+
+private static string EscapeCsv(string? value)
 		{
 				if (string.IsNullOrEmpty(value))
 				{
@@ -801,6 +914,8 @@ public partial class PayrollViewModel : BaseViewModel
 		{
 				OnPropertyChanged(nameof(CanSavePayrollPeriod));
 				OnPropertyChanged(nameof(CanDownloadPayrollPeriod));
+			OnPropertyChanged(nameof(CanUploadServiceCharge));
+			UploadServiceChargeCommand.NotifyCanExecuteChanged();
 				//SavePayrollCommand.NotifyCanExecuteChanged();
 		}
 
@@ -811,6 +926,11 @@ public partial class PayrollViewModel : BaseViewModel
 
 				payrollCountInPeriod = payrollPeriodState.TotalCount;
 				hasPendingPayrollsInPeriod = payrollPeriodState.Items.Any(payroll => !payroll.IsSaved);
+			hasServiceChargeInPeriod = payrollPeriodState.Items.Any(payroll => payroll.SvcCharge > 0);
+
+			IReadOnlyList<ServiceChargeSummary> serviceCharges = await serviceChargeApiService.GetServiceChargesByDateAsync(EndDate).ConfigureAwait(false);
+			hasServiceChargeInPeriod = hasServiceChargeInPeriod || serviceCharges.Count > 0;
+			UpdatePayrollCommandStates();
 		}
 
 		private void RaiseNavigationState()


### PR DESCRIPTION
### Motivation

- Introduce client-side support for service charge records so payroll workflows can query and create service charges for a payslip period.
- Allow operators to upload service charge CSV files from the payroll UI and prevent duplicate uploads for a period.

### Description

- Add `IServiceChargeApiService` interface and `ServiceChargeApiService` implementation that use the existing `IApiClient` to `GetAsync` and `PostAsync` service charge endpoints.
- Add DTO/model types in `ServiceChargeDtos.cs` for request/response payloads and domain summaries (`ServiceChargeSummary`, `ServiceChargeRecordDto`, `ServiceChargeListResponseDto`, `CreateServiceChargeRequestDto`, `CreateServiceChargeResponseDto`).
- Register `IServiceChargeApiService` in DI (`MauiProgram.cs`).
- Extend `PayrollViewModel` to inject `IServiceChargeApiService`, add `HasServiceChargeInPeriod` tracking and `CanUploadServiceCharge` property, and to query service charges for the current end date when refreshing period state.
- Add `UploadServiceChargeAsync` command that opens a file picker, parses a simple CSV format into `ServiceChargeSummary` rows, confirms upload, posts each row via the API service, and refreshes state; add CSV parsing helper and wire command can-execute notifications.

### Testing

- No automated tests were added for this change.
- No automated test run was performed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02ff55293883298069008df6ed1d71)