### PR TITLE
Exclude approved leave shifts from undertime totals

### DIFF
--- a/src/Bluewater.UseCases/Attendances/AttendanceSummaryCalculator.cs
+++ b/src/Bluewater.UseCases/Attendances/AttendanceSummaryCalculator.cs
@@ -12,6 +12,11 @@ public static class AttendanceSummaryCalculator
   public static int CountApprovedLeaves(IEnumerable<AttendanceDTO> attendances) =>
     attendances.Count(HasApprovedLeave);
 
+  public static decimal SumUndertimesExcludingApprovedLeaves(IEnumerable<AttendanceDTO> attendances) =>
+    attendances
+      .Where(attendance => !(HasApprovedLeave(attendance) && attendance.ShiftId.HasValue && attendance.Shift is not null))
+      .Sum(attendance => attendance.UnderHrs ?? 0m);
+
   public static int CountAbsencesExcludingApprovedLeaves(
     IEnumerable<AttendanceDTO> attendances,
     IEnumerable<DateOnly>? holidayDates = null)

--- a/src/Bluewater.UseCases/Timesheets/List/ListAllTimesheetHandler.cs
+++ b/src/Bluewater.UseCases/Timesheets/List/ListAllTimesheetHandler.cs
@@ -161,7 +161,7 @@ internal class ListAllTimesheetHandler(
     var totalLates = attendances.Sum(i => i.LateHrs) ?? 0;
     var totalAbsents = AttendanceSummaryCalculator.CountAbsencesExcludingApprovedLeaves(attendances, holidayDates);
 
-    decimal totalUndertimes = attendances.Sum(i => i.UnderHrs) ?? 0;
+    decimal totalUndertimes = AttendanceSummaryCalculator.SumUndertimesExcludingApprovedLeaves(attendances);
     decimal totalOverbreaks = attendances.Sum(i => i.OverbreakHrs) ?? 0;
     decimal totalLeaves = AttendanceSummaryCalculator.CountApprovedLeaves(attendances);
 

--- a/tests/Bluewater.UnitTests/UseCases/Attendances/AttendanceSummaryCalculatorTests.cs
+++ b/tests/Bluewater.UnitTests/UseCases/Attendances/AttendanceSummaryCalculatorTests.cs
@@ -42,6 +42,23 @@ public class AttendanceSummaryCalculatorTests
 
 
   [Fact]
+  public void SumUndertimesExcludingApprovedLeaves_ExcludesUndertimeWhenApprovedLeaveHasScheduledShift()
+  {
+    ShiftDTO shift = new(Guid.NewGuid(), "D", new TimeOnly(8, 0), new TimeOnly(12, 0), new TimeOnly(13, 0), new TimeOnly(17, 0), 1);
+
+    List<AttendanceDTO> attendances =
+    [
+      new AttendanceDTO(Guid.NewGuid(), Guid.NewGuid(), shift.Id, null, Guid.NewGuid(), DateOnly.FromDateTime(DateTime.Today), 0, 0, 2, 0, 0, ApplicationStatusDTO.Approved, shift: shift),
+      new AttendanceDTO(Guid.NewGuid(), Guid.NewGuid(), shift.Id, null, Guid.NewGuid(), DateOnly.FromDateTime(DateTime.Today.AddDays(1)), 0, 0, 1, 0, 0, ApplicationStatusDTO.Pending, shift: shift),
+      new AttendanceDTO(Guid.NewGuid(), Guid.NewGuid(), shift.Id, null, null, DateOnly.FromDateTime(DateTime.Today.AddDays(2)), 0, 0, 3, 0, 0, shift: shift)
+    ];
+
+    decimal totalUndertimes = AttendanceSummaryCalculator.SumUndertimesExcludingApprovedLeaves(attendances);
+
+    totalUndertimes.Should().Be(4m);
+  }
+
+  [Fact]
   public void CountAbsencesExcludingApprovedLeaves_DoesNotTreatHolidayAsAbsence()
   {
     ShiftDTO shift = new(Guid.NewGuid(), "D", new TimeOnly(8, 0), new TimeOnly(12, 0), new TimeOnly(13, 0), new TimeOnly(17, 0), 1);


### PR DESCRIPTION
### Motivation
- Ensure `TotalUndertimes` shown in Timesheet/Timesheets summaries does not include undertime deductions for days where there is an *Approved* leave that already covers a scheduled shift. 
- Prevent double-dipping deductions when a scheduled shift coincides with an approved leave (same date).

### Description
- Added `AttendanceSummaryCalculator.SumUndertimesExcludingApprovedLeaves` to compute undertime totals while excluding attendances that have an approved leave and a scheduled shift (`AttendanceSummaryCalculator.SumUndertimesExcludingApprovedLeaves`).
- Updated timesheet aggregation to use the new helper in `ListAllTimesheetHandler.ProcessAttendanceSummary`, replacing the previous blind sum of `UnderHrs` with `AttendanceSummaryCalculator.SumUndertimesExcludingApprovedLeaves`.
- Added a unit test `SumUndertimesExcludingApprovedLeaves_ExcludesUndertimeWhenApprovedLeaveHasScheduledShift` to `AttendanceSummaryCalculatorTests` to verify that undertime is excluded for approved-leave scheduled shifts and included for other undertime entries.
- Modified files: `src/Bluewater.UseCases/Attendances/AttendanceSummaryCalculator.cs`, `src/Bluewater.UseCases/Timesheets/List/ListAllTimesheetHandler.cs`, and `tests/Bluewater.UnitTests/UseCases/Attendances/AttendanceSummaryCalculatorTests.cs`.

### Testing
- Added a unit test `AttendanceSummaryCalculatorTests.SumUndertimesExcludingApprovedLeaves_ExcludesUndertimeWhenApprovedLeaveHasScheduledShift` (tests committed with the change).
- Attempted to run the test suite with `dotnet test tests/Bluewater.UnitTests/Bluewater.UnitTests.csproj --filter AttendanceSummaryCalculatorTests` in the current environment, but the command failed because the `dotnet` SDK is not available here; no automated test results could be produced in this environment.
- Recommend running `dotnet test` or CI pipeline to validate the change (`dotnet test tests/Bluewater.UnitTests/Bluewater.UnitTests.csproj --filter AttendanceSummaryCalculatorTests`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03a00bcfdc832980bebb3ea59d43d4)